### PR TITLE
Write to indexeddb first

### DIFF
--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -228,6 +228,12 @@ impl<G> From<std::sync::TryLockError<G>> for MutinyError {
     }
 }
 
+impl<G> From<std::sync::TryLockError<G>> for MutinyStorageError {
+    fn from(_e: std::sync::TryLockError<G>) -> Self {
+        MutinyStorageError::LockError
+    }
+}
+
 impl From<bitcoin::hashes::hex::Error> for MutinyError {
     fn from(_e: bitcoin::hashes::hex::Error) -> Self {
         MutinyError::ReadError {

--- a/mutiny-core/src/indexed_db.rs
+++ b/mutiny-core/src/indexed_db.rs
@@ -66,7 +66,7 @@ impl MutinyStorage {
 
         let mut map = self
             .memory
-            .write()
+            .try_write()
             .map_err(|e| MutinyError::write_err(e.into()))?;
         map.insert(key, data);
 
@@ -110,7 +110,7 @@ impl MutinyStorage {
     {
         let map = self
             .memory
-            .read()
+            .try_read()
             .map_err(|e| MutinyError::read_err(e.into()))?;
         match map.get(key.as_ref()) {
             None => Ok(None),
@@ -131,7 +131,7 @@ impl MutinyStorage {
     {
         let map = self
             .memory
-            .read()
+            .try_read()
             .map_err(|e| MutinyError::read_err(e.into()))?;
 
         Ok(map
@@ -186,7 +186,7 @@ impl MutinyStorage {
         let map = Self::read_all(&self.indexed_db, &self.password).await?;
         let mut memory = self
             .memory
-            .write()
+            .try_write()
             .map_err(|e| MutinyError::write_err(e.into()))?;
         *memory = map;
         Ok(())


### PR DESCRIPTION
This is a safety check to make sure that we write to indexeddb first. This should be done so if writing to the in memory map fails or if the program stops in the middle, we make sure we right to indexeddb which is actually persistent. That way if writing to memory fails, then if the user just refreshes, the data is not lost.

Second commit changes it to use `try_read` and `try_write`, we need to use these because the others would block if waiting which could cause a panic for us. This instead will return an Error and can be handled correctly.