### PR TITLE
Skip phantom invoices if LSP is involved

### DIFF
--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -791,7 +791,7 @@ impl NodeManager {
         description: Option<String>,
     ) -> Result<MutinyInvoice, MutinyError> {
         let nodes = self.nodes.lock().await;
-        let use_phantom = nodes.len() > 1;
+        let use_phantom = nodes.len() > 1 && self.lsp_clients.is_empty();
         if nodes.len() == 0 {
             return Err(MutinyError::InvoiceCreationFailed);
         }


### PR DESCRIPTION
LSP helps with privacy and will handle the direct JIT channel open so it's not really necessary and fixes the TODO we had in the redshift PR.