### PR TITLE
Use mempool.space's fee rate api 

### DIFF
--- a/mutiny-core/src/fees.rs
+++ b/mutiny-core/src/fees.rs
@@ -56,3 +56,72 @@ fn fallback_fee_from_conf_target(confirmation_target: ConfirmationTarget) -> u32
         ConfirmationTarget::HighPriority => 5000,
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::indexed_db::MutinyStorage;
+    use crate::test_utils::*;
+    use std::collections::HashMap;
+
+    use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[test]
+    fn test_num_blocks_from_conf_target() {
+        assert_eq!(
+            num_blocks_from_conf_target(ConfirmationTarget::Background),
+            12
+        );
+        assert_eq!(num_blocks_from_conf_target(ConfirmationTarget::Normal), 6);
+        assert_eq!(
+            num_blocks_from_conf_target(ConfirmationTarget::HighPriority),
+            3
+        );
+    }
+
+    #[test]
+    fn test_fallback_fee_from_conf_target() {
+        assert_eq!(
+            fallback_fee_from_conf_target(ConfirmationTarget::Background),
+            253
+        );
+        assert_eq!(
+            fallback_fee_from_conf_target(ConfirmationTarget::Normal),
+            2000
+        );
+        assert_eq!(
+            fallback_fee_from_conf_target(ConfirmationTarget::HighPriority),
+            5000
+        );
+    }
+
+    #[test]
+    async fn test_get_est_sat_per_1000_weight() {
+        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let mut fee_estimates = HashMap::new();
+        fee_estimates.insert("6".to_string(), 10_f64);
+        storage.insert_fee_estimates(fee_estimates).unwrap();
+
+        let fee_estimator = MutinyFeeEstimator::new(storage);
+
+        // test that we get the fee rate from the cache
+        assert_eq!(
+            fee_estimator.get_est_sat_per_1000_weight(ConfirmationTarget::Normal),
+            2500
+        );
+
+        // test that we get the fallback fee rate
+        assert_eq!(
+            fee_estimator.get_est_sat_per_1000_weight(ConfirmationTarget::Background),
+            253
+        );
+        assert_eq!(
+            fee_estimator.get_est_sat_per_1000_weight(ConfirmationTarget::HighPriority),
+            5000
+        );
+
+        cleanup_wallet_test().await;
+    }
+}

--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -229,15 +229,16 @@ mod tests {
         log!("creating pubkeys from a child seed");
 
         let mnemonic = Mnemonic::from_str("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about").expect("could not generate");
-        let esplora = Builder::new("https://blockstream.info/testnet/api/")
-            .build_async()
-            .unwrap();
-        let db = MutinyStorage::new("".to_string()).await.unwrap();
-        let fees = Arc::new(MutinyFeeEstimator::new(db.clone()));
-
-        let wallet = Arc::new(
-            MutinyWallet::new(&mnemonic, db, Network::Testnet, Arc::new(esplora), fees).unwrap(),
+        let esplora = Arc::new(
+            Builder::new("https://blockstream.info/testnet/api/")
+                .build_async()
+                .unwrap(),
         );
+        let db = MutinyStorage::new("".to_string()).await.unwrap();
+        let fees = Arc::new(MutinyFeeEstimator::new(db.clone(), esplora.clone()));
+
+        let wallet =
+            Arc::new(MutinyWallet::new(&mnemonic, db, Network::Testnet, esplora, fees).unwrap());
 
         let km = create_keys_manager(wallet.clone(), &mnemonic, 1).unwrap();
         let pubkey = pubkey_from_keys_manager(&km);

--- a/mutiny-core/src/wallet.rs
+++ b/mutiny-core/src/wallet.rs
@@ -284,8 +284,8 @@ pub(crate) fn get_esplora_url(network: Network, user_provided_url: Option<String
         url
     } else {
         match network {
-            Network::Bitcoin => "https://blockstream.info/api",
-            Network::Testnet => "https://blockstream.info/testnet/api",
+            Network::Bitcoin => "https://mempool.space/api",
+            Network::Testnet => "https://mempool.space/testnet/api",
             Network::Signet => "https://mutinynet.com/api",
             Network::Regtest => "http://localhost:3003",
         }


### PR DESCRIPTION
Mempool.space's fee rate api should be smarter than the generic esplora one. Hopefully this will cause less issues.

Added some tests and cleaned up how we calculate them as well too

part of #423