### PR TITLE
Clippy fixes

### DIFF
--- a/mutiny-core/src/background.rs
+++ b/mutiny-core/src/background.rs
@@ -9,6 +9,7 @@
 #![deny(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(dead_code)]
+#![allow(clippy::all)]
 
 #[cfg(any(test, feature = "std"))]
 extern crate core;

--- a/mutiny-core/src/esplora.rs
+++ b/mutiny-core/src/esplora.rs
@@ -1,5 +1,7 @@
 // --- lightning_transaction_sync::common
 
+#![allow(clippy::all)]
+
 use bitcoin::{BlockHeader, OutPoint, Transaction};
 
 use std::collections::HashMap;

--- a/mutiny-core/src/gossip.rs
+++ b/mutiny-core/src/gossip.rs
@@ -329,9 +329,9 @@ async fn fetch_updated_gossip(
     // save the network graph if has been updated
     if new_last_sync_timestamp_result != last_sync_timestamp {
         write_gossip_data(
-            &rexie,
+            rexie,
             new_last_sync_timestamp_result,
-            &gossip_sync.network_graph(),
+            gossip_sync.network_graph(),
         )
         .await?;
     }
@@ -465,8 +465,7 @@ pub(crate) async fn get_all_peers() -> Result<HashMap<NodeId, LnPeerMetadata>, M
     let mut peers = HashMap::new();
 
     let all_json = store.get_all(None, None, None, None).await?;
-    let mut iter = all_json.into_iter();
-    while let Some((key, value)) = iter.next() {
+    for (key, value) in all_json {
         let pub_key = PublicKey::from_str(&key.as_string().unwrap()).unwrap();
         let node_id = NodeId::from_pubkey(&pub_key);
         let data: Option<LnPeerMetadata> = serde_wasm_bindgen::from_value(value)?;

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(io_error_other)]
 #![feature(async_fn_in_trait)]
 // background file is mostly an LDK copy paste
-#![allow(clippy::all)]
 mod background;
 
 mod bdkstorage;

--- a/mutiny-core/src/lspclient.rs
+++ b/mutiny-core/src/lspclient.rs
@@ -28,12 +28,12 @@ pub(crate) struct GetInfoAddress {
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum GetInfoAddressType {
-    DNS,
+    Dns,
     IPV4,
     IPV6,
     TORV2,
     TORV3,
-    WEBSOCKET,
+    Websocket,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -262,7 +262,7 @@ impl Node {
             wallet.clone(),
             keys_manager.clone(),
             persister.clone(),
-            lsp_client_pubkey.clone(),
+            lsp_client_pubkey,
             logger.clone(),
         );
         let peer_man = Arc::new(create_peer_manager(
@@ -754,7 +754,7 @@ impl Node {
                 return Err(MutinyError::InvoiceInvalid);
             }
             (
-                pay_invoice(&invoice, Retry::Attempts(5), self.channel_manager.as_ref()),
+                pay_invoice(invoice, Retry::Attempts(5), self.channel_manager.as_ref()),
                 invoice.amount_milli_satoshis().unwrap(),
             )
         };

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -332,7 +332,7 @@ impl NodeManager {
         let node_storage = match MutinyBrowserStorage::get_nodes() {
             Ok(node_storage) => node_storage,
             Err(e) => {
-                return Err(MutinyError::ReadError { source: e }.into());
+                return Err(MutinyError::ReadError { source: e });
             }
         };
 
@@ -441,16 +441,16 @@ impl NodeManager {
         description: Option<String>,
     ) -> Result<MutinyBip21RawMaterials, MutinyError> {
         let Ok(address) = self.get_new_address().await else {
-            return Err(MutinyError::WalletOperationFailed.into());
+            return Err(MutinyError::WalletOperationFailed);
         };
 
         // TODO if there's no description should be something random I guess
         let Ok(invoice) = self.create_invoice(amount, description.clone().unwrap_or_else(|| "".into())).await else {
-            return Err(MutinyError::WalletOperationFailed.into());
+            return Err(MutinyError::WalletOperationFailed);
         };
 
         let Some(bolt11) = invoice.bolt11 else {
-            return Err(MutinyError::WalletOperationFailed.into());
+            return Err(MutinyError::WalletOperationFailed);
         };
 
         Ok(MutinyBip21RawMaterials {
@@ -534,7 +534,7 @@ impl NodeManager {
         &self,
         txid: &Txid,
     ) -> Result<Option<TransactionDetails>, MutinyError> {
-        Ok(self.wallet.get_transaction(txid, false).await?)
+        self.wallet.get_transaction(txid, false).await
     }
 
     pub async fn get_balance(&self) -> Result<MutinyBalance, MutinyError> {
@@ -558,7 +558,7 @@ impl NodeManager {
     }
 
     pub async fn list_utxos(&self) -> Result<Vec<LocalUtxo>, MutinyError> {
-        Ok(self.wallet.list_utxos().await?)
+        self.wallet.list_utxos().await
     }
 
     async fn sync_ldk(&self) -> Result<(), MutinyError> {
@@ -592,7 +592,7 @@ impl NodeManager {
         // sync bdk wallet
         match self.wallet.sync().await {
             Ok(()) => Ok(info!("We are synced!")),
-            Err(e) => Err(e.into()),
+            Err(e) => Err(e),
         }
     }
 
@@ -607,10 +607,7 @@ impl NodeManager {
     }
 
     pub async fn new_node(&self) -> Result<NodeIdentity, MutinyError> {
-        match create_new_node_from_node_manager(self).await {
-            Ok(node_identity) => Ok(node_identity),
-            Err(e) => Err(e.into()),
-        }
+        create_new_node_from_node_manager(self).await
     }
 
     pub async fn list_nodes(&self) -> Result<Vec<PublicKey>, MutinyError> {
@@ -636,13 +633,13 @@ impl NodeManager {
                 }
                 Err(e) => {
                     error!("could not connect to peer: {connection_string} - {e}");
-                    return Err(e.into());
+                    return Err(e);
                 }
             };
         }
 
         error!("could not find internal node {self_node_pubkey}");
-        Err(MutinyError::WalletOperationFailed.into())
+        Err(MutinyError::WalletOperationFailed)
     }
 
     pub async fn disconnect_peer(
@@ -655,7 +652,7 @@ impl NodeManager {
             Ok(())
         } else {
             error!("could not find internal node {self_node_pubkey}");
-            Err(MutinyError::WalletOperationFailed.into())
+            Err(MutinyError::WalletOperationFailed)
         }
     }
 
@@ -671,7 +668,7 @@ impl NodeManager {
             Ok(())
         } else {
             error!("could not find internal node {self_node_pubkey}");
-            Err(MutinyError::WalletOperationFailed.into())
+            Err(MutinyError::WalletOperationFailed)
         }
     }
 

--- a/mutiny-core/src/utils.rs
+++ b/mutiny-core/src/utils.rs
@@ -95,7 +95,7 @@ impl<'a, T: 'a + Score> LockableScore<'a> for Mutex<T> {
     }
 }
 
-impl<'a, S: Writeable> Writeable for Mutex<S> {
+impl<S: Writeable> Writeable for Mutex<S> {
     fn write<W: Writer>(&self, writer: &mut W) -> Result<(), lightning::io::Error> {
         self.lock()
             .expect("Failed to lock mutex for write")
@@ -114,13 +114,13 @@ impl<'a, S: Writeable> Writeable for MutexGuard<'a, S> {
 /// We can't just compare the network directly because signet and testnet
 /// have conflicting address prefixes.
 pub(crate) fn is_valid_network(my_network: Network, dest_network: Network) -> bool {
-    match (my_network, dest_network) {
-        (Network::Bitcoin, Network::Bitcoin) => true,
-        (Network::Testnet, Network::Testnet) => true,
-        (Network::Signet, Network::Testnet) => true,
-        (Network::Testnet, Network::Signet) => true,
-        (Network::Signet, Network::Signet) => true,
-        (Network::Regtest, Network::Regtest) => true,
-        _ => false,
-    }
+    matches!(
+        (my_network, dest_network),
+        (Network::Bitcoin, Network::Bitcoin)
+            | (Network::Testnet, Network::Testnet)
+            | (Network::Signet, Network::Testnet)
+            | (Network::Testnet, Network::Signet)
+            | (Network::Signet, Network::Signet)
+            | (Network::Regtest, Network::Regtest)
+    )
 }


### PR DESCRIPTION
We were doing `#![allow(clippy::all)]` for the whole crate instead of individual files. I kept it for background.rs and esplora.rs since those are just copy pastes from ldk