### PR TITLE
Remove duplicate UUID in storage

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -143,6 +143,7 @@ pub(crate) struct Node {
 impl Node {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
+        uuid: String,
         node_index: NodeIndex,
         mnemonic: Mnemonic,
         storage: MutinyBrowserStorage,
@@ -156,7 +157,7 @@ impl Node {
         esplora: Arc<EsploraBlockchain>,
         lsp_client: Option<LspClient>,
     ) -> Result<Self, MutinyError> {
-        info!("initialized a new node: {}", node_index.uuid);
+        info!("initialized a new node: {uuid}");
 
         let logger = Arc::new(MutinyLogger::default());
 
@@ -164,7 +165,7 @@ impl Node {
         let pubkey = pubkey_from_keys_manager(&keys_manager);
 
         // init the persister
-        let persister = Arc::new(MutinyNodePersister::new(node_index.uuid.clone(), storage));
+        let persister = Arc::new(MutinyNodePersister::new(uuid.clone(), storage));
 
         // init chain monitor
         let chain_monitor: Arc<ChainMonitor> = Arc::new(ChainMonitor::new(
@@ -428,7 +429,7 @@ impl Node {
         });
 
         Ok(Node {
-            _uuid: node_index.uuid,
+            _uuid: uuid,
             pubkey,
             peer_manager: peer_man,
             keys_manager,

--- a/src/nodemanager.rs
+++ b/src/nodemanager.rs
@@ -64,7 +64,6 @@ pub(crate) struct NodeStorage {
 // This is the NodeIndex reference that is saved to the DB
 #[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct NodeIndex {
-    pub uuid: String,
     pub child_index: u32,
 }
 
@@ -419,6 +418,7 @@ impl NodeManager {
 
         for node_item in node_storage.clone().nodes {
             let node = Node::new(
+                node_item.0,
                 node_item.1,
                 mnemonic.clone(),
                 storage.clone(),
@@ -1176,7 +1176,6 @@ pub(crate) async fn create_new_node_from_node_manager(
     // Create and save a new node using the next child index
     let next_node_uuid = Uuid::new_v4().to_string();
     let next_node = NodeIndex {
-        uuid: next_node_uuid.clone(),
         child_index: next_node_index,
     };
 
@@ -1189,6 +1188,7 @@ pub(crate) async fn create_new_node_from_node_manager(
 
     // now create the node process and init it
     let new_node = match Node::new(
+        next_node_uuid.clone(),
         next_node.clone(),
         node_manager.mnemonic.clone(),
         node_manager.storage.clone(),
@@ -1217,7 +1217,7 @@ pub(crate) async fn create_new_node_from_node_manager(
         .insert(node_pubkey.to_string(), Arc::new(new_node));
 
     Ok(NodeIdentity {
-        uuid: next_node.uuid.clone(),
+        uuid: next_node_uuid.clone(),
         pubkey: node_pubkey.to_string(),
     })
 }


### PR DESCRIPTION
We were unnecessarily storing the UUID for a node twice. My node storage looked like this

```json
{"nodes":{"7ac78a3c-8570-4c54-aa97-e818d955807e":{"uuid":"7ac78a3c-8570-4c54-aa97-e818d955807e","child_index":0}}
```

This removes the `uuid` param in the object and uses the key instead so we don't need to store the data twice.

We could also change it to remove the `nodes:` but that is probably fine to keep in case we want to add more data there