### PR TITLE
Fix bug with wallet keys, cleanup deps

### DIFF
--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -19,7 +19,6 @@ lnurl-rs = { version = "0.2", default-features = false, features = ["async", "as
 cfg-if = "1.0.0"
 wasm-bindgen = "0.2.84"
 bip39 = { version = "2.0.0" }
-bip32 = "0.4.0"
 bitcoin-bech32 = "0.12"
 js-sys = "0.3.60"
 bitcoin = { version = "0.29.2", default-features = false, features = ["serde", "secp-recovery"] }

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -170,7 +170,7 @@ impl Node {
             wallet.clone(),
             mnemonic,
             node_index.child_index,
-        ));
+        )?);
         let pubkey = pubkey_from_keys_manager(&keys_manager);
 
         // init the persister


### PR DESCRIPTION
Fixed the bug where we were generating incorrect keys the on-chain wallet.

Also cleaned up the code around keys:
- Remove bip32 crate and use rust-bitcoin's re-export of it
- Remove use of unwraps and handle errors
- Remove some unnecessary conversions