### PR TITLE
Broadcast tx over nostr

### DIFF
--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/mutinywallet/mutiny-node"
 [dependencies]
 ln-websocket-proxy = "0.3.0"
 lnurl-rs = { version = "0.2.2", default-features = false, features = ["async", "async-https"] }
-
+nostr-sdk = { version = "0.21.0", default-features = false }
 cfg-if = "1.0.0"
 wasm-bindgen = "0.2.84"
 bip39 = { version = "2.0.0" }

--- a/mutiny-core/src/chain.rs
+++ b/mutiny-core/src/chain.rs
@@ -49,7 +49,7 @@ impl MutinyChain {
         client.connect().await;
 
         let tag = Tag::Generic("magic".into(), vec![network_magic.to_hex()]);
-        let base64_tx = base64::encode(&tx.encode());
+        let base64_tx = base64::encode(tx.encode());
         let event = nostr_sdk::event::builder::EventBuilder::new(28333.into(), base64_tx, &[tag])
             .to_event(&ephemeral_key)?;
 
@@ -75,7 +75,7 @@ impl BroadcasterInterface for MutinyChain {
     fn broadcast_transaction(&self, tx: &Transaction) {
         let blockchain = self.tx_sync.clone();
         let tx_clone = tx.clone();
-        let magic = self.network_magic.clone();
+        let magic = self.network_magic;
         spawn_local(async move {
             // broadcast to esplora client
             maybe_await!(blockchain.client().broadcast(&tx_clone))

--- a/mutiny-core/src/chain.rs
+++ b/mutiny-core/src/chain.rs
@@ -2,21 +2,62 @@ use std::sync::Arc;
 
 use crate::esplora::EsploraSyncClient;
 use bdk_macros::maybe_await;
+use bitcoin::hashes::hex::ToHex;
 use bitcoin::{Script, Transaction, Txid};
 use lightning::chain::chaininterface::BroadcasterInterface;
 use lightning::chain::{Filter, WatchedOutput};
+use lightning::util::ser::Writeable;
 use log::error;
+use nostr_sdk::{Client, Keys, Tag};
 use wasm_bindgen_futures::spawn_local;
 
 use crate::logging::MutinyLogger;
 
 pub struct MutinyChain {
     pub tx_sync: Arc<EsploraSyncClient<Arc<MutinyLogger>>>,
+    network_magic: [u8; 4],
 }
 
 impl MutinyChain {
-    pub(crate) fn new(tx_sync: Arc<EsploraSyncClient<Arc<MutinyLogger>>>) -> Self {
-        Self { tx_sync }
+    pub(crate) fn new(
+        tx_sync: Arc<EsploraSyncClient<Arc<MutinyLogger>>>,
+        network_magic: [u8; 4],
+    ) -> Self {
+        Self {
+            tx_sync,
+            network_magic,
+        }
+    }
+
+    async fn broadcast_tx_over_nostr(
+        tx: &Transaction,
+        network_magic: [u8; 4],
+    ) -> anyhow::Result<()> {
+        // Generate new keys
+        let ephemeral_key: Keys = Keys::generate();
+
+        // Create new client
+        let client = Client::new(&ephemeral_key);
+
+        // TODO make relays configurable
+        // Add relays
+        client.add_relay("wss://relay.damus.io").await?;
+        client.add_relay("wss://nostr.mutinywallet.com").await?;
+        client.add_relay("wss://relay.nostr.info").await?;
+
+        // Connect to relays
+        client.connect().await;
+
+        let tag = Tag::Generic("magic".into(), vec![network_magic.to_hex()]);
+        let base64_tx = base64::encode(&tx.encode());
+        let event = nostr_sdk::event::builder::EventBuilder::new(28333.into(), base64_tx, &[tag])
+            .to_event(&ephemeral_key)?;
+
+        client.send_event(event).await?;
+
+        client.disconnect().await?;
+
+        Ok(())
     }
 }
 
@@ -34,9 +75,18 @@ impl BroadcasterInterface for MutinyChain {
     fn broadcast_transaction(&self, tx: &Transaction) {
         let blockchain = self.tx_sync.clone();
         let tx_clone = tx.clone();
+        let magic = self.network_magic.clone();
         spawn_local(async move {
+            // broadcast to esplora client
             maybe_await!(blockchain.client().broadcast(&tx_clone))
-                .unwrap_or_else(|_| error!("failed to broadcast tx! {}", tx_clone.txid()))
+                .unwrap_or_else(|_| error!("failed to broadcast tx! {}", tx_clone.txid()));
+
+            // broadcast to nostr
+            MutinyChain::broadcast_tx_over_nostr(&tx_clone, magic)
+                .await
+                .unwrap_or_else(|_| {
+                    error!("failed to broadcast tx over nostr! {}", tx_clone.txid())
+                });
         });
     }
 }

--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -8,6 +8,7 @@ use anyhow::anyhow;
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::secp256k1::Secp256k1;
+use lightning::chain::chaininterface::BroadcasterInterface;
 use lightning::chain::keysinterface::SpendableOutputDescriptor;
 use lightning::events::{Event, PaymentPurpose};
 use lightning::{
@@ -627,7 +628,7 @@ impl EventHandler {
             )
             .map_err(|_| anyhow!("Failed to spend spendable outputs"))?;
 
-        self.wallet.blockchain.broadcast(&spending_tx).await?;
+        self.wallet.chain.broadcast_transaction(&spending_tx);
 
         Ok(())
     }

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -315,7 +315,13 @@ impl NodeManager {
             fee_estimator.clone(),
         )?);
 
-        let chain = Arc::new(MutinyChain::new(tx_sync));
+        let network_magic = match network {
+            Network::Bitcoin => Network::Bitcoin.magic().to_le_bytes(),
+            Network::Testnet => Network::Testnet.magic().to_le_bytes(),
+            Network::Regtest => Network::Regtest.magic().to_le_bytes(),
+            Network::Signet => [0xA5, 0xDF, 0x2D, 0xCB], // mutinynet has different magic
+        };
+        let chain = Arc::new(MutinyChain::new(tx_sync, network_magic));
 
         // We don't need to actually sync gossip in tests unless we need to test gossip
         #[cfg(test)]

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -307,14 +307,6 @@ impl NodeManager {
         let esplora = Arc::new(tx_sync.client().clone());
         let fee_estimator = Arc::new(MutinyFeeEstimator::new(storage.clone(), esplora.clone()));
 
-        let wallet = Arc::new(MutinyWallet::new(
-            &mnemonic,
-            storage.clone(),
-            network,
-            esplora.clone(),
-            fee_estimator.clone(),
-        )?);
-
         let network_magic = match network {
             Network::Bitcoin => Network::Bitcoin.magic().to_le_bytes(),
             Network::Testnet => Network::Testnet.magic().to_le_bytes(),
@@ -322,6 +314,14 @@ impl NodeManager {
             Network::Signet => [0xA5, 0xDF, 0x2D, 0xCB], // mutinynet has different magic
         };
         let chain = Arc::new(MutinyChain::new(tx_sync, network_magic));
+
+        let wallet = Arc::new(MutinyWallet::new(
+            &mnemonic,
+            storage.clone(),
+            network,
+            chain.clone(),
+            fee_estimator.clone(),
+        )?);
 
         // We don't need to actually sync gossip in tests unless we need to test gossip
         #[cfg(test)]


### PR DESCRIPTION
Implements https://github.com/nostr-protocol/nips/pull/476

For now we still broadcast to esplora as well because I am pretty sure I am the only one running a server.

Need to make the nostr-sdk more wasm safe