### PR TITLE
Add ability to sweep to a new channel

### DIFF
--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -12,7 +12,7 @@ use lightning::chain::keysinterface::SpendableOutputDescriptor;
 use lightning::events::{Event, PaymentPurpose};
 use lightning::{
     chain::chaininterface::{ConfirmationTarget, FeeEstimator},
-    log_debug, log_error,
+    log_debug, log_error, log_info, log_warn,
     util::errors::APIError,
     util::logger::{Logger, Record},
 };
@@ -94,59 +94,65 @@ impl EventHandler {
                 counterparty_node_id,
                 channel_value_satoshis,
                 output_script,
-                ..
+                user_channel_id,
             } => {
-                self.logger.log(&Record::new(
-                    lightning::util::logger::Level::Debug,
-                    format_args!("EVENT: FundingGenerationReady processing"),
-                    "event",
-                    "",
-                    0,
-                ));
+                log_debug!(self.logger, "EVENT: FundingGenerationReady processing");
 
-                let psbt = match self.wallet.create_signed_psbt_to_spk(
-                    output_script,
-                    channel_value_satoshis,
-                    None,
-                ) {
-                    Ok(psbt) => psbt,
+                // Get the open parameters for this channel
+                let params_opt = match self.persister.get_channel_open_params(user_channel_id) {
+                    Ok(params) => params,
                     Err(e) => {
-                        self.logger.log(&Record::new(
-                                lightning::util::logger::Level::Error,
-                                format_args!("ERROR: Could not create a signed transaction to open channel with: {e}"),
-                                "node",
-                                "",
-                                0,
-                            ));
+                        log_error!(self.logger, "ERROR: Could not get channel open params: {e}");
                         return;
                     }
                 };
-                if self
-                    .channel_manager
-                    .funding_transaction_generated(
-                        &temporary_channel_id,
-                        &counterparty_node_id,
-                        psbt.extract_tx(),
-                    )
-                    .is_err()
-                {
-                    self.logger.log(&Record::new(
-                            lightning::util::logger::Level::Error,
-                            format_args!("ERROR: Channel went away before we could fund it. The peer disconnected or refused the channel."),
-                            "node",
-                            "",
-                            0,
-                        ));
+
+                let psbt_result = match params_opt {
+                    None => self.wallet.create_signed_psbt_to_spk(
+                        output_script,
+                        channel_value_satoshis,
+                        None,
+                    ),
+                    Some(params) => {
+                        let psbt = self.wallet.spend_utxos_to_output(
+                            &params.utxos,
+                            output_script,
+                            channel_value_satoshis,
+                        );
+
+                        // delete from storage, if it fails, it is fine, just log it.
+                        if let Err(e) = self.persister.delete_channel_open_params(user_channel_id) {
+                            log_warn!(
+                                self.logger,
+                                "ERROR: Could not delete channel open params, but continuing: {e}"
+                            );
+                        }
+
+                        psbt
+                    }
+                };
+
+                let psbt = match psbt_result {
+                    Ok(psbt) => psbt,
+                    Err(e) => {
+                        log_error!(self.logger, "ERROR: Could not create a signed transaction to open channel with: {e}");
+                        return;
+                    }
+                };
+
+                if let Err(e) = self.channel_manager.funding_transaction_generated(
+                    &temporary_channel_id,
+                    &counterparty_node_id,
+                    psbt.extract_tx(),
+                ) {
+                    log_error!(
+                        self.logger,
+                        "ERROR: Could not send funding transaction to channel manager: {e:?}"
+                    );
                     return;
                 }
 
-                self.logger.log(&Record::new(
-                    lightning::util::logger::Level::Info,
-                    format_args!("FundingGenerationReady success"),
-                    "event",
-                    "",
-                    0,
-                ));
+                log_info!(self.logger, "EVENT: FundingGenerationReady success");
             }
             Event::PaymentClaimable {
                 receiver_node_id,

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -32,6 +32,7 @@ use lightning::util::logger::Logger;
 use lightning::util::logger::Record;
 use lightning::util::persist::Persister;
 use lightning::util::ser::{Readable, ReadableArgs, Writeable};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
@@ -40,6 +41,7 @@ pub(crate) const CHANNEL_MANAGER_KEY: &str = "manager";
 const MONITORS_PREFIX_KEY: &str = "monitors/";
 const PAYMENT_INBOUND_PREFIX_KEY: &str = "payment_inbound/";
 const PAYMENT_OUTBOUND_PREFIX_KEY: &str = "payment_outbound/";
+const CHANNEL_OPENING_PARAMS_PREFIX: &str = "chan_open_params/";
 const FAILED_SPENDABLE_OUTPUT_DESCRIPTOR_KEY: &str = "failed_spendable_outputs";
 
 pub(crate) type PhantomChannelManager = LdkChannelManager<
@@ -56,7 +58,7 @@ pub(crate) type PhantomChannelManager = LdkChannelManager<
 #[derive(Clone)]
 pub struct MutinyNodePersister {
     node_id: String,
-    storage: MutinyStorage,
+    pub(crate) storage: MutinyStorage,
 }
 
 pub(crate) struct ReadChannelManager {
@@ -324,6 +326,38 @@ impl MutinyNodePersister {
 
         Ok(())
     }
+
+    pub(crate) fn persist_channel_open_params(
+        &self,
+        id: u128,
+        params: ChannelOpenParams,
+    ) -> Result<(), MutinyError> {
+        let key = self.get_key(&channel_open_params_key(id));
+        self.storage.set(key, params)
+    }
+
+    pub(crate) fn get_channel_open_params(
+        &self,
+        id: u128,
+    ) -> Result<Option<ChannelOpenParams>, MutinyError> {
+        let key = self.get_key(&channel_open_params_key(id));
+        self.storage.get(key)
+    }
+
+    pub(crate) fn delete_channel_open_params(&self, id: u128) -> Result<(), MutinyError> {
+        let key = self.get_key(&channel_open_params_key(id));
+        self.storage.delete(key)
+    }
+}
+
+fn channel_open_params_key(id: u128) -> String {
+    format!("{CHANNEL_OPENING_PARAMS_PREFIX}{id}")
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct ChannelOpenParams {
+    pub sats_per_kw: u32,
+    pub utxos: Vec<bitcoin::OutPoint>,
 }
 
 fn payment_key(inbound: bool, payment_hash: &PaymentHash) -> String {

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1,4 +1,5 @@
 use crate::keymanager::PhantomKeysManager;
+use crate::ldkstorage::ChannelOpenParams;
 use crate::{
     background::process_events_async,
     chain::MutinyChain,
@@ -22,11 +23,13 @@ use crate::{
 };
 use crate::{indexed_db::MutinyStorage, lspclient::FeeRequest};
 use anyhow::{anyhow, Context};
+use bdk::FeeRate;
 use bdk_esplora::esplora_client::AsyncClient;
 use bip39::Mnemonic;
 use bitcoin::hashes::{hex::ToHex, sha256::Hash as Sha256};
 use bitcoin::secp256k1::rand;
-use bitcoin::{hashes::Hash, secp256k1::PublicKey, Network};
+use bitcoin::{hashes::Hash, secp256k1::PublicKey, Network, OutPoint};
+use lightning::chain::chaininterface::{ConfirmationTarget, FeeEstimator};
 use lightning::ln::channelmanager::RecipientOnionFields;
 use lightning::{
     chain::{
@@ -43,7 +46,7 @@ use lightning::{
         },
         PaymentHash, PaymentPreimage,
     },
-    log_info, log_warn,
+    log_error, log_info, log_warn,
     routing::{
         gossip,
         gossip::NodeId,
@@ -105,6 +108,12 @@ pub(crate) struct PubkeyConnectionInfo {
     pub original_connection_string: String,
 }
 
+// Constants for overhead, input, and output sizes
+const TX_OVERHEAD: usize = 10;
+const TAPROOT_INPUT_NON_WITNESS_SIZE: usize = 41;
+const TAPROOT_INPUT_WITNESS_SIZE: usize = 67;
+const P2WSH_OUTPUT_SIZE: usize = 43;
+
 impl PubkeyConnectionInfo {
     pub fn new(connection: &str) -> Result<Self, MutinyError> {
         if connection.is_empty() {
@@ -141,6 +150,7 @@ pub(crate) struct Node {
     pub chain_monitor: Arc<ChainMonitor>,
     network: Network,
     pub persister: Arc<MutinyNodePersister>,
+    wallet: Arc<MutinyWallet>,
     logger: Arc<MutinyLogger>,
     websocket_proxy_addr: String,
     multi_socket: MultiWsSocketDescriptor,
@@ -500,6 +510,7 @@ impl Node {
             chain_monitor,
             network,
             persister,
+            wallet,
             logger,
             websocket_proxy_addr,
             multi_socket,
@@ -1023,6 +1034,96 @@ impl Node {
                     "",
                     0,
                 ));
+                Err(MutinyError::ChannelCreationFailed)
+            }
+        }
+    }
+
+    pub async fn sweep_utxos_to_channel(
+        &self,
+        utxos: &[OutPoint],
+        pubkey: PublicKey,
+    ) -> Result<[u8; 32], MutinyError> {
+        // Calculate the total value of the selected utxos
+        let utxo_value: u64 = {
+            // find the wallet utxos
+            let wallet = self.wallet.wallet.try_read()?;
+            let all_utxos = wallet.list_unspent();
+
+            // calculate total value of utxos
+            let mut total = 0;
+            for utxo in all_utxos {
+                if utxos.contains(&utxo.outpoint) {
+                    total += utxo.txout.value;
+                }
+            }
+            total
+        };
+
+        // Calculate the expected transaction fee
+        let sats_per_kw = self
+            .wallet
+            .fees
+            .get_est_sat_per_1000_weight(ConfirmationTarget::Normal);
+        let expected_weight = {
+            let num_utxos = utxos.len();
+            // Calculate the non-witness and witness data sizes
+            let non_witness_size =
+                TX_OVERHEAD + (num_utxos * TAPROOT_INPUT_NON_WITNESS_SIZE) + P2WSH_OUTPUT_SIZE;
+            let witness_size = num_utxos * TAPROOT_INPUT_WITNESS_SIZE;
+
+            // Calculate the transaction weight
+            (non_witness_size * 4) + witness_size
+        };
+        let expected_fee = FeeRate::from_sat_per_kwu(sats_per_kw as f32).fee_wu(expected_weight);
+
+        // channel size is the total value of the utxos minus the fee
+        let channel_value_satoshis = utxo_value - expected_fee;
+
+        let mut config = default_user_config();
+        // if we are opening channel to LSP, turn off SCID alias until CLN is updated
+        // LSP protects all invoice information anyways, so no UTXO leakage
+        if let Some(lsp) = self.lsp_client.clone() {
+            if pubkey == lsp.pubkey {
+                config.channel_handshake_config.negotiate_scid_privacy = false;
+            }
+        }
+
+        // generate random user channel id
+        let mut user_channel_id_bytes = [0u8; 16];
+        getrandom::getrandom(&mut user_channel_id_bytes)
+            .map_err(|_| MutinyError::Other(anyhow!("Failed to generate user channel id")))?;
+        let user_channel_id = u128::from_be_bytes(user_channel_id_bytes);
+
+        // save params to db
+        let params = ChannelOpenParams {
+            sats_per_kw,
+            utxos: utxos.to_vec(),
+        };
+        self.persister
+            .persist_channel_open_params(user_channel_id, params)?;
+
+        match self.channel_manager.create_channel(
+            pubkey,
+            channel_value_satoshis,
+            0,
+            user_channel_id,
+            Some(config),
+        ) {
+            Ok(res) => {
+                log_info!(
+                    self.logger,
+                    "SUCCESS: channel initiated with peer: {pubkey:?}"
+                );
+                Ok(res)
+            }
+            Err(e) => {
+                log_error!(
+                    self.logger,
+                    "ERROR: failed to open channel to pubkey {pubkey:?}: {e:?}"
+                );
+                // delete params from db because channel failed
+                self.persister.delete_channel_open_params(user_channel_id)?;
                 Err(MutinyError::ChannelCreationFailed)
             }
         }


### PR DESCRIPTION
Needed for redshifts. We need the ability to sweep a utxo (or set of utxos) to a given channel. LDK makes this difficult where we need to calculate the channel size beforehand by calculating the fee and subtracting from the total value of the selected outputs, then we need to save it so the event manager can fetch it.