### PR TITLE
Add custom Persister for ProbabilisticScorer and NetworkGraph

### DIFF
--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -261,6 +261,11 @@ pub async fn get_gossip_sync(
 
     let now = utils::now().as_secs();
 
+    // remove stale channels
+    gossip_sync
+        .network_graph()
+        .remove_stale_channels_and_tracking_with_time(now);
+
     // if the last sync was less than 24 hours ago, we don't need to sync
     let time_since_sync = now - gossip_data.last_sync_timestamp as u64;
     if time_since_sync < 86_400 {

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -3,32 +3,38 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use bitcoin::Network;
 use bitcoin_hashes::hex::{FromHex, ToHex};
+use lightning::routing::scoring::ProbabilisticScoringParameters;
 use lightning::util::ser::{ReadableArgs, Writeable};
 use log::{debug, error, info, warn};
 use reqwest::Client;
-use rexie::{ObjectStore, Rexie, TransactionMode};
+use rexie::{ObjectStore, Rexie, Store, TransactionMode};
 use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::spawn_local;
 
 use crate::error::{MutinyError, MutinyStorageError};
 use crate::logging::MutinyLogger;
-use crate::node::{NetworkGraph, RapidGossipSync};
+use crate::node::{NetworkGraph, ProbScorer, RapidGossipSync};
+use crate::utils;
 use crate::wallet::get_rgs_url;
 
 pub(crate) const GOSSIP_DATABASE_NAME: &str = "gossip";
 pub(crate) const GOSSIP_OBJECT_STORE_NAME: &str = "gossip_store";
 pub(crate) const GOSSIP_SYNC_TIME_KEY: &str = "last_sync_timestamp";
 pub(crate) const NETWORK_GRAPH_KEY: &str = "network_graph";
+pub(crate) const PROB_SCORER_KEY: &str = "prob_scorer";
 
 struct Gossip {
     pub last_sync_timestamp: u32,
-    pub network_graph: NetworkGraph,
+    pub network_graph: Arc<NetworkGraph>,
+    pub scorer: Option<ProbScorer>,
 }
 
 impl Gossip {
     pub fn new(network: Network, logger: Arc<MutinyLogger>) -> Self {
         Self {
             last_sync_timestamp: 0,
-            network_graph: NetworkGraph::new(network, logger),
+            network_graph: Arc::new(NetworkGraph::new(network, logger)),
+            scorer: None,
         }
     }
 }
@@ -84,17 +90,38 @@ async fn get_gossip_data(
     let network_graph_str: String = serde_wasm_bindgen::from_value(network_graph_js)?;
     let network_graph_bytes: Vec<u8> = Vec::from_hex(&network_graph_str)?;
     let mut readable_bytes = lightning::io::Cursor::new(network_graph_bytes);
-    let network_graph = NetworkGraph::read(&mut readable_bytes, logger)?;
+    let network_graph = Arc::new(NetworkGraph::read(&mut readable_bytes, logger.clone())?);
+
+    // Get the probabilistic scorer
+    let prob_scorer_js = store.get(&JsValue::from(PROB_SCORER_KEY)).await?;
+
+    // If the key doesn't exist, we return None for the scorer
+    if prob_scorer_js.is_null() || prob_scorer_js.is_undefined() {
+        let gossip = Gossip {
+            last_sync_timestamp,
+            network_graph,
+            scorer: None,
+        };
+        return Ok(Some(gossip));
+    }
+
+    let prob_scorer_str: String = serde_wasm_bindgen::from_value(prob_scorer_js)?;
+    let prob_scorer_bytes: Vec<u8> = Vec::from_hex(&prob_scorer_str)?;
+    let mut readable_bytes = lightning::io::Cursor::new(prob_scorer_bytes);
+    let params = ProbabilisticScoringParameters::default();
+    let args = (params, Arc::clone(&network_graph), Arc::clone(&logger));
+    let scorer = ProbScorer::read(&mut readable_bytes, args)?;
 
     let gossip = Gossip {
         last_sync_timestamp,
         network_graph,
+        scorer: Some(scorer),
     };
 
     Ok(Some(gossip))
 }
 
-async fn write_network_graph(
+async fn write_gossip_data(
     rexie: &Rexie,
     last_sync_timestamp: u32,
     network_graph: &NetworkGraph,
@@ -113,13 +140,88 @@ async fn write_network_graph(
         .await?;
 
     // Save the network graph
-    let network_graph_js = serde_wasm_bindgen::to_value(&network_graph.encode().to_hex())?;
+    let network_graph_str = network_graph.encode().to_hex();
+    write_network_graph_to_store(&store, &network_graph_str).await?;
+
+    // Waits for the transaction to complete
+    transaction.done().await?;
+
+    Ok(())
+}
+
+/// Write the Network Graph to indexedDB
+/// This is done in a spawn_local so that it can be done for sync functions
+pub fn persist_network_graph(network_graph: &NetworkGraph) -> Result<(), lightning::io::Error> {
+    let network_graph_str = network_graph.encode().to_hex();
+    spawn_local(async move {
+        write_network_graph(&network_graph_str)
+            .await
+            .expect("Failed to write network graph")
+    });
+    Ok(())
+}
+
+async fn write_network_graph(network_graph_str: &str) -> Result<(), MutinyError> {
+    let rexie = build_gossip_database().await?;
+    // Create a new read-write transaction
+    let transaction = rexie.transaction(&[GOSSIP_OBJECT_STORE_NAME], TransactionMode::ReadWrite)?;
+
+    let store = transaction.store(GOSSIP_OBJECT_STORE_NAME)?;
+
+    // Save the network graph
+    write_network_graph_to_store(&store, network_graph_str).await?;
+
+    // Waits for the transaction to complete
+    transaction.done().await?;
+
+    Ok(())
+}
+
+/// Write the Probabilistic Scorer to indexedDB
+/// This is done in a spawn_local so that it can be done for sync functions
+pub fn persist_scorer(scorer: &utils::Mutex<ProbScorer>) -> Result<(), lightning::io::Error> {
+    let scorer_str = scorer.encode().to_hex();
+    spawn_local(async move {
+        write_scorer(&scorer_str)
+            .await
+            .expect("Failed to write scorer")
+    });
+    Ok(())
+}
+
+async fn write_scorer(scorer_str: &str) -> Result<(), MutinyError> {
+    let rexie = build_gossip_database().await?;
+    // Create a new read-write transaction
+    let transaction = rexie.transaction(&[GOSSIP_OBJECT_STORE_NAME], TransactionMode::ReadWrite)?;
+
+    let store = transaction.store(GOSSIP_OBJECT_STORE_NAME)?;
+
+    // Save the scorer
+    write_scorer_to_store(&store, scorer_str).await?;
+
+    // Waits for the transaction to complete
+    transaction.done().await?;
+
+    Ok(())
+}
+
+async fn write_network_graph_to_store(
+    store: &Store,
+    network_graph_str: &str,
+) -> Result<(), MutinyError> {
+    let network_graph_js = serde_wasm_bindgen::to_value(network_graph_str)?;
     store
         .put(&network_graph_js, Some(&JsValue::from(NETWORK_GRAPH_KEY)))
         .await?;
 
-    // Waits for the transaction to complete
-    transaction.done().await?;
+    Ok(())
+}
+
+async fn write_scorer_to_store(store: &Store, scorer_str: &str) -> Result<(), MutinyError> {
+    let scorer_js = serde_wasm_bindgen::to_value(scorer_str)?;
+    store
+        .put(&scorer_js, Some(&JsValue::from(PROB_SCORER_KEY)))
+        .await?;
 
     Ok(())
 }
@@ -128,7 +230,7 @@ pub async fn get_gossip_sync(
     user_rgs_url: Option<String>,
     network: Network,
     logger: Arc<MutinyLogger>,
-) -> Result<RapidGossipSync, MutinyError> {
+) -> Result<(RapidGossipSync, ProbScorer), MutinyError> {
     let rexie = build_gossip_database().await?;
 
     // if we error out, we just use the default gossip data
@@ -147,15 +249,22 @@ pub async fn get_gossip_sync(
     );
 
     // get network graph
-    let network_graph = Arc::new(gossip_data.network_graph);
-    let gossip_sync = RapidGossipSync::new(network_graph, logger);
+    let gossip_sync = RapidGossipSync::new(gossip_data.network_graph.clone(), logger.clone());
 
-    let now = crate::utils::now().as_secs();
+    let prob_scorer = match gossip_data.scorer {
+        Some(scorer) => scorer,
+        None => {
+            let params = ProbabilisticScoringParameters::default();
+            ProbScorer::new(params, gossip_data.network_graph.clone(), logger)
+        }
+    };
+
+    let now = utils::now().as_secs();
 
     // if the last sync was less than 24 hours ago, we don't need to sync
     let time_since_sync = now - gossip_data.last_sync_timestamp as u64;
     if time_since_sync < 86_400 {
-        return Ok(gossip_sync);
+        return Ok((gossip_sync, prob_scorer));
     };
 
     let rgs_url = get_rgs_url(network, user_rgs_url, Some(gossip_data.last_sync_timestamp));
@@ -174,7 +283,7 @@ pub async fn get_gossip_sync(
         warn!("Failed to fetch updated gossip, using default gossip data");
     }
 
-    Ok(gossip_sync)
+    Ok((gossip_sync, prob_scorer))
 }
 
 async fn fetch_updated_gossip(
@@ -206,7 +315,7 @@ async fn fetch_updated_gossip(
 
     // save the network graph if has been updated
     if new_last_sync_timestamp_result != last_sync_timestamp {
-        write_network_graph(
+        write_gossip_data(
             &rexie,
             new_last_sync_timestamp_result,
             &gossip_sync.network_graph(),
@@ -222,9 +331,16 @@ pub fn get_dummy_gossip(
     _user_rgs_url: Option<String>,
     network: Network,
     logger: Arc<MutinyLogger>,
-) -> RapidGossipSync {
+) -> (RapidGossipSync, ProbScorer) {
     let network_graph = Arc::new(NetworkGraph::new(network, logger.clone()));
-    RapidGossipSync::new(network_graph, logger)
+    let gossip_sync = RapidGossipSync::new(network_graph.clone(), logger.clone());
+    let scorer = ProbScorer::new(
+        ProbabilisticScoringParameters::default(),
+        network_graph,
+        logger,
+    );
+
+    (gossip_sync, scorer)
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -92,7 +92,15 @@ impl<'a, T: 'a + Score> LockableScore<'a> for Mutex<T> {
     type Locked = MutexGuard<'a, T>;
 
     fn lock(&'a self) -> MutexGuard<'a, T> {
-        Mutex::lock(self).unwrap()
+        Mutex::lock(self).expect("Failed to lock mutex")
+    }
+}
+
+impl<'a, S: Writeable> Writeable for Mutex<S> {
+    fn write<W: Writer>(&self, writer: &mut W) -> Result<(), lightning::io::Error> {
+        self.lock()
+            .expect("Failed to lock mutex for write")
+            .write(writer)
     }
 }
 


### PR DESCRIPTION
Refactors so we no longer use KVStorePersister and instead use our own impl. This impl currently uses indexedDB for just the `NetworkGraph` and `ProbabilisticScorer`, otherwise is just a copy-paste of the `KVStorePersister` for the channel manager and updates so they are still in LocalStorage.

Closes #340 
