### PR TITLE
Turn off upfront shutdown pubkey for channels

### DIFF
--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1291,6 +1291,7 @@ pub(crate) fn default_user_config() -> UserConfig {
             minimum_depth: 1,
             announced_channel: false,
             negotiate_scid_privacy: true,
+            commit_upfront_shutdown_pubkey: false,
             max_inbound_htlc_value_in_flight_percent_of_channel: 100,
             ..Default::default()
         },


### PR DESCRIPTION
When this setting is `true` it generates an address and assigns it to the channel when it is opened. This is not ideal for us when we will be wanting to do things like label every address and could have complications with redshifts.