### PR TITLE
Better handle syncing transaction from check_address

### DIFF
--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -80,6 +80,9 @@ pub enum MutinyError {
     /// A chain access operation failed.
     #[error("Failed to conduct chain access operation.")]
     ChainAccessFailed,
+    /// A failure to sync the on-chain wallet
+    #[error("Failed to to sync on-chain wallet.")]
+    WalletSyncError,
     /// An error with rapid gossip sync
     #[error("Failed to execute a rapid gossip sync function")]
     RapidGossipSyncError,
@@ -280,7 +283,18 @@ impl From<esplora_client::Error> for MutinyError {
 
 impl<T> From<bdk::chain::chain_graph::UpdateError<T>> for MutinyError {
     fn from(_e: bdk::chain::chain_graph::UpdateError<T>) -> Self {
-        // This is a syncing error
-        Self::ChainAccessFailed
+        Self::WalletSyncError
+    }
+}
+
+impl<T> From<bdk::chain::chain_graph::InsertTxError<T>> for MutinyError {
+    fn from(_e: bdk::chain::chain_graph::InsertTxError<T>) -> Self {
+        Self::WalletSyncError
+    }
+}
+
+impl From<bdk::chain::chain_graph::InsertCheckpointError> for MutinyError {
+    fn from(_e: bdk::chain::chain_graph::InsertCheckpointError) -> Self {
+        Self::WalletSyncError
     }
 }

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -75,6 +75,9 @@ pub enum MutinyJsError {
     /// A chain access operation failed.
     #[error("Failed to conduct chain access operation.")]
     ChainAccessFailed,
+    /// A failure to sync the on-chain wallet
+    #[error("Failed to to sync on-chain wallet.")]
+    WalletSyncError,
     /// An error with rapid gossip sync
     #[error("Failed to execute a rapid gossip sync function")]
     RapidGossipSyncError,
@@ -127,6 +130,7 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::InvalidMnemonic => MutinyJsError::InvalidMnemonic,
             MutinyError::WalletSigningFailed => MutinyJsError::WalletSigningFailed,
             MutinyError::ChainAccessFailed => MutinyJsError::ChainAccessFailed,
+            MutinyError::WalletSyncError => MutinyJsError::WalletSyncError,
             MutinyError::RapidGossipSyncError => MutinyJsError::RapidGossipSyncError,
             MutinyError::DLCManagerError => MutinyJsError::DLCManagerError,
             MutinyError::PubkeyInvalid => MutinyJsError::PubkeyInvalid,


### PR DESCRIPTION
Closes #414

When we were try to insert the tx it could can fail if our chain tip isn't caught up, so confirmed txs would fail.

This fixes it so we do it in a spawn_local so it doesn't hold up the api call and will still return correctly even if the sync failed (because the sync is just a small optimization).

Also changed it so if the transaction is confirmed that we properly handle it by either giving bdk the block the tx was included in or if we don't have that, just doing a normal sync so we catch everything correctly.