### PR TITLE
Fix invalid hash bug in list_payment_info

### DIFF
--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -253,15 +253,14 @@ impl MutinyNodePersister {
             true => PAYMENT_INBOUND_PREFIX_KEY,
             false => PAYMENT_OUTBOUND_PREFIX_KEY,
         };
-        let map: HashMap<String, PaymentInfo> = self.storage.scan(prefix, None)?;
+        let suffix = format!("_{}", self.node_id);
+        let map: HashMap<String, PaymentInfo> = self.storage.scan(prefix, Some(&suffix))?;
 
         // convert keys to PaymentHash
         Ok(map
             .into_iter()
             .map(|(key, value)| {
-                let payment_hash_str = key
-                    .trim_start_matches(prefix)
-                    .trim_end_matches(&format!("_{}", self.node_id));
+                let payment_hash_str = key.trim_start_matches(prefix).trim_end_matches(&suffix);
                 let hash: [u8; 32] =
                     FromHex::from_hex(payment_hash_str).expect("key should be a sha256 hash");
                 (PaymentHash(hash), value)


### PR DESCRIPTION
Before we weren't scanning with the suffix so we would try to read in the other node's payment infos but then not strip the nodeid off the back of it, resulting in us trying to read the `{hash}_{node_id}` string as a hash instead. 

This fixes by properly using the suffix when scanning.