### PR TITLE
Logging and error clarification on closing channel

### DIFF
--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -17,6 +17,9 @@ pub enum MutinyError {
     /// Returned when trying to stop Mutiny while it is not running.
     #[error("Mutiny is not running.")]
     NotRunning,
+    // Returned on any resource that is not found.
+    #[error("Resource Not found.")]
+    NotFound,
     /// The funding transaction could not be created.
     #[error("Funding transaction could not be created.")]
     FundingTxCreationFailed,

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -969,11 +969,24 @@ impl NodeManager {
             Some((node, channel)) => {
                 node.channel_manager
                     .close_channel(&channel.channel_id, &channel.counterparty.node_id)
-                    .map_err(|_| MutinyError::ChannelClosingFailed)?;
+                    .map_err(|e| {
+                        error!(
+                            "had an error closing channel {} with node {} : {e:?}",
+                            &channel.channel_id.to_hex(),
+                            &channel.counterparty.node_id.to_hex()
+                        );
+                        MutinyError::ChannelClosingFailed
+                    })?;
 
                 Ok(())
             }
-            None => Err(MutinyError::ChannelClosingFailed),
+            None => {
+                error!(
+                    "Channel not found with this transaction: {}",
+                    outpoint.to_string()
+                );
+                Err(MutinyError::NotFound)
+            }
         }
     }
 

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -12,6 +12,9 @@ pub enum MutinyJsError {
     /// Returned when trying to stop Mutiny while it is not running.
     #[error("Mutiny is not running.")]
     NotRunning,
+    // Returned on any resource that is not found.
+    #[error("Resource Not found.")]
+    NotFound,
     /// The funding transaction could not be created.
     #[error("Funding transaction could not be created.")]
     FundingTxCreationFailed,
@@ -109,6 +112,7 @@ impl From<MutinyError> for MutinyJsError {
         match e {
             MutinyError::AlreadyRunning => MutinyJsError::AlreadyRunning,
             MutinyError::NotRunning => MutinyJsError::NotRunning,
+            MutinyError::NotFound => MutinyJsError::NotFound,
             MutinyError::FundingTxCreationFailed => MutinyJsError::FundingTxCreationFailed,
             MutinyError::ConnectionFailed => MutinyJsError::ConnectionFailed,
             MutinyError::IncorrectNetwork(net) => MutinyJsError::IncorrectNetwork(net),


### PR DESCRIPTION
This adds:
- logging when a channel is not found when you're trying to close it
- a new error type that we can use for anything that is related to `Not Found`

Fixes https://github.com/MutinyWallet/mutiny-node/issues/382