### PR TITLE
Basic RGS support

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use bdk::esplora_client;
 use lightning::ln::peer_handler::PeerHandleError;
 use lightning_invoice::payment::PaymentError;
 use lightning_invoice::ParseOrSemanticError;
+use lightning_rapid_gossip_sync::GraphSyncError;
 use lightning_transaction_sync::TxSyncError;
 use thiserror::Error;
 use wasm_bindgen::JsValue;
@@ -75,6 +76,9 @@ pub enum MutinyError {
     /// A chain access operation failed.
     #[error("Failed to conduct chain access operation.")]
     ChainAccessFailed,
+    /// An error with rapid gossip sync
+    #[error("Failed to execute a rapid gossip sync function")]
+    RapidGossipSyncError,
     /// A error with DLCs
     #[error("Failed to execute a dlc function")]
     DLCManagerError,
@@ -167,6 +171,12 @@ impl From<MutinyStorageError> for bdk::Error {
     }
 }
 
+impl From<GraphSyncError> for MutinyError {
+    fn from(_e: GraphSyncError) -> Self {
+        MutinyError::RapidGossipSyncError
+    }
+}
+
 impl From<std::io::Error> for MutinyError {
     fn from(e: std::io::Error) -> Self {
         MutinyError::PersistenceFailed {
@@ -241,6 +251,9 @@ pub enum MutinyJsError {
     /// A chain access operation failed.
     #[error("Failed to conduct chain access operation.")]
     ChainAccessFailed,
+    /// An error with rapid gossip sync
+    #[error("Failed to execute a rapid gossip sync function")]
+    RapidGossipSyncError,
     /// An error when reading/writing json to the front end.
     #[error("Failed to read or write json from the front end")]
     JsonReadWriteError,
@@ -285,6 +298,7 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::InvalidMnemonic => MutinyJsError::InvalidMnemonic,
             MutinyError::WalletSigningFailed => MutinyJsError::WalletSigningFailed,
             MutinyError::ChainAccessFailed => MutinyJsError::ChainAccessFailed,
+            MutinyError::RapidGossipSyncError => MutinyJsError::RapidGossipSyncError,
             MutinyError::DLCManagerError => MutinyJsError::DLCManagerError,
             MutinyError::Other(_) => MutinyJsError::UnknownError,
         }
@@ -319,6 +333,12 @@ impl From<esplora_client::Error> for MutinyJsError {
     fn from(_e: esplora_client::Error) -> Self {
         // This is most likely a chain access failure
         Self::ChainAccessFailed
+    }
+}
+
+impl From<GraphSyncError> for MutinyJsError {
+    fn from(e: GraphSyncError) -> Self {
+        MutinyError::from(e).into()
     }
 }
 

--- a/src/ldkstorage.rs
+++ b/src/ldkstorage.rs
@@ -89,6 +89,8 @@ impl MutinyNodePersister {
         self.persist(NETWORK_KEY, network_graph)
     }
 
+    // FIXME: Useful to use soon when we implement paying network nodes
+    #[allow(dead_code)]
     pub fn read_network_graph(&self, network: Network, logger: Arc<MutinyLogger>) -> NetworkGraph {
         match self.read_value(NETWORK_KEY) {
             Ok(kv_value) => {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -242,3 +242,30 @@ pub(crate) fn get_esplora_url(network: Network, user_provided_url: Option<String
         .to_string()
     }
 }
+
+pub(crate) fn get_rgs_url(
+    network: Network,
+    user_provided_url: Option<String>,
+    last_sync_time: Option<u64>,
+) -> String {
+    let last_sync_time = last_sync_time.unwrap_or(0);
+    if let Some(url) = user_provided_url {
+        url
+    } else {
+        // todo - add regtest and signet
+        match network {
+            Network::Bitcoin => {
+                format!("https://rapidsync.lightningdevkit.org/snapshot/{last_sync_time}")
+            }
+            Network::Testnet => {
+                format!("https://rapidsync.lightningdevkit.org/testnet/snapshot/{last_sync_time}")
+            }
+            Network::Signet => {
+                format!("https://rapidsync.lightningdevkit.org/testnet/snapshot/{last_sync_time}")
+            }
+            Network::Regtest => {
+                format!("https://rapidsync.lightningdevkit.org/testnet/snapshot/{last_sync_time}")
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds basic RGS support by having it download the full snapshot on startup and use it across all the nodes. We should later add it so it stores the snapshot for later so we dont need to download the full 4mb every boot.

We also don't have anything for regtest and signet. We should maybe add to our docs how to setup a rgs dev server.