### PR TITLE
Move rest of ldk storage to indexed db

### DIFF
--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -71,7 +71,8 @@ mockall = "0.11.2"
 
 [features]
 default = ["console_error_panic_hook"]
-ignored_tests = []
+ignored_tests = ["test-utils"]
+test-utils = []
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = true

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -18,7 +18,6 @@ lnurl-rs = { version = "0.2", default-features = false, features = ["async", "as
 
 cfg-if = "1.0.0"
 wasm-bindgen = "0.2.84"
-serde-wasm-bindgen = "0.5.0"
 bip39 = { version = "2.0.0" }
 bip32 = "0.4.0"
 bitcoin-bech32 = "0.12"
@@ -59,6 +58,7 @@ wasm-bindgen-futures = "0.4.33"
 wasm-logger = "0.2.0"
 log = "0.4.17"
 gloo-net = "0.2.4"
+gloo-utils = { version = "0.1.6", features = ["serde"] }
 futures = "0.3.25"
 thiserror = "1.0"
 web-sys = { version = "0.3.60", features = ["console"] }

--- a/mutiny-core/src/bdkstorage.rs
+++ b/mutiny-core/src/bdkstorage.rs
@@ -384,7 +384,7 @@ mod tests {
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
     use crate::localstorage::MutinyBrowserStorage;
-    use crate::test::*;
+    use crate::test_utils::*;
 
     use super::*;
 

--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -215,14 +215,6 @@ impl From<std::io::Error> for MutinyError {
     }
 }
 
-impl From<serde_wasm_bindgen::Error> for MutinyError {
-    fn from(_: serde_wasm_bindgen::Error) -> Self {
-        Self::ReadError {
-            source: MutinyStorageError::Other(anyhow::anyhow!("Failed to deserialize")),
-        }
-    }
-}
-
 impl From<serde_json::Error> for MutinyError {
     fn from(_: serde_json::Error) -> Self {
         Self::ReadError {

--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -114,6 +114,8 @@ pub enum MutinyStorageError {
         #[from]
         source: serde_json::Error,
     },
+    #[error("Failed to get lock on memory storage")]
+    LockError,
     #[error("Failed to use indexeddb storage")]
     IndexedDBError,
     #[error(transparent)]
@@ -124,6 +126,10 @@ impl MutinyError {
     pub fn read_err(e: MutinyStorageError) -> Self {
         MutinyError::ReadError { source: e }
     }
+
+    pub fn write_err(e: MutinyStorageError) -> Self {
+        MutinyError::PersistenceFailed { source: e }
+    }
 }
 
 impl From<bdk::Error> for MutinyError {
@@ -132,6 +138,12 @@ impl From<bdk::Error> for MutinyError {
             bdk::Error::Signer(_) => Self::WalletSigningFailed,
             _ => Self::WalletOperationFailed,
         }
+    }
+}
+
+impl From<bip39::Error> for MutinyError {
+    fn from(_e: bip39::Error) -> Self {
+        Self::InvalidMnemonic
     }
 }
 
@@ -211,11 +223,25 @@ impl From<serde_wasm_bindgen::Error> for MutinyError {
     }
 }
 
+impl From<serde_json::Error> for MutinyError {
+    fn from(_: serde_json::Error) -> Self {
+        Self::ReadError {
+            source: MutinyStorageError::Other(anyhow::anyhow!("Failed to deserialize")),
+        }
+    }
+}
+
 impl From<rexie::Error> for MutinyError {
     fn from(_e: rexie::Error) -> Self {
         MutinyError::PersistenceFailed {
             source: MutinyStorageError::IndexedDBError,
         }
+    }
+}
+
+impl<G> From<std::sync::PoisonError<G>> for MutinyStorageError {
+    fn from(_e: std::sync::PoisonError<G>) -> Self {
+        MutinyStorageError::LockError
     }
 }
 

--- a/mutiny-core/src/gossip.rs
+++ b/mutiny-core/src/gossip.rs
@@ -712,8 +712,7 @@ mod test {
         assert!(data.is_some());
         assert!(data.unwrap().last_sync_timestamp > 0);
 
-        cleanup_indexdb_test().await;
-        cleanup_test();
+        cleanup_gossip_test().await;
     }
 
     #[test]
@@ -740,8 +739,7 @@ mod test {
 
         assert!(read.is_none());
 
-        cleanup_indexdb_test().await;
-        cleanup_test();
+        cleanup_gossip_test().await;
     }
 
     #[test]
@@ -766,7 +764,6 @@ mod test {
         assert!(read.is_some());
         assert_eq!(read.unwrap(), expected);
 
-        cleanup_indexdb_test().await;
-        cleanup_test();
+        cleanup_gossip_test().await;
     }
 }

--- a/mutiny-core/src/gossip.rs
+++ b/mutiny-core/src/gossip.rs
@@ -639,7 +639,7 @@ mod test {
     use uuid::Uuid;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-    use crate::test::*;
+    use crate::test_utils::*;
 
     use super::*;
 
@@ -696,7 +696,7 @@ mod test {
     // hack to disable this test
     #[cfg(feature = "ignored_tests")]
     async fn test_gossip() {
-        crate::test::log!("test RGS sync");
+        crate::test_utils::log!("test RGS sync");
         // delete the database if it exists
         Rexie::delete(GOSSIP_DATABASE_NAME).await.unwrap();
 

--- a/mutiny-core/src/gossip.rs
+++ b/mutiny-core/src/gossip.rs
@@ -6,6 +6,7 @@ use anyhow::anyhow;
 use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::Network;
+use gloo_utils::format::JsValueSerdeExt;
 use lightning::ln::msgs::NodeAnnouncement;
 use lightning::routing::gossip::{NodeAlias, NodeId};
 use lightning::routing::scoring::ProbabilisticScoringParameters;
@@ -95,7 +96,7 @@ async fn get_gossip_data(
         return Ok(None);
     }
 
-    let network_graph_str: String = serde_wasm_bindgen::from_value(network_graph_js)?;
+    let network_graph_str: String = network_graph_js.into_serde()?;
     let network_graph_bytes: Vec<u8> = Vec::from_hex(&network_graph_str)?;
     let mut readable_bytes = lightning::io::Cursor::new(network_graph_bytes);
     let network_graph = Arc::new(NetworkGraph::read(&mut readable_bytes, logger.clone())?);
@@ -113,7 +114,7 @@ async fn get_gossip_data(
         return Ok(Some(gossip));
     }
 
-    let prob_scorer_str: String = serde_wasm_bindgen::from_value(prob_scorer_js)?;
+    let prob_scorer_str: String = network_graph_js.into_serde()?;
     let prob_scorer_bytes: Vec<u8> = Vec::from_hex(&prob_scorer_str)?;
     let mut readable_bytes = lightning::io::Cursor::new(prob_scorer_bytes);
     let params = ProbabilisticScoringParameters::default();
@@ -217,7 +218,7 @@ async fn write_network_graph_to_store(
     store: &Store,
     network_graph_str: &str,
 ) -> Result<(), MutinyError> {
-    let network_graph_js = serde_wasm_bindgen::to_value(network_graph_str)?;
+    let network_graph_js = JsValue::from_serde(network_graph_str)?;
     store
         .put(&network_graph_js, Some(&JsValue::from(NETWORK_GRAPH_KEY)))
         .await?;
@@ -226,7 +227,7 @@ async fn write_network_graph_to_store(
 }
 
 async fn write_scorer_to_store(store: &Store, scorer_str: &str) -> Result<(), MutinyError> {
-    let scorer_js = serde_wasm_bindgen::to_value(scorer_str)?;
+    let scorer_js = JsValue::from_serde(scorer_str)?;
     store
         .put(&scorer_js, Some(&JsValue::from(PROB_SCORER_KEY)))
         .await?;
@@ -447,7 +448,7 @@ pub(crate) async fn read_peer_info(
     let key = JsValue::from(node_id.to_string());
 
     let json: JsValue = store.get(&key).await?;
-    let data: Option<LnPeerMetadata> = serde_wasm_bindgen::from_value(json)?;
+    let data: Option<LnPeerMetadata> = json.into_serde()?;
 
     // Waits for the transaction to complete
     transaction.done().await?;
@@ -468,7 +469,7 @@ pub(crate) async fn get_all_peers() -> Result<HashMap<NodeId, LnPeerMetadata>, M
     for (key, value) in all_json {
         let pub_key = PublicKey::from_str(&key.as_string().unwrap()).unwrap();
         let node_id = NodeId::from_pubkey(&pub_key);
-        let data: Option<LnPeerMetadata> = serde_wasm_bindgen::from_value(value)?;
+        let data: Option<LnPeerMetadata> = value.into_serde()?;
 
         if let Some(peer_metadata) = data {
             peers.insert(node_id, peer_metadata);
@@ -496,7 +497,7 @@ pub(crate) async fn save_peer_connection_info(
     let key = JsValue::from(node_id.to_string());
 
     let current_js: JsValue = store.get(&key).await?;
-    let current: Option<LnPeerMetadata> = serde_wasm_bindgen::from_value(current_js)?;
+    let current: Option<LnPeerMetadata> = current_js.into_serde()?;
 
     // If there is already some metadata, we add the connection string to it
     // Otherwise we create a new metadata with the connection string
@@ -513,7 +514,7 @@ pub(crate) async fn save_peer_connection_info(
         },
     };
 
-    let json = serde_wasm_bindgen::to_value(&new_info)?;
+    let json = JsValue::from_serde(&new_info)?;
     store.put(&json, Some(&key)).await?;
 
     // Waits for the transaction to complete
@@ -537,7 +538,7 @@ pub(crate) async fn set_peer_label(
     let key = JsValue::from(node_id.to_string());
 
     let current_js: JsValue = store.get(&key).await?;
-    let current: Option<LnPeerMetadata> = serde_wasm_bindgen::from_value(current_js)?;
+    let current: Option<LnPeerMetadata> = current_js.into_serde()?;
 
     // If there is already some metadata, we add the label to it
     // Otherwise we create a new metadata with the label
@@ -550,7 +551,7 @@ pub(crate) async fn set_peer_label(
         },
     };
 
-    let json = serde_wasm_bindgen::to_value(&new_info)?;
+    let json = JsValue::from_serde(&new_info)?;
     store.put(&json, Some(&key)).await?;
 
     // Waits for the transaction to complete
@@ -569,14 +570,14 @@ pub(crate) async fn delete_peer_info(uuid: &str, node_id: &NodeId) -> Result<(),
     let key = JsValue::from(node_id.to_string());
 
     let current_js: JsValue = store.get(&key).await?;
-    let current: Option<LnPeerMetadata> = serde_wasm_bindgen::from_value(current_js)?;
+    let current: Option<LnPeerMetadata> = current_js.into_serde()?;
 
     if let Some(mut current) = current {
         current.nodes.retain(|n| n != uuid);
         if current.nodes.is_empty() {
             store.delete(&key).await?;
         } else {
-            let json = serde_wasm_bindgen::to_value(&current)?;
+            let json = JsValue::from_serde(&current)?;
             store.put(&json, Some(&key)).await?;
         }
     }
@@ -600,13 +601,13 @@ pub(crate) async fn save_ln_peer_info(
     let key = JsValue::from(node_id.to_string());
 
     let current_js: JsValue = store.get(&key).await?;
-    let current: Option<LnPeerMetadata> = serde_wasm_bindgen::from_value(current_js)?;
+    let current: Option<LnPeerMetadata> = current_js.into_serde()?;
 
     let new_info = info.merge_opt(&current);
 
     // if the new info is different than the current info, we should to save it
     if !current.is_some_and(|c| c == new_info) {
-        let json = serde_wasm_bindgen::to_value(&new_info)?;
+        let json = JsValue::from_serde(&new_info)?;
         store.put(&json, Some(&key)).await?;
     }
 

--- a/mutiny-core/src/indexed_db.rs
+++ b/mutiny-core/src/indexed_db.rs
@@ -212,7 +212,7 @@ impl MutinyStorage {
                 .ok_or(MutinyError::read_err(MutinyStorageError::Other(anyhow!(
                     "key from indexedDB is not a string"
                 ))))?;
-            let json: serde_json::Value = match password {
+            let json: Option<serde_json::Value> = match password {
                 Some(pw) if Self::needs_encryption(&key) => {
                     let str: String = serde_wasm_bindgen::from_value(value)?;
                     let ciphertext = decrypt(&str, pw);
@@ -220,7 +220,10 @@ impl MutinyStorage {
                 }
                 _ => serde_wasm_bindgen::from_value(value)?,
             };
-            map.insert(key, json);
+
+            if let Some(json) = json {
+                map.insert(key, json);
+            }
         }
 
         Ok(map)

--- a/mutiny-core/src/indexed_db.rs
+++ b/mutiny-core/src/indexed_db.rs
@@ -1,0 +1,249 @@
+use crate::encrypt::{decrypt, encrypt};
+use crate::error::{MutinyError, MutinyStorageError};
+use crate::ldkstorage::CHANNEL_MANAGER_KEY;
+use anyhow::anyhow;
+use bip39::Mnemonic;
+use rexie::{ObjectStore, Rexie, TransactionMode};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::{Arc, RwLock};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::spawn_local;
+
+pub(crate) const WALLET_DATABASE_NAME: &str = "wallet";
+pub(crate) const WALLET_OBJECT_STORE_NAME: &str = "wallet_store";
+
+const MNEMONIC_KEY: &str = "mnemonic";
+
+#[derive(Clone)]
+pub struct MutinyStorage {
+    pub(crate) password: Option<String>,
+    /// In-memory cache of the wallet data
+    /// This is used to avoid having to read from IndexedDB on every get.
+    /// This is a RwLock because we want to be able to read from it without blocking
+    memory: Arc<RwLock<HashMap<String, serde_json::Value>>>,
+    indexed_db: Arc<Rexie>,
+}
+
+impl MutinyStorage {
+    pub async fn new(password: String) -> Result<MutinyStorage, MutinyError> {
+        let indexed_db = Arc::new(Self::build_indexed_db_database().await?);
+
+        // If the password is empty, set to None
+        let password = Some(password).filter(|pw| !pw.is_empty());
+
+        let map = Self::read_all(&indexed_db, &password).await?;
+        let memory = Arc::new(RwLock::new(map));
+
+        Ok(MutinyStorage {
+            password,
+            memory,
+            indexed_db,
+        })
+    }
+
+    pub(crate) fn set<T>(&self, key: impl AsRef<str>, value: T) -> Result<(), MutinyError>
+    where
+        T: Serialize,
+    {
+        let data = serde_json::to_value(value)?;
+        let mut map = self
+            .memory
+            .write()
+            .map_err(|e| MutinyError::write_err(e.into()))?;
+        map.insert(key.as_ref().to_string(), data.clone());
+
+        let indexed_db = self.indexed_db.clone();
+        let password = self.password.clone();
+        let key = key.as_ref().to_string();
+        spawn_local(async move {
+            Self::save_to_indexed_db(indexed_db, &password, &key, &data)
+                .await
+                .expect(&format!("Failed to save to indexed db: {key}"))
+        });
+
+        Ok(())
+    }
+
+    async fn save_to_indexed_db(
+        indexed_db: Arc<Rexie>,
+        password: &Option<String>,
+        key: &str,
+        data: &serde_json::Value,
+    ) -> Result<(), MutinyError> {
+        let tx = indexed_db
+            .as_ref()
+            .transaction(&[WALLET_OBJECT_STORE_NAME], TransactionMode::ReadWrite)?;
+
+        let store = tx.store(WALLET_OBJECT_STORE_NAME)?;
+
+        // Only bother encrypting if a password is set
+        let json = match password {
+            Some(pw) if Self::needs_encryption(key) => {
+                let str = serde_json::to_string(data)?;
+                let ciphertext = encrypt(&str, pw);
+                serde_wasm_bindgen::to_value(&ciphertext)?
+            }
+            _ => serde_wasm_bindgen::to_value(data)?,
+        };
+
+        // save to indexed db
+        store.put(&json, Some(&JsValue::from(key))).await?;
+
+        tx.done().await?;
+
+        Ok(())
+    }
+
+    pub(crate) fn get<T>(&self, key: impl AsRef<str>) -> Result<Option<T>, MutinyError>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let map = self
+            .memory
+            .read()
+            .map_err(|e| MutinyError::read_err(e.into()))?;
+        match map.get(key.as_ref()) {
+            None => Ok(None),
+            Some(value) => {
+                let data: T = serde_json::from_value(value.clone())?;
+                Ok(Some(data))
+            }
+        }
+    }
+
+    pub(crate) fn scan<T>(
+        &self,
+        prefix: &str,
+        suffix: Option<&str>,
+    ) -> Result<HashMap<String, T>, MutinyError>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let map = self
+            .memory
+            .read()
+            .map_err(|e| MutinyError::read_err(e.into()))?;
+
+        Ok(map
+            .keys()
+            .filter(|key| {
+                key.starts_with(prefix) && (suffix.is_none() || key.ends_with(suffix.unwrap()))
+            })
+            .filter_map(|key| {
+                self.get(key)
+                    .ok()
+                    .flatten()
+                    .map(|value: T| (key.to_owned(), value))
+            })
+            .collect())
+    }
+
+    pub(crate) async fn insert_mnemonic(
+        &self,
+        mnemonic: Mnemonic,
+    ) -> Result<Mnemonic, MutinyError> {
+        // Instead of calling self.set we manually write to indexed db
+        // so we get a guarantee that the mnemonic is saved before we return
+
+        let data = serde_json::to_value(mnemonic.to_string())?;
+        Self::save_to_indexed_db(self.indexed_db.clone(), &self.password, MNEMONIC_KEY, &data)
+            .await?;
+        Ok(mnemonic)
+    }
+
+    pub(crate) async fn get_mnemonic(&self) -> Result<Mnemonic, MutinyError> {
+        let tx = self
+            .indexed_db
+            .transaction(&[WALLET_OBJECT_STORE_NAME], TransactionMode::ReadOnly)?;
+        let store = tx.store(WALLET_OBJECT_STORE_NAME)?;
+
+        let key = JsValue::from(MNEMONIC_KEY);
+        let json = store.get(&key).await?;
+        let value: Option<String> = serde_wasm_bindgen::from_value(json)?;
+
+        let mnemonic = match value {
+            Some(mnemonic) => Mnemonic::from_str(&mnemonic)?,
+            None => return Err(MutinyError::InvalidMnemonic), // maybe need a better error
+        };
+
+        tx.done().await?;
+
+        Ok(mnemonic)
+    }
+
+    pub(crate) async fn has_mnemonic() -> Result<bool, MutinyError> {
+        let indexed_db = Self::build_indexed_db_database().await?;
+        let tx = indexed_db.transaction(&[WALLET_OBJECT_STORE_NAME], TransactionMode::ReadOnly)?;
+        let store = tx.store(WALLET_OBJECT_STORE_NAME)?;
+
+        let key = JsValue::from(MNEMONIC_KEY);
+        let json = store.get(&key).await?;
+        let value: Option<String> = serde_wasm_bindgen::from_value(json)?;
+
+        Ok(value.is_some())
+    }
+
+    async fn build_indexed_db_database() -> Result<Rexie, MutinyError> {
+        let rexie = Rexie::builder(WALLET_DATABASE_NAME)
+            .version(1)
+            .add_object_store(ObjectStore::new(WALLET_OBJECT_STORE_NAME))
+            .build()
+            .await?;
+
+        Ok(rexie)
+    }
+
+    async fn read_all(
+        indexed_db: &Rexie,
+        password: &Option<String>,
+    ) -> Result<HashMap<String, serde_json::Value>, MutinyError> {
+        let tx = indexed_db.transaction(&[WALLET_OBJECT_STORE_NAME], TransactionMode::ReadOnly)?;
+
+        let store = tx.store(WALLET_OBJECT_STORE_NAME)?;
+
+        let mut map = HashMap::new();
+        let all_json = store.get_all(None, None, None, None).await?;
+        let mut iter = all_json.into_iter();
+        while let Some((key, value)) = iter.next() {
+            let key = key
+                .as_string()
+                .ok_or(MutinyError::read_err(MutinyStorageError::Other(anyhow!(
+                    "key from indexedDB is not a string"
+                ))))?;
+            let json: serde_json::Value = match password {
+                Some(pw) if Self::needs_encryption(&key) => {
+                    let str: String = serde_wasm_bindgen::from_value(value)?;
+                    let ciphertext = decrypt(&str, pw);
+                    serde_json::from_str(&ciphertext)?
+                }
+                _ => serde_wasm_bindgen::from_value(value)?,
+            };
+            map.insert(key, json);
+        }
+
+        Ok(map)
+    }
+
+    fn needs_encryption(key: &str) -> bool {
+        match key {
+            MNEMONIC_KEY => true,
+            str if str.starts_with(CHANNEL_MANAGER_KEY) => true,
+            _ => false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn clear() -> Result<(), MutinyError> {
+        let indexed_db = Self::build_indexed_db_database().await?;
+        let tx = indexed_db.transaction(&[WALLET_OBJECT_STORE_NAME], TransactionMode::ReadWrite)?;
+        let store = tx.store(WALLET_OBJECT_STORE_NAME)?;
+
+        store.clear().await?;
+
+        tx.done().await?;
+
+        Ok(())
+    }
+}

--- a/mutiny-core/src/indexed_db.rs
+++ b/mutiny-core/src/indexed_db.rs
@@ -218,8 +218,7 @@ impl MutinyStorage {
 
         let mut map = HashMap::new();
         let all_json = store.get_all(None, None, None, None).await?;
-        let mut iter = all_json.into_iter();
-        while let Some((key, value)) = iter.next() {
+        for (key, value) in all_json {
             let key = key
                 .as_string()
                 .ok_or(MutinyError::read_err(MutinyStorageError::Other(anyhow!(

--- a/mutiny-core/src/indexed_db.rs
+++ b/mutiny-core/src/indexed_db.rs
@@ -234,7 +234,7 @@ impl MutinyStorage {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-utils"))]
     pub(crate) async fn clear() -> Result<(), MutinyError> {
         let indexed_db = Self::build_indexed_db_database().await?;
         let tx = indexed_db.transaction(&[WALLET_OBJECT_STORE_NAME], TransactionMode::ReadWrite)?;

--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -66,7 +66,7 @@ mod tests {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    use crate::{keymanager::pubkey_from_keys_manager, test::*};
+    use crate::{keymanager::pubkey_from_keys_manager, test_utils::*};
 
     use super::create_keys_manager;
     use bip39::Mnemonic;

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -359,7 +359,7 @@ mod test {
 
     use super::*;
 
-    use crate::test::*;
+    use crate::test_utils::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
 

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod esplora;
 mod event;
 mod fees;
 mod gossip;
+mod indexed_db;
 mod keymanager;
 mod ldkstorage;
 mod localstorage;
@@ -40,12 +41,19 @@ mod test {
     use rexie::Rexie;
 
     use crate::gossip::GOSSIP_DATABASE_NAME;
+    use crate::indexed_db::MutinyStorage;
 
     pub(crate) fn cleanup_test() {
         LocalStorage::clear();
     }
 
-    pub(crate) async fn cleanup_indexdb_test() {
+    pub(crate) async fn cleanup_gossip_test() {
+        cleanup_test();
         Rexie::delete(GOSSIP_DATABASE_NAME).await.unwrap();
+    }
+
+    pub(crate) async fn cleanup_wallet_test() {
+        cleanup_test();
+        MutinyStorage::clear().await.unwrap();
     }
 }

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -25,35 +25,7 @@ pub mod nodemanager;
 mod peermanager;
 mod proxy;
 mod socket;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
 mod utils;
 mod wallet;
-
-#[cfg(test)]
-mod test {
-    use gloo_storage::{LocalStorage, Storage};
-
-    macro_rules! log {
-        ( $( $t:tt )* ) => {
-            web_sys::console::log_1(&format!( $( $t )* ).into());
-        }
-    }
-    pub(crate) use log;
-    use rexie::Rexie;
-
-    use crate::gossip::GOSSIP_DATABASE_NAME;
-    use crate::indexed_db::MutinyStorage;
-
-    pub(crate) fn cleanup_test() {
-        LocalStorage::clear();
-    }
-
-    pub(crate) async fn cleanup_gossip_test() {
-        cleanup_test();
-        Rexie::delete(GOSSIP_DATABASE_NAME).await.unwrap();
-    }
-
-    pub(crate) async fn cleanup_wallet_test() {
-        cleanup_test();
-        MutinyStorage::clear().await.unwrap();
-    }
-}

--- a/mutiny-core/src/localstorage.rs
+++ b/mutiny-core/src/localstorage.rs
@@ -1,8 +1,5 @@
 use std::collections::HashMap;
 use std::str;
-use std::str::FromStr;
-
-use bip39::Mnemonic;
 
 use gloo_storage::errors::StorageError;
 use gloo_storage::{LocalStorage, Storage};
@@ -12,7 +9,6 @@ use crate::encrypt::*;
 use crate::error::MutinyStorageError;
 use crate::nodemanager::NodeStorage;
 
-const MNEMONIC_KEY: &str = "mnemonic";
 const NODES_KEY: &str = "nodes";
 const FEE_ESTIMATES_KEY: &str = "fee_estimates";
 
@@ -81,38 +77,6 @@ impl MutinyBrowserStorage {
         }
 
         map
-    }
-
-    pub(crate) fn insert_mnemonic(&self, mnemonic: Mnemonic) -> Mnemonic {
-        self.set(MNEMONIC_KEY, mnemonic.to_string())
-            .expect("Failed to write to storage");
-        mnemonic
-    }
-
-    pub(crate) fn get_mnemonic(&self) -> anyhow::Result<Mnemonic> {
-        // TODO: here's another way to write this... but the error conversions end up being a pain in the ass
-        //
-        // self.get(MNEMONIC_KEY)
-        //     .and_then(|raw_mnemonic| {
-        //         Ok(Mnemonic::from_str(raw_mnemonic)
-        //             .with_context(|| format!("BIP 39 parse error"))?)
-        //     })
-        //     .with_context(|| format!("storage error"))
-
-        let res: Result<String, MutinyStorageError> = self.get(MNEMONIC_KEY);
-        match res {
-            Ok(str) => Ok(Mnemonic::from_str(&str).expect("could not parse specified mnemonic")),
-            Err(e) => Err(e)?,
-        }
-    }
-
-    pub(crate) fn has_mnemonic() -> bool {
-        LocalStorage::get::<String>("mnemonic").is_ok()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn delete_mnemonic() {
-        LocalStorage::delete(MNEMONIC_KEY);
     }
 
     pub(crate) fn get_nodes() -> Result<NodeStorage, MutinyStorageError> {

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1099,7 +1099,7 @@ pub(crate) fn default_user_config() -> UserConfig {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::*;
+    use crate::test_utils::*;
     use bitcoin::secp256k1::PublicKey;
     use std::str::FromStr;
 

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1214,7 +1214,6 @@ mod tests {
             assert_eq!(1, retrieved_node.child_index);
         }
 
-        cleanup_test();
         cleanup_wallet_test().await;
     }
 

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1134,7 +1134,6 @@ mod tests {
     async fn create_node_manager() {
         log!("creating node manager!");
 
-        cleanup_wallet_test().await;
         assert!(!NodeManager::has_node_manager().await);
         NodeManager::new(
             "password".to_string(),

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1121,7 +1121,7 @@ mod tests {
     use lightning::ln::PaymentHash;
     use std::str::FromStr;
 
-    use crate::test::*;
+    use crate::test_utils::*;
 
     use crate::event::{HTLCStatus, MillisatAmount, PaymentInfo};
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use std::{collections::HashMap, ops::Deref, sync::Arc};
 
 use crate::event::{HTLCStatus, PaymentInfo};
+use crate::indexed_db::MutinyStorage;
 use crate::{
     chain::MutinyChain,
     error::MutinyError,
@@ -51,7 +52,7 @@ pub struct NodeManager {
     scorer: Arc<utils::Mutex<ProbScorer>>,
     chain: Arc<MutinyChain>,
     fee_estimator: Arc<MutinyFeeEstimator>,
-    storage: MutinyBrowserStorage,
+    storage: MutinyStorage,
     node_storage: Mutex<NodeStorage>,
     nodes: Arc<Mutex<HashMap<PublicKey, Arc<Node>>>>,
     lnurl_client: LnUrlClient,
@@ -243,8 +244,8 @@ pub struct LnUrlParams {
 }
 
 impl NodeManager {
-    pub fn has_node_manager() -> bool {
-        MutinyBrowserStorage::has_mnemonic()
+    pub async fn has_node_manager() -> bool {
+        MutinyStorage::has_mnemonic().await.unwrap_or(false)
     }
 
     pub async fn new(
@@ -262,15 +263,15 @@ impl NodeManager {
         // todo we should eventually have default mainnet
         let network: Network = network.unwrap_or(Network::Testnet);
 
-        let storage = MutinyBrowserStorage::new(password);
+        let storage = MutinyStorage::new(password.clone()).await?;
 
         let mnemonic = match mnemonic {
-            Some(seed) => storage.insert_mnemonic(seed),
-            None => match storage.get_mnemonic() {
+            Some(seed) => storage.insert_mnemonic(seed).await?,
+            None => match storage.get_mnemonic().await {
                 Ok(mnemonic) => mnemonic,
                 Err(_) => {
                     let seed = keymanager::generate_seed(12)?;
-                    storage.insert_mnemonic(seed)
+                    storage.insert_mnemonic(seed).await?
                 }
             },
         };
@@ -281,9 +282,10 @@ impl NodeManager {
         let tx_sync = Arc::new(EsploraSyncClient::new(esplora_server_url, logger.clone()));
 
         let esplora = Arc::new(EsploraBlockchain::from_client(tx_sync.client().clone(), 5));
+        let database = MutinyBrowserStorage::new(password);
         let wallet = Arc::new(MutinyWallet::new(
             &mnemonic,
-            storage.clone(),
+            database,
             network,
             esplora.clone(),
         ));
@@ -1132,7 +1134,8 @@ mod tests {
     async fn create_node_manager() {
         log!("creating node manager!");
 
-        assert!(!NodeManager::has_node_manager());
+        cleanup_wallet_test().await;
+        assert!(!NodeManager::has_node_manager().await);
         NodeManager::new(
             "password".to_string(),
             None,
@@ -1144,9 +1147,9 @@ mod tests {
         )
         .await
         .expect("node manager should initialize");
-        assert!(NodeManager::has_node_manager());
+        assert!(NodeManager::has_node_manager().await);
 
-        cleanup_test();
+        cleanup_wallet_test().await;
     }
 
     #[test]
@@ -1166,10 +1169,10 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(NodeManager::has_node_manager());
+        assert!(NodeManager::has_node_manager().await);
         assert_eq!(seed, nm.show_seed());
 
-        cleanup_test();
+        cleanup_wallet_test().await;
     }
 
     #[test]
@@ -1213,6 +1216,7 @@ mod tests {
         }
 
         cleanup_test();
+        cleanup_wallet_test().await;
     }
 
     #[test]

--- a/mutiny-core/src/proxy.rs
+++ b/mutiny-core/src/proxy.rs
@@ -96,7 +96,7 @@ pub fn mutiny_conn_proxy_to_url(proxy_url: &str, peer_pubkey: &str) -> String {
 #[cfg(test)]
 mod tests {
     use crate::proxy::{Proxy, PubkeyConnectionInfo};
-    use crate::test::*;
+    use crate::test_utils::*;
 
     use crate::proxy::{mutiny_conn_proxy_to_url, tcp_proxy_to_url, WsProxy};
 

--- a/mutiny-core/src/test_utils.rs
+++ b/mutiny-core/src/test_utils.rs
@@ -1,0 +1,26 @@
+use gloo_storage::{LocalStorage, Storage};
+
+macro_rules! log {
+        ( $( $t:tt )* ) => {
+            web_sys::console::log_1(&format!( $( $t )* ).into());
+        }
+    }
+pub(crate) use log;
+use rexie::Rexie;
+
+use crate::gossip::GOSSIP_DATABASE_NAME;
+use crate::indexed_db::MutinyStorage;
+
+pub fn cleanup_test() {
+    LocalStorage::clear();
+}
+
+pub async fn cleanup_gossip_test() {
+    cleanup_test();
+    Rexie::delete(GOSSIP_DATABASE_NAME).await.unwrap();
+}
+
+pub async fn cleanup_wallet_test() {
+    cleanup_test();
+    MutinyStorage::clear().await.unwrap();
+}

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -30,7 +30,6 @@ lnurl-rs = { version = "0.2", default-features = false }
 wasm-logger = "0.2.0"
 log = "0.4.17"
 gloo-storage = "0.2.2"
-rexie = "0.4"
 web-sys = { version = "0.3.60", features = ["console"] }
 bip39 = { version = "2.0.0" }
 getrandom = { version = "0.2", features = ["js"] }
@@ -42,6 +41,7 @@ getrandom = { version = "0.2", features = ["js"] }
 console_error_panic_hook = { version = "0.1.6", optional = true }
 
 [dev-dependencies]
+mutiny-core = { path = "../mutiny-core", features = ["test-utils"] }
 wasm-bindgen-test = "0.3.33"
 mockall = "0.11.2"
 

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -30,6 +30,7 @@ lnurl-rs = { version = "0.2", default-features = false }
 wasm-logger = "0.2.0"
 log = "0.4.17"
 gloo-storage = "0.2.2"
+rexie = "0.4"
 web-sys = { version = "0.3.60", features = ["console"] }
 bip39 = { version = "2.0.0" }
 getrandom = { version = "0.2", features = ["js"] }

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -19,7 +19,6 @@ crate-type = ["cdylib"]
 mutiny-core = { path = "../mutiny-core" }
 
 wasm-bindgen = "0.2.84"
-serde-wasm-bindgen = "0.5.0"
 wasm-bindgen-futures = "0.4.33"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
@@ -30,6 +29,7 @@ lnurl-rs = { version = "0.2", default-features = false }
 wasm-logger = "0.2.0"
 log = "0.4.17"
 gloo-storage = "0.2.2"
+gloo-utils = { version = "0.1.6", features = ["serde"] }
 web-sys = { version = "0.3.60", features = ["console"] }
 bip39 = { version = "2.0.0" }
 getrandom = { version = "0.2", features = ["js"] }

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -93,6 +93,9 @@ pub enum MutinyJsError {
     /// A error with DLCs
     #[error("Failed to execute a dlc function")]
     DLCManagerError,
+    /// A error with WasmBindgen
+    #[error("Failed to execute a wasm_bindgen function")]
+    WasmBindgenError,
     /// Unknown error.
     #[error("Unknown Error")]
     UnknownError,
@@ -141,12 +144,6 @@ impl From<MutinyStorageError> for MutinyJsError {
     }
 }
 
-impl From<serde_wasm_bindgen::Error> for MutinyJsError {
-    fn from(_: serde_wasm_bindgen::Error) -> Self {
-        Self::JsonReadWriteError
-    }
-}
-
 impl From<bitcoin::util::address::Error> for MutinyJsError {
     fn from(_: bitcoin::util::address::Error) -> Self {
         Self::JsonReadWriteError
@@ -174,6 +171,12 @@ impl From<bitcoin::hashes::hex::Error> for MutinyJsError {
 impl From<bitcoin::secp256k1::Error> for MutinyJsError {
     fn from(_e: bitcoin::secp256k1::Error) -> Self {
         Self::PubkeyInvalid
+    }
+}
+
+impl From<serde_json::error::Error> for MutinyJsError {
+    fn from(_e: serde_json::error::Error) -> Self {
+        Self::WasmBindgenError
     }
 }
 

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -390,9 +390,9 @@ impl NodeManager {
 
 #[cfg(test)]
 mod tests {
-    use crate::NodeManager;
-
     use crate::utils::test::*;
+    use crate::NodeManager;
+    use mutiny_core::test_utils::*;
 
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -61,8 +61,8 @@ impl NodeManager {
     }
 
     #[wasm_bindgen]
-    pub fn has_node_manager() -> bool {
-        nodemanager::NodeManager::has_node_manager()
+    pub async fn has_node_manager() -> bool {
+        nodemanager::NodeManager::has_node_manager().await
     }
 
     #[wasm_bindgen]
@@ -402,7 +402,7 @@ mod tests {
     async fn create_node_manager() {
         log!("creating node manager!");
 
-        assert!(!NodeManager::has_node_manager());
+        assert!(!NodeManager::has_node_manager().await);
         NodeManager::new(
             "password".to_string(),
             None,
@@ -414,9 +414,9 @@ mod tests {
         )
         .await
         .expect("node manager should initialize");
-        assert!(NodeManager::has_node_manager());
+        assert!(NodeManager::has_node_manager().await);
 
-        cleanup_test();
+        cleanup_wallet_test().await;
     }
 
     #[test]
@@ -439,10 +439,10 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(NodeManager::has_node_manager());
+        assert!(NodeManager::has_node_manager().await);
         assert_eq!(seed.to_string(), nm.show_seed());
 
-        cleanup_test();
+        cleanup_wallet_test().await;
     }
 
     #[test]
@@ -474,6 +474,6 @@ mod tests {
         assert_ne!("", node_identity.uuid());
         assert_ne!("", node_identity.pubkey());
 
-        cleanup_test();
+        cleanup_wallet_test().await;
     }
 }

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -15,6 +15,7 @@ use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::sha256;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::{Address, Network, OutPoint, Transaction, Txid};
+use gloo_utils::format::JsValueSerdeExt;
 use lightning_invoice::Invoice;
 use lnurl::lnurl::LnUrl;
 use mutiny_core::nodemanager;
@@ -138,7 +139,7 @@ impl NodeManager {
         address: String,
     ) -> Result<JsValue /* Option<TransactionDetails> */, MutinyJsError> {
         let address = Address::from_str(&address)?;
-        Ok(serde_wasm_bindgen::to_value(
+        Ok(JsValue::from_serde(
             &self.inner.check_address(&address).await?,
         )?)
     }
@@ -147,9 +148,7 @@ impl NodeManager {
     pub async fn list_onchain(
         &self,
     ) -> Result<JsValue /* Vec<TransactionDetails> */, MutinyJsError> {
-        Ok(serde_wasm_bindgen::to_value(
-            &self.inner.list_onchain().await?,
-        )?)
+        Ok(JsValue::from_serde(&self.inner.list_onchain().await?)?)
     }
 
     #[wasm_bindgen]
@@ -158,7 +157,7 @@ impl NodeManager {
         txid: String,
     ) -> Result<JsValue /* Option<TransactionDetails> */, MutinyJsError> {
         let txid = Txid::from_str(&txid)?;
-        Ok(serde_wasm_bindgen::to_value(
+        Ok(JsValue::from_serde(
             &self.inner.get_transaction(&txid).await?,
         )?)
     }
@@ -170,9 +169,7 @@ impl NodeManager {
 
     #[wasm_bindgen]
     pub async fn list_utxos(&self) -> Result<JsValue, MutinyJsError> {
-        Ok(serde_wasm_bindgen::to_value(
-            &self.inner.list_utxos().await?,
-        )?)
+        Ok(JsValue::from_serde(&self.inner.list_utxos().await?)?)
     }
 
     #[wasm_bindgen]
@@ -197,9 +194,7 @@ impl NodeManager {
 
     #[wasm_bindgen]
     pub async fn list_nodes(&self) -> Result<JsValue /* Vec<String> */, MutinyJsError> {
-        Ok(serde_wasm_bindgen::to_value(
-            &self.inner.list_nodes().await?,
-        )?)
+        Ok(JsValue::from_serde(&self.inner.list_nodes().await?)?)
     }
 
     #[wasm_bindgen]
@@ -331,9 +326,7 @@ impl NodeManager {
 
     #[wasm_bindgen]
     pub async fn list_invoices(&self) -> Result<JsValue /* Vec<MutinyInvoice> */, MutinyJsError> {
-        Ok(serde_wasm_bindgen::to_value(
-            &self.inner.list_invoices().await?,
-        )?)
+        Ok(JsValue::from_serde(&self.inner.list_invoices().await?)?)
     }
 
     #[wasm_bindgen]
@@ -360,16 +353,12 @@ impl NodeManager {
 
     #[wasm_bindgen]
     pub async fn list_channels(&self) -> Result<JsValue /* Vec<MutinyChannel> */, MutinyJsError> {
-        Ok(serde_wasm_bindgen::to_value(
-            &self.inner.list_channels().await?,
-        )?)
+        Ok(JsValue::from_serde(&self.inner.list_channels().await?)?)
     }
 
     #[wasm_bindgen]
     pub async fn list_peers(&self) -> Result<JsValue /* Vec<MutinyPeer> */, MutinyJsError> {
-        Ok(serde_wasm_bindgen::to_value(
-            &self.inner.list_peers().await?,
-        )?)
+        Ok(JsValue::from_serde(&self.inner.list_peers().await?)?)
     }
 
     #[wasm_bindgen]

--- a/mutiny-wasm/src/utils.rs
+++ b/mutiny-wasm/src/utils.rs
@@ -21,22 +21,10 @@ pub async fn main_js() -> Result<(), JsValue> {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use gloo_storage::{LocalStorage, Storage};
-    use rexie::Rexie;
-
     macro_rules! log {
         ( $( $t:tt )* ) => {
             web_sys::console::log_1(&format!( $( $t )* ).into());
         }
     }
     pub(crate) use log;
-
-    pub(crate) fn cleanup_test() {
-        LocalStorage::clear();
-    }
-
-    pub(crate) async fn cleanup_wallet_test() {
-        cleanup_test();
-        Rexie::delete("wallet").await.unwrap();
-    }
 }

--- a/mutiny-wasm/src/utils.rs
+++ b/mutiny-wasm/src/utils.rs
@@ -22,6 +22,7 @@ pub async fn main_js() -> Result<(), JsValue> {
 #[cfg(test)]
 pub(crate) mod test {
     use gloo_storage::{LocalStorage, Storage};
+    use rexie::Rexie;
 
     macro_rules! log {
         ( $( $t:tt )* ) => {
@@ -32,5 +33,10 @@ pub(crate) mod test {
 
     pub(crate) fn cleanup_test() {
         LocalStorage::clear();
+    }
+
+    pub(crate) async fn cleanup_wallet_test() {
+        cleanup_test();
+        Rexie::delete("wallet").await.unwrap();
     }
 }


### PR DESCRIPTION
This does the in memory HashMap of our data, and writes async to indexed db. I needed to put it in an `Arc<RwLock>`, otherwise we needed LDK to make everything mut. Not too sure on the safety implications of this and still need to do some testing.

Will try bdk in a follow up, but would rather wait until bdk core.

Also moved our test utils to a separate module that we can export. Eventually these current ones will probably be in mutiny-wasm but makes it so we don't have to reimplement the same thing on both ends for now

Part of #236