### PR TITLE
Properly handle checking signet address

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use crate::esplora::TxSyncError;
 use bdk::esplora_client;
+use bitcoin::Network;
 use lightning::ln::peer_handler::PeerHandleError;
 use lightning_invoice::payment::PaymentError;
 use lightning_invoice::ParseOrSemanticError;
@@ -26,7 +27,7 @@ pub enum MutinyError {
     ConnectionFailed,
     /// The invoice or address is on a different network
     #[error("The invoice or address is on a different network.")]
-    IncorrectNetwork,
+    IncorrectNetwork(Network),
     /// Payment of the given invoice has already been initiated.
     #[error("An invoice must not get payed twice.")]
     NonUniquePaymentHash,
@@ -229,7 +230,7 @@ pub enum MutinyJsError {
     ConnectionFailed,
     /// The invoice or address is on a different network
     #[error("The invoice or address is on a different network.")]
-    IncorrectNetwork,
+    IncorrectNetwork(Network),
     /// Payment of the given invoice has already been initiated.
     #[error("An invoice must not get payed twice.")]
     NonUniquePaymentHash,
@@ -311,7 +312,7 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::NotRunning => MutinyJsError::NotRunning,
             MutinyError::FundingTxCreationFailed => MutinyJsError::FundingTxCreationFailed,
             MutinyError::ConnectionFailed => MutinyJsError::ConnectionFailed,
-            MutinyError::IncorrectNetwork => MutinyJsError::IncorrectNetwork,
+            MutinyError::IncorrectNetwork(net) => MutinyJsError::IncorrectNetwork(net),
             MutinyError::NonUniquePaymentHash => MutinyJsError::NonUniquePaymentHash,
             MutinyError::InvoiceInvalid => MutinyJsError::InvoiceInvalid,
             MutinyError::InvoiceCreationFailed => MutinyJsError::InvoiceCreationFailed,

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -15,6 +15,7 @@ use wasm_bindgen_futures::spawn_local;
 
 use crate::error::MutinyError;
 use crate::localstorage::MutinyBrowserStorage;
+use crate::utils::is_valid_network;
 
 #[derive(Debug)]
 pub struct MutinyWallet {
@@ -103,8 +104,8 @@ impl MutinyWallet {
         fee_rate: Option<f32>,
     ) -> Result<bitcoin::psbt::PartiallySignedTransaction, MutinyError> {
         let wallet = self.wallet.lock().await;
-        if send_to.network != wallet.network() {
-            return Err(MutinyError::IncorrectNetwork);
+        if is_valid_network(wallet.network(), send_to.network) {
+            return Err(MutinyError::IncorrectNetwork(send_to.network));
         }
 
         let fee_rate = if let Some(rate) = fee_rate {
@@ -152,8 +153,8 @@ impl MutinyWallet {
     ) -> Result<bitcoin::psbt::PartiallySignedTransaction, MutinyError> {
         let wallet = self.wallet.lock().await;
 
-        if destination_address.network != wallet.network() {
-            return Err(MutinyError::IncorrectNetwork);
+        if is_valid_network(wallet.network(), destination_address.network) {
+            return Err(MutinyError::IncorrectNetwork(destination_address.network));
         }
 
         let fee_rate = if let Some(rate) = fee_rate {


### PR DESCRIPTION
Signet is stupid and has the same address prefix as testnet, this leads to us parsing signet addresses as having a testnet network. This PR changes it so we allow testnet addresses on signet and vice versa because they are the same.

I also added the network to the `IncorrectNetwork` error type so it'd be easier to debug