### PR TITLE
Fix key for channel monitors

### DIFF
--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -417,7 +417,7 @@ impl<ChannelSigner: WriteableEcdsaChannelSigner> Persist<ChannelSigner> for Muti
         _update_id: MonitorUpdateId,
     ) -> chain::ChannelMonitorUpdateStatus {
         let key = format!(
-            "{MONITORS_PREFIX_KEY}/{}_{}",
+            "{MONITORS_PREFIX_KEY}{}_{}",
             funding_txo.txid.to_hex(),
             funding_txo.index
         );
@@ -435,7 +435,7 @@ impl<ChannelSigner: WriteableEcdsaChannelSigner> Persist<ChannelSigner> for Muti
         _update_id: MonitorUpdateId,
     ) -> chain::ChannelMonitorUpdateStatus {
         let key = format!(
-            "{MONITORS_PREFIX_KEY}/{}_{}",
+            "{MONITORS_PREFIX_KEY}{}_{}",
             funding_txo.txid.to_hex(),
             funding_txo.index
         );


### PR DESCRIPTION
Was a bug where it was resulting in `monitors//<id>`