### PR TITLE
A ton of API cleanups

### DIFF
--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -204,7 +204,7 @@ impl EventHandler {
                 };
                 match self
                     .persister
-                    .read_payment_info(payment_hash, true, self.logger.clone())
+                    .read_payment_info(&payment_hash, true, self.logger.clone())
                 {
                     Some(mut saved_payment_info) => {
                         let payment_preimage = payment_preimage.map(|p| p.0);
@@ -215,8 +215,8 @@ impl EventHandler {
                         saved_payment_info.amt_msat = MillisatAmount(Some(amount_msat));
                         saved_payment_info.last_update = crate::utils::now().as_secs();
                         match self.persister.persist_payment_info(
-                            payment_hash,
-                            saved_payment_info,
+                            &payment_hash,
+                            &saved_payment_info,
                             true,
                         ) {
                             Ok(_) => (),
@@ -246,10 +246,11 @@ impl EventHandler {
                             bolt11: None,
                             last_update,
                         };
-                        match self
-                            .persister
-                            .persist_payment_info(payment_hash, payment_info, true)
-                        {
+                        match self.persister.persist_payment_info(
+                            &payment_hash,
+                            &payment_info,
+                            true,
+                        ) {
                             Ok(_) => (),
                             Err(e) => {
                                 self.logger.log(&Record::new(
@@ -280,7 +281,7 @@ impl EventHandler {
 
                 match self
                     .persister
-                    .read_payment_info(payment_hash, false, self.logger.clone())
+                    .read_payment_info(&payment_hash, false, self.logger.clone())
                 {
                     Some(mut saved_payment_info) => {
                         saved_payment_info.status = HTLCStatus::Succeeded;
@@ -288,8 +289,8 @@ impl EventHandler {
                         saved_payment_info.fee_paid_msat = fee_paid_msat;
                         saved_payment_info.last_update = crate::utils::now().as_secs();
                         match self.persister.persist_payment_info(
-                            payment_hash,
-                            saved_payment_info,
+                            &payment_hash,
+                            &saved_payment_info,
                             false,
                         ) {
                             Ok(_) => (),
@@ -429,14 +430,14 @@ impl EventHandler {
 
                 match self
                     .persister
-                    .read_payment_info(payment_hash, false, self.logger.clone())
+                    .read_payment_info(&payment_hash, false, self.logger.clone())
                 {
                     Some(mut saved_payment_info) => {
                         saved_payment_info.status = HTLCStatus::Failed;
                         saved_payment_info.last_update = crate::utils::now().as_secs();
                         match self.persister.persist_payment_info(
-                            payment_hash,
-                            saved_payment_info,
+                            &payment_hash,
+                            &saved_payment_info,
                             false,
                         ) {
                             Ok(_) => (),

--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -31,7 +31,7 @@ fn generate_12_word_seed() -> Result<Mnemonic, MutinyError> {
 // A node private key will be derived from `m/0'/X'`, where its node pubkey will
 // be derived from the LDK default being `m/0'/X'/0'`. The PhantomKeysManager shared
 // key secret will be derived from `m/0'`.
-pub(crate) fn create_keys_manager(mnemonic: Mnemonic, child_index: u32) -> PhantomKeysManager {
+pub(crate) fn create_keys_manager(mnemonic: &Mnemonic, child_index: u32) -> PhantomKeysManager {
     let shared_key = XPrv::new(mnemonic.to_seed(""))
         .unwrap()
         .derive_child(bip32::ChildNumber::new(0, true).unwrap())
@@ -78,21 +78,21 @@ mod tests {
 
         let mnemonic = Mnemonic::from_str("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about").expect("could not generate");
 
-        let km = create_keys_manager(mnemonic.clone(), 1);
+        let km = create_keys_manager(&mnemonic, 1);
         let pubkey = pubkey_from_keys_manager(&km);
         assert_eq!(
             "02cae09cf2c8842ace44068a5bf3117a494ebbf69a99e79712483c36f97cdb7b54",
             pubkey.to_string()
         );
 
-        let km = create_keys_manager(mnemonic.clone(), 2);
+        let km = create_keys_manager(&mnemonic, 2);
         let second_pubkey = pubkey_from_keys_manager(&km);
         assert_eq!(
             "03fcc9eaaf0b84946ea7935e3bc4f2b498893c2f53e5d2994d6877d149601ce553",
             second_pubkey.to_string()
         );
 
-        let km = create_keys_manager(mnemonic, 2);
+        let km = create_keys_manager(&mnemonic, 2);
         let second_pubkey_again = pubkey_from_keys_manager(&km);
 
         assert_eq!(second_pubkey, second_pubkey_again);

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -202,8 +202,8 @@ impl MutinyNodePersister {
 
     pub(crate) fn persist_payment_info(
         &self,
-        payment_hash: PaymentHash,
-        payment_info: PaymentInfo,
+        payment_hash: &PaymentHash,
+        payment_info: &PaymentInfo,
         inbound: bool,
     ) -> io::Result<()> {
         let key = self.get_key(payment_key(inbound, payment_hash).as_str());
@@ -214,7 +214,7 @@ impl MutinyNodePersister {
 
     pub(crate) fn read_payment_info(
         &self,
-        payment_hash: PaymentHash,
+        payment_hash: &PaymentHash,
         inbound: bool,
         logger: Arc<MutinyLogger>,
     ) -> Option<PaymentInfo> {
@@ -252,7 +252,7 @@ impl MutinyNodePersister {
     }
 }
 
-fn payment_key(inbound: bool, payment_hash: PaymentHash) -> String {
+fn payment_key(inbound: bool, payment_hash: &PaymentHash) -> String {
     if inbound {
         format!(
             "{}{}",
@@ -341,8 +341,7 @@ impl<ChannelSigner: WriteableEcdsaChannelSigner> Persist<ChannelSigner> for Muti
 #[cfg(test)]
 mod test {
     use crate::event::{HTLCStatus, MillisatAmount};
-    use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
-    use lightning::ln::PaymentPreimage;
+    use bitcoin::secp256k1::PublicKey;
     use std::str::FromStr;
     use uuid::Uuid;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
@@ -378,11 +377,11 @@ mod test {
             secret: None,
             last_update: utils::now().as_secs(),
         };
-        let result = persister.persist_payment_info(payment_hash, payment_info, true);
+        let result = persister.persist_payment_info(&payment_hash, &payment_info, true);
         assert!(result.is_ok());
 
         let result =
-            persister.read_payment_info(payment_hash, true, Arc::new(MutinyLogger::default()));
+            persister.read_payment_info(&payment_hash, true, Arc::new(MutinyLogger::default()));
 
         assert!(result.is_some());
         assert_eq!(result.clone().unwrap().preimage, Some(preimage));

--- a/mutiny-core/src/wallet.rs
+++ b/mutiny-core/src/wallet.rs
@@ -26,7 +26,7 @@ pub struct MutinyWallet {
 
 impl MutinyWallet {
     pub fn new(
-        mnemonic: Mnemonic,
+        mnemonic: &Mnemonic,
         database: MutinyBrowserStorage,
         network: Network,
         esplora: Arc<EsploraBlockchain>,

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -139,7 +139,7 @@ impl NodeManager {
     ) -> Result<JsValue /* Option<TransactionDetails> */, MutinyJsError> {
         let address = Address::from_str(&address)?;
         Ok(serde_wasm_bindgen::to_value(
-            &self.inner.check_address(address).await?,
+            &self.inner.check_address(&address).await?,
         )?)
     }
 
@@ -212,7 +212,7 @@ impl NodeManager {
         let self_node_pubkey = PublicKey::from_str(&self_node_pubkey)?;
         Ok(self
             .inner
-            .connect_to_peer(self_node_pubkey, connection_string, label)
+            .connect_to_peer(&self_node_pubkey, &connection_string, label)
             .await?)
     }
 
@@ -224,7 +224,7 @@ impl NodeManager {
     ) -> Result<(), MutinyJsError> {
         let self_node_pubkey = PublicKey::from_str(&self_node_pubkey)?;
         let peer = PublicKey::from_str(&peer)?;
-        Ok(self.inner.disconnect_peer(self_node_pubkey, peer).await?)
+        Ok(self.inner.disconnect_peer(&self_node_pubkey, peer).await?)
     }
 
     #[wasm_bindgen]
@@ -235,7 +235,7 @@ impl NodeManager {
     ) -> Result<(), MutinyJsError> {
         let self_node_pubkey = PublicKey::from_str(&self_node_pubkey)?;
         let peer = PublicKey::from_str(&peer)?;
-        Ok(self.inner.delete_peer(self_node_pubkey, peer).await?)
+        Ok(self.inner.delete_peer(&self_node_pubkey, peer).await?)
     }
 
     #[wasm_bindgen]
@@ -258,7 +258,7 @@ impl NodeManager {
         let invoice = Invoice::from_str(&invoice_str)?;
         Ok(self
             .inner
-            .pay_invoice(from_node, invoice, amt_sats)
+            .pay_invoice(&from_node, &invoice, amt_sats)
             .await?
             .into())
     }
@@ -274,7 +274,7 @@ impl NodeManager {
         let to_node = PublicKey::from_str(&to_node)?;
         Ok(self
             .inner
-            .keysend(from_node, to_node, amt_sats)
+            .keysend(&from_node, to_node, amt_sats)
             .await?
             .into())
     }
@@ -302,7 +302,7 @@ impl NodeManager {
         let lnurl = LnUrl::from_str(&lnurl)?;
         Ok(self
             .inner
-            .lnurl_pay(from_node, lnurl, amount_sats)
+            .lnurl_pay(&from_node, &lnurl, amount_sats)
             .await?
             .into())
     }
@@ -314,19 +314,19 @@ impl NodeManager {
         amount_sats: u64,
     ) -> Result<bool, MutinyJsError> {
         let lnurl = LnUrl::from_str(&lnurl)?;
-        Ok(self.inner.lnurl_withdraw(lnurl, amount_sats).await?)
+        Ok(self.inner.lnurl_withdraw(&lnurl, amount_sats).await?)
     }
 
     #[wasm_bindgen]
     pub async fn get_invoice(&self, invoice: String) -> Result<MutinyInvoice, MutinyJsError> {
         let invoice = Invoice::from_str(&invoice)?;
-        Ok(self.inner.get_invoice(invoice).await?.into())
+        Ok(self.inner.get_invoice(&invoice).await?.into())
     }
 
     #[wasm_bindgen]
     pub async fn get_invoice_by_hash(&self, hash: String) -> Result<MutinyInvoice, MutinyJsError> {
         let hash: sha256::Hash = sha256::Hash::from_str(&hash)?;
-        Ok(self.inner.get_invoice_by_hash(hash).await?.into())
+        Ok(self.inner.get_invoice_by_hash(&hash).await?.into())
     }
 
     #[wasm_bindgen]
@@ -347,7 +347,7 @@ impl NodeManager {
         let to_pubkey = PublicKey::from_str(&to_pubkey)?;
         Ok(self
             .inner
-            .open_channel(from_node, to_pubkey, amount)
+            .open_channel(&from_node, to_pubkey, amount)
             .await?
             .into())
     }
@@ -355,7 +355,7 @@ impl NodeManager {
     #[wasm_bindgen]
     pub async fn close_channel(&self, outpoint: String) -> Result<(), MutinyJsError> {
         let outpoint: OutPoint = OutPoint::from_str(outpoint.as_str()).expect("invalid outpoint");
-        Ok(self.inner.close_channel(outpoint).await?)
+        Ok(self.inner.close_channel(&outpoint).await?)
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION
When we started this we were pretty new to rust and just used clone() everywhere. I went through and found everywhere we should be able to references and fixed that. Should make us slightly more efficient and make the APIs a little cleaner to user (less having to clone()).

Sorry for the mondo PR