### PR TITLE
Fix variable names for clippy

### DIFF
--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -12,7 +12,7 @@ ln-websocket-proxy = "0.3.0"
 lnurl-rs = { version = "0.2", default-features = false, features = ["async", "async-https"] }
 
 cfg-if = "1.0.0"
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 serde-wasm-bindgen = "0.5.0"
 bip39 = { version = "2.0.0" }
 bip32 = "0.4.0"

--- a/mutiny-core/src/fees.rs
+++ b/mutiny-core/src/fees.rs
@@ -20,8 +20,8 @@ impl FeeEstimator for MutinyFeeEstimator {
                 match found {
                     Some(num) => {
                         trace!("Got fee rate from saved cache!");
-                        let satsVbyte = num.to_owned() as f32;
-                        let fee_rate = FeeRate::from_sat_per_vb(satsVbyte);
+                        let sats_vbyte = num.to_owned() as f32;
+                        let fee_rate = FeeRate::from_sat_per_vb(sats_vbyte);
                         (fee_rate.fee_wu(1000) as u32).max(FEERATE_FLOOR_SATS_PER_KW)
                     }
                     None => fallback_fee,

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -1,13 +1,6 @@
 #![crate_name = "mutiny_core"]
-// wasm_bindgen uses improper casing and it needs to be turned off:
-// https://github.com/rustwasm/wasm-bindgen/issues/2882
-// wasm is also considered "extra_unused_type_parameters"
-#![allow(
-    incomplete_features,
-    non_snake_case,
-    non_upper_case_globals,
-    clippy::extra_unused_type_parameters
-)]
+// wasm is considered "extra_unused_type_parameters"
+#![allow(incomplete_features, clippy::extra_unused_type_parameters)]
 #![feature(io_error_other)]
 #![feature(async_fn_in_trait)]
 // background file is mostly an LDK copy paste

--- a/mutiny-core/src/localstorage.rs
+++ b/mutiny-core/src/localstorage.rs
@@ -12,9 +12,9 @@ use crate::encrypt::*;
 use crate::error::MutinyStorageError;
 use crate::nodemanager::NodeStorage;
 
-const mnemonic_key: &str = "mnemonic";
-const nodes_key: &str = "nodes";
-const fee_estimates_key: &str = "fee_estimates";
+const MNEMONIC_KEY: &str = "mnemonic";
+const NODES_KEY: &str = "nodes";
+const FEE_ESTIMATES_KEY: &str = "fee_estimates";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MutinyBrowserStorage {
@@ -84,7 +84,7 @@ impl MutinyBrowserStorage {
     }
 
     pub(crate) fn insert_mnemonic(&self, mnemonic: Mnemonic) -> Mnemonic {
-        self.set(mnemonic_key, mnemonic.to_string())
+        self.set(MNEMONIC_KEY, mnemonic.to_string())
             .expect("Failed to write to storage");
         mnemonic
     }
@@ -92,14 +92,14 @@ impl MutinyBrowserStorage {
     pub(crate) fn get_mnemonic(&self) -> anyhow::Result<Mnemonic> {
         // TODO: here's another way to write this... but the error conversions end up being a pain in the ass
         //
-        // self.get(mnemonic_key)
+        // self.get(MNEMONIC_KEY)
         //     .and_then(|raw_mnemonic| {
         //         Ok(Mnemonic::from_str(raw_mnemonic)
         //             .with_context(|| format!("BIP 39 parse error"))?)
         //     })
         //     .with_context(|| format!("storage error"))
 
-        let res: Result<String, MutinyStorageError> = self.get(mnemonic_key);
+        let res: Result<String, MutinyStorageError> = self.get(MNEMONIC_KEY);
         match res {
             Ok(str) => Ok(Mnemonic::from_str(&str).expect("could not parse specified mnemonic")),
             Err(e) => Err(e)?,
@@ -112,11 +112,11 @@ impl MutinyBrowserStorage {
 
     #[allow(dead_code)]
     pub(crate) fn delete_mnemonic() {
-        LocalStorage::delete(mnemonic_key);
+        LocalStorage::delete(MNEMONIC_KEY);
     }
 
     pub(crate) fn get_nodes() -> Result<NodeStorage, MutinyStorageError> {
-        let res: gloo_storage::Result<NodeStorage> = LocalStorage::get(nodes_key);
+        let res: gloo_storage::Result<NodeStorage> = LocalStorage::get(NODES_KEY);
         match res {
             Ok(k) => Ok(k),
             Err(e) => match e {
@@ -129,16 +129,16 @@ impl MutinyBrowserStorage {
     }
 
     pub(crate) fn insert_nodes(nodes: NodeStorage) -> Result<(), MutinyStorageError> {
-        Ok(LocalStorage::set(nodes_key, nodes)?)
+        Ok(LocalStorage::set(NODES_KEY, nodes)?)
     }
 
     pub(crate) fn get_fee_estimates() -> Result<HashMap<String, f64>, MutinyStorageError> {
-        Ok(LocalStorage::get(fee_estimates_key)?)
+        Ok(LocalStorage::get(FEE_ESTIMATES_KEY)?)
     }
 
     pub(crate) fn insert_fee_estimates(
         fees: HashMap<String, f64>,
     ) -> Result<(), MutinyStorageError> {
-        Ok(LocalStorage::set(fee_estimates_key, fees)?)
+        Ok(LocalStorage::set(FEE_ESTIMATES_KEY, fees)?)
     }
 }

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 [dependencies]
 mutiny-core = { path = "../mutiny-core" }
 
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 serde-wasm-bindgen = "0.5.0"
 wasm-bindgen-futures = "0.4.33"
 serde = { version = "^1.0", features = ["derive"] }

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -1,11 +1,5 @@
-// wasm_bindgen uses improper casing and it needs to be turned off:
-// https://github.com/rustwasm/wasm-bindgen/issues/2882
-// wasm is also considered "extra_unused_type_parameters"
-#![allow(
-    non_snake_case,
-    non_upper_case_globals,
-    clippy::extra_unused_type_parameters
-)]
+// wasm is considered "extra_unused_type_parameters"
+#![allow(clippy::extra_unused_type_parameters)]
 
 extern crate mutiny_core;
 


### PR DESCRIPTION
Latest version of wasm-bindgen fixed the variable name casing issue so we can re-enable those warnings.

Fixed the issues where we caused it as well.