### PR TITLE
Improve typesafety, cleanup deps

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,5 +18,5 @@ test:
     wasm-pack test --headless --chrome ./mutiny-wasm
 
 clippy:
-    cargo clippy --package mutiny-core -- -Aclippy::drop_non_drop
+    cargo clippy --package mutiny-core
     cargo clippy --package mutiny-wasm -- -Aclippy::drop_non_drop

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -14,15 +14,12 @@ lnurl-rs = { version = "0.2", default-features = false, features = ["async", "as
 cfg-if = "1.0.0"
 wasm-bindgen = "0.2.83"
 serde-wasm-bindgen = "0.5.0"
-bip39 = { version = "1.0.1" }
+bip39 = { version = "2.0.0" }
 bip32 = "0.4.0"
 bitcoin-bech32 = "0.12"
 js-sys = "0.3.60"
-secp256k1 = "0.24.0"
-bitcoin_hashes = { version = "0.11", default-features = false }
 bitcoin = { version = "0.29.2", default-features = false, features = ["serde", "secp-recovery"] }
-# TODO waiting for esplora version 0.4.0
-bdk = { git = "https://github.com/mutinywallet/bdk", branch = "esplora-tmp", default-features = false, features = ["keys-bip39", "esplora", "use-esplora-reqwest", "async-interface"] }
+bdk = { version = "0.28.0", default-features = false, features = ["keys-bip39", "esplora", "use-esplora-reqwest", "async-interface"] }
 bdk-macros = "0.6.0"
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "^1.0", features = ["derive"] }

--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -216,8 +216,8 @@ impl From<rexie::Error> for MutinyError {
     }
 }
 
-impl From<bitcoin_hashes::hex::Error> for MutinyError {
-    fn from(_e: bitcoin_hashes::hex::Error) -> Self {
+impl From<bitcoin::hashes::hex::Error> for MutinyError {
+    fn from(_e: bitcoin::hashes::hex::Error) -> Self {
         MutinyError::ReadError {
             source: MutinyStorageError::Other(anyhow::anyhow!("Failed to decode hex")),
         }

--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -5,9 +5,9 @@ use crate::utils::sleep;
 use crate::wallet::MutinyWallet;
 use bdk::blockchain::Blockchain;
 use bdk::wallet::AddressIndex;
+use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::secp256k1::Secp256k1;
-use bitcoin_hashes::hex::ToHex;
 use lightning::{
     chain::chaininterface::{ConfirmationTarget, FeeEstimator},
     chain::keysinterface::PhantomKeysManager,

--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -31,10 +31,10 @@ pub(crate) struct PaymentInfo {
     pub last_update: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct MillisatAmount(pub Option<u64>);
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum HTLCStatus {
     Pending,
     InFlight,

--- a/mutiny-core/src/gossip.rs
+++ b/mutiny-core/src/gossip.rs
@@ -3,8 +3,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use bitcoin::hashes::hex::{FromHex, ToHex};
+use bitcoin::secp256k1::PublicKey;
 use bitcoin::Network;
-use bitcoin_hashes::hex::{FromHex, ToHex};
 use lightning::ln::msgs::NodeAnnouncement;
 use lightning::routing::gossip::{NodeAlias, NodeId};
 use lightning::routing::scoring::ProbabilisticScoringParameters;
@@ -12,7 +13,6 @@ use lightning::util::ser::{ReadableArgs, Writeable};
 use log::{debug, error, info, warn};
 use reqwest::Client;
 use rexie::{ObjectStore, Rexie, Store, TransactionMode};
-use secp256k1::PublicKey;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::spawn_local;
@@ -636,7 +636,7 @@ pub fn get_dummy_gossip(
 
 #[cfg(test)]
 mod test {
-    use secp256k1::*;
+    use bitcoin::secp256k1::{Secp256k1, SecretKey};
     use uuid::Uuid;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 

--- a/mutiny-core/src/lspclient.rs
+++ b/mutiny-core/src/lspclient.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use bitcoin::secp256k1::PublicKey;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -14,7 +12,7 @@ pub(crate) struct LspClient {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct GetInfoResponse {
-    pub pubkey: String,
+    pub pubkey: PublicKey,
     pub connection_methods: Vec<GetInfoAddress>,
 }
 
@@ -65,7 +63,6 @@ impl LspClient {
             .json()
             .await?;
 
-        let pubkey = PublicKey::from_str(&get_info_response.pubkey)?;
         let connection_string = get_info_response
             .connection_methods
             .iter()
@@ -86,7 +83,7 @@ impl LspClient {
             .map(|address| {
                 format!(
                     "{}@{}:{}",
-                    pubkey.to_string(),
+                    get_info_response.pubkey.to_string(),
                     address.address,
                     address.port
                 )
@@ -94,7 +91,7 @@ impl LspClient {
             .ok_or_else(|| anyhow::anyhow!("No suitable connection method found"))?;
 
         Ok(LspClient {
-            pubkey,
+            pubkey: get_info_response.pubkey,
             url: String::from(url),
             connection_string,
             http_client,

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -733,7 +733,7 @@ impl Node {
                     let params = MutinyInvoice {
                         bolt11: None,
                         description: None,
-                        payment_hash: h,
+                        payment_hash: sha256::Hash::from_inner(h.0),
                         preimage,
                         payee_pubkey: None,
                         amount_sats,

--- a/mutiny-core/src/proxy.rs
+++ b/mutiny-core/src/proxy.rs
@@ -109,6 +109,7 @@ mod tests {
     const PEER_PUBKEY: &str = "02e6642fd69bd211f93f7f1f36ca51a26a5290eb2dd1b0d8279a87bb0d480c8443";
 
     #[test]
+    #[cfg(feature = "ignored_tests")]
     async fn test_websocket_proxy_init() {
         log!("test websocket proxy");
 

--- a/mutiny-core/src/socket.rs
+++ b/mutiny-core/src/socket.rs
@@ -1,7 +1,7 @@
 use crate::peermanager::PeerManager;
 use crate::proxy::Proxy;
 use crate::utils;
-use bitcoin_hashes::hex::ToHex;
+use bitcoin::hashes::hex::ToHex;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use futures::lock::Mutex;
 use gloo_net::websocket::events::CloseEvent;

--- a/mutiny-core/src/utils.rs
+++ b/mutiny-core/src/utils.rs
@@ -9,17 +9,6 @@ use lightning::util::ser::Writeable;
 use lightning::util::ser::Writer;
 use lightning_invoice::Currency;
 
-pub fn set_panic_hook() {
-    // When the `console_error_panic_hook` feature is enabled, we can call the
-    // `set_panic_hook` function at least once during initialization, and then
-    // we will get better error messages if our code ever panics.
-    //
-    // For more details see
-    // https://github.com/rustwasm/console_error_panic_hook#readme
-    #[cfg(feature = "console_error_panic_hook")]
-    console_error_panic_hook::set_once();
-}
-
 pub async fn sleep(millis: i32) {
     let mut cb = |resolve: js_sys::Function, _reject: js_sys::Function| {
         web_sys::window()

--- a/mutiny-core/src/wallet.rs
+++ b/mutiny-core/src/wallet.rs
@@ -87,7 +87,7 @@ impl MutinyWallet {
 
     pub async fn get_transaction(
         &self,
-        txid: Txid,
+        txid: &Txid,
         include_raw: bool,
     ) -> Result<Option<TransactionDetails>, MutinyError> {
         Ok(self
@@ -96,7 +96,7 @@ impl MutinyWallet {
             .await
             .list_transactions(include_raw)?
             .into_iter()
-            .find(|tx| tx.txid == txid))
+            .find(|tx| &tx.txid == txid))
     }
 
     pub async fn create_signed_psbt(

--- a/mutiny-core/webdriver.json
+++ b/mutiny-core/webdriver.json
@@ -9,7 +9,8 @@
     "prefs": {
       "media.navigator.streams.fake": true,
       "media.navigator.permission.disabled": true,
-      "media.webaudio.enabled": false
+      "media.webaudio.enabled": false,
+      "datareporting.healthreport.uploadEnabled": false
     },
     "args": []
   }

--- a/mutiny-core/webdriver.json
+++ b/mutiny-core/webdriver.json
@@ -4,5 +4,13 @@
       "--use-fake-device-for-media-stream",
       "--use-fake-ui-for-media-stream"
     ]
+  },
+  "moz:firefoxOptions": {
+    "prefs": {
+      "media.navigator.streams.fake": true,
+      "media.navigator.permission.disabled": true,
+      "media.webaudio.enabled": false
+    },
+    "args": []
   }
 }

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -18,21 +18,15 @@ serde-wasm-bindgen = "0.5.0"
 wasm-bindgen-futures = "0.4.33"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-secp256k1 = "0.24.0"
-bitcoin_hashes = { version = "0.11", default-features = false }
 bitcoin = { version = "0.29.2", default-features = false, features = ["serde", "secp-recovery"] }
 lightning-invoice = { version = "0.22", default-features = false, features = ["no-std"] }
-lightning-rapid-gossip-sync = { version = "0.0.114", default-features = false, features = ["no-std"] }
-# TODO waiting for esplora version 0.4.0
-bdk = { git = "https://github.com/mutinywallet/bdk", branch = "esplora-tmp", default-features = false, features = ["keys-bip39", "esplora", "use-esplora-reqwest", "async-interface"] }
 thiserror = "1.0"
-lnurl-rs = { version = "0.2", default-features = false, features = ["async", "async-https"] }
-reqwest = { version = "0.11", default-features = false, features = ["json"] }
+lnurl-rs = { version = "0.2", default-features = false }
 wasm-logger = "0.2.0"
 log = "0.4.17"
 gloo-storage = "0.2.2"
 web-sys = { version = "0.3.60", features = ["console"] }
-bip39 = { version = "1.0.1" }
+bip39 = { version = "2.0.0" }
 getrandom = { version = "0.2", features = ["js"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -1,8 +1,5 @@
-use bdk::esplora_client;
 use bitcoin::Network;
-use lightning_invoice::payment::PaymentError;
 use lightning_invoice::ParseOrSemanticError;
-use lightning_rapid_gossip_sync::GraphSyncError;
 use mutiny_core::error::{MutinyError, MutinyStorageError};
 use thiserror::Error;
 use wasm_bindgen::JsValue;
@@ -152,27 +149,8 @@ impl From<bitcoin::util::address::Error> for MutinyJsError {
     }
 }
 
-impl From<PaymentError> for MutinyJsError {
-    fn from(e: PaymentError) -> Self {
-        MutinyError::from(e).into()
-    }
-}
-
 impl From<lnurl::Error> for MutinyJsError {
     fn from(e: lnurl::Error) -> Self {
-        MutinyError::from(e).into()
-    }
-}
-
-impl From<esplora_client::Error> for MutinyJsError {
-    fn from(_e: esplora_client::Error) -> Self {
-        // This is most likely a chain access failure
-        Self::ChainAccessFailed
-    }
-}
-
-impl From<GraphSyncError> for MutinyJsError {
-    fn from(e: GraphSyncError) -> Self {
         MutinyError::from(e).into()
     }
 }
@@ -183,15 +161,15 @@ impl From<ParseOrSemanticError> for MutinyJsError {
     }
 }
 
-impl From<reqwest::Error> for MutinyJsError {
-    fn from(_e: reqwest::Error) -> Self {
-        Self::BitcoinPriceError
+impl From<bitcoin::hashes::hex::Error> for MutinyJsError {
+    fn from(_e: bitcoin::hashes::hex::Error) -> Self {
+        Self::JsonReadWriteError
     }
 }
 
-impl From<bitcoin_hashes::hex::Error> for MutinyJsError {
-    fn from(_e: bitcoin_hashes::hex::Error) -> Self {
-        Self::JsonReadWriteError
+impl From<bitcoin::secp256k1::Error> for MutinyJsError {
+    fn from(_e: bitcoin::secp256k1::Error) -> Self {
+        Self::PubkeyInvalid
     }
 }
 

--- a/mutiny-wasm/src/models.rs
+++ b/mutiny-wasm/src/models.rs
@@ -1,4 +1,6 @@
 use bitcoin::hashes::hex::ToHex;
+use bitcoin::secp256k1::PublicKey;
+use mutiny_core::*;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
@@ -45,14 +47,14 @@ impl MutinyInvoice {
     }
 }
 
-impl From<mutiny_core::nodemanager::MutinyInvoice> for MutinyInvoice {
-    fn from(m: mutiny_core::nodemanager::MutinyInvoice) -> Self {
+impl From<nodemanager::MutinyInvoice> for MutinyInvoice {
+    fn from(m: nodemanager::MutinyInvoice) -> Self {
         MutinyInvoice {
             bolt11: m.bolt11,
             description: m.description,
-            payment_hash: m.payment_hash,
+            payment_hash: m.payment_hash.to_hex(),
             preimage: m.preimage,
-            payee_pubkey: m.payee_pubkey,
+            payee_pubkey: m.payee_pubkey.map(|p| p.to_hex()),
             amount_sats: m.amount_sats,
             expire: m.expire,
             paid: m.paid,
@@ -65,7 +67,7 @@ impl From<mutiny_core::nodemanager::MutinyInvoice> for MutinyInvoice {
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[wasm_bindgen]
 pub struct MutinyPeer {
-    pubkey: secp256k1::PublicKey,
+    pubkey: PublicKey,
     connection_string: Option<String>,
     alias: Option<String>,
     color: Option<String>,
@@ -101,8 +103,8 @@ impl MutinyPeer {
     }
 }
 
-impl From<mutiny_core::nodemanager::MutinyPeer> for MutinyPeer {
-    fn from(m: mutiny_core::nodemanager::MutinyPeer) -> Self {
+impl From<nodemanager::MutinyPeer> for MutinyPeer {
+    fn from(m: nodemanager::MutinyPeer) -> Self {
         MutinyPeer {
             pubkey: m.pubkey,
             connection_string: m.connection_string,
@@ -138,14 +140,14 @@ impl MutinyChannel {
     }
 }
 
-impl From<mutiny_core::nodemanager::MutinyChannel> for MutinyChannel {
-    fn from(m: mutiny_core::nodemanager::MutinyChannel) -> Self {
+impl From<nodemanager::MutinyChannel> for MutinyChannel {
+    fn from(m: nodemanager::MutinyChannel) -> Self {
         MutinyChannel {
             balance: m.balance,
             size: m.size,
             reserve: m.reserve,
-            outpoint: m.outpoint,
-            peer: m.peer,
+            outpoint: m.outpoint.map(|o| o.to_string()),
+            peer: m.peer.to_hex(),
             confirmed: m.confirmed,
         }
     }
@@ -158,8 +160,8 @@ pub struct MutinyBalance {
     pub lightning: u64,
 }
 
-impl From<mutiny_core::nodemanager::MutinyBalance> for MutinyBalance {
-    fn from(m: mutiny_core::nodemanager::MutinyBalance) -> Self {
+impl From<nodemanager::MutinyBalance> for MutinyBalance {
+    fn from(m: nodemanager::MutinyBalance) -> Self {
         MutinyBalance {
             confirmed: m.confirmed,
             unconfirmed: m.unconfirmed,
@@ -183,8 +185,8 @@ impl LnUrlParams {
     }
 }
 
-impl From<mutiny_core::nodemanager::LnUrlParams> for LnUrlParams {
-    fn from(m: mutiny_core::nodemanager::LnUrlParams) -> Self {
+impl From<nodemanager::LnUrlParams> for LnUrlParams {
+    fn from(m: nodemanager::LnUrlParams) -> Self {
         LnUrlParams {
             max: m.max,
             min: m.min,
@@ -198,7 +200,7 @@ impl From<mutiny_core::nodemanager::LnUrlParams> for LnUrlParams {
 #[wasm_bindgen]
 pub struct NodeIdentity {
     uuid: String,
-    pubkey: String,
+    pubkey: PublicKey,
 }
 
 #[wasm_bindgen]
@@ -210,12 +212,12 @@ impl NodeIdentity {
 
     #[wasm_bindgen(getter)]
     pub fn pubkey(&self) -> String {
-        self.pubkey.clone()
+        self.pubkey.to_string()
     }
 }
 
-impl From<mutiny_core::nodemanager::NodeIdentity> for NodeIdentity {
-    fn from(m: mutiny_core::nodemanager::NodeIdentity) -> Self {
+impl From<nodemanager::NodeIdentity> for NodeIdentity {
+    fn from(m: nodemanager::NodeIdentity) -> Self {
         NodeIdentity {
             uuid: m.uuid,
             pubkey: m.pubkey,
@@ -255,11 +257,11 @@ impl MutinyBip21RawMaterials {
     }
 }
 
-impl From<mutiny_core::nodemanager::MutinyBip21RawMaterials> for MutinyBip21RawMaterials {
-    fn from(m: mutiny_core::nodemanager::MutinyBip21RawMaterials) -> Self {
+impl From<nodemanager::MutinyBip21RawMaterials> for MutinyBip21RawMaterials {
+    fn from(m: nodemanager::MutinyBip21RawMaterials) -> Self {
         MutinyBip21RawMaterials {
-            address: m.address,
-            invoice: m.invoice,
+            address: m.address.to_string(),
+            invoice: m.invoice.to_string(),
             btc_amount: m.btc_amount,
             description: m.description,
         }


### PR DESCRIPTION
Follow up to the wasm split, this should improve the type safety for the node manager and found a couple places to do it more internally.

Also cleaned up some dependencies as we didn't need that because they were being re-exported (namely secp256k1 and bitcon_hashes)

Finally, added some small stuff to get CI more reliable :pray: 