### PR TITLE
Create PSBT from spk in event manager

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -236,7 +236,6 @@ impl Node {
             keys_manager.clone(),
             persister.clone(),
             lsp_client_pubkey.clone(),
-            network,
             logger.clone(),
         );
         let peer_man = Arc::new(create_peer_manager(


### PR DESCRIPTION
We turning the script pub key into an address just to later check turn it back into the spk, removes that step.