### PR TITLE
Create MutinyManager that holds a node manager

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -30,4 +30,46 @@ pub mod test_utils;
 mod utils;
 mod wallet;
 
+use crate::error::MutinyError;
+use crate::nodemanager::NodeManager;
 pub use auth::AuthProfile;
+use bip39::Mnemonic;
+use bitcoin::Network;
+use std::sync::Arc;
+
+#[derive(Clone)]
+/// MutinyManager is the main entry point for the library.
+/// It contains the NodeManager, which is the main interface to manage the
+/// bitcoin and the lightning functionality.
+pub struct MutinyManager {
+    pub node_manager: Arc<NodeManager>,
+}
+
+impl MutinyManager {
+    pub async fn new(
+        password: String,
+        mnemonic: Option<Mnemonic>,
+        websocket_proxy_addr: Option<String>,
+        network: Option<Network>,
+        user_esplora_url: Option<String>,
+        user_rgs_url: Option<String>,
+        lsp_url: Option<String>,
+    ) -> Result<MutinyManager, MutinyError> {
+        let node_manager = Arc::new(
+            NodeManager::new(
+                password,
+                mnemonic,
+                websocket_proxy_addr,
+                network,
+                user_esplora_url,
+                user_rgs_url,
+                lsp_url,
+            )
+            .await?,
+        );
+
+        NodeManager::start_redshifts(node_manager.clone());
+
+        Ok(Self { node_manager })
+    }
+}

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -292,7 +292,7 @@ impl NodeManager {
         user_esplora_url: Option<String>,
         user_rgs_url: Option<String>,
         lsp_url: Option<String>,
-    ) -> Result<Arc<NodeManager>, MutinyError> {
+    ) -> Result<NodeManager, MutinyError> {
         let websocket_proxy_addr =
             websocket_proxy_addr.unwrap_or_else(|| String::from("wss://p.mutinywallet.com"));
 
@@ -433,7 +433,7 @@ impl NodeManager {
             .build_async()
             .expect("failed to make lnurl client");
 
-        let nm = Arc::new(NodeManager {
+        Ok(NodeManager {
             mnemonic,
             network,
             wallet,
@@ -450,15 +450,10 @@ impl NodeManager {
             lnurl_client,
             lsp_clients,
             logger,
-        });
-
-        // todo move to start function
-        NodeManager::start_redshifts(nm.clone());
-
-        Ok(nm)
+        })
     }
 
-    fn start_redshifts(nm: Arc<NodeManager>) {
+    pub(crate) fn start_redshifts(nm: Arc<NodeManager>) {
         let node_manager = nm.clone();
         spawn_local(async move {
             loop {

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -22,15 +22,14 @@ use lnurl::lnurl::LnUrl;
 use mutiny_core::redshift::RedshiftManager;
 use mutiny_core::{nodemanager, redshift::RedshiftRecipient};
 use std::str::FromStr;
-use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct NodeManager {
-    inner: Arc<nodemanager::NodeManager>,
+pub struct MutinyManager {
+    inner: mutiny_core::MutinyManager,
 }
 
-/// The [NodeManager] is the main entry point for interacting with the Mutiny Wallet.
+/// The [MutinyManager] is the main entry point for interacting with the Mutiny Wallet.
 /// It is responsible for managing the on-chain wallet and the lightning nodes.
 ///
 /// It can be used to create a new wallet, or to load an existing wallet.
@@ -38,8 +37,8 @@ pub struct NodeManager {
 /// It can be configured to use all different custom backend services, or to use the default
 /// services provided by Mutiny.
 #[wasm_bindgen]
-impl NodeManager {
-    /// Creates a new [NodeManager] with the given parameters.
+impl MutinyManager {
+    /// Creates a new [MutinyManager] with the given parameters.
     /// The mnemonic seed is read from storage, unless one is provided.
     /// If no mnemonic is provided, a new one is generated and stored.
     #[wasm_bindgen(constructor)]
@@ -51,7 +50,7 @@ impl NodeManager {
         user_esplora_url: Option<String>,
         user_rgs_url: Option<String>,
         lsp_url: Option<String>,
-    ) -> Result<NodeManager, MutinyJsError> {
+    ) -> Result<MutinyManager, MutinyJsError> {
         utils::set_panic_hook();
 
         let network: Option<Network> = network_str.map(|s| s.parse().expect("Invalid network"));
@@ -61,7 +60,7 @@ impl NodeManager {
             None => None,
         };
 
-        let inner = nodemanager::NodeManager::new(
+        let inner = mutiny_core::MutinyManager::new(
             password,
             mnemonic,
             websocket_proxy_addr,
@@ -71,7 +70,7 @@ impl NodeManager {
             lsp_url,
         )
         .await?;
-        Ok(NodeManager { inner })
+        Ok(MutinyManager { inner })
     }
 
     /// Returns if there is a saved wallet in storage.
@@ -89,19 +88,19 @@ impl NodeManager {
             Vec::from_hex(str.as_str()).map_err(|_| MutinyJsError::WalletOperationFailed)?;
         let tx: Transaction =
             deserialize(&tx_bytes).map_err(|_| MutinyJsError::WalletOperationFailed)?;
-        Ok(self.inner.broadcast_transaction(&tx)?)
+        Ok(self.inner.node_manager.broadcast_transaction(&tx)?)
     }
 
     /// Returns the mnemonic seed phrase for the wallet.
     #[wasm_bindgen]
     pub fn show_seed(&self) -> String {
-        self.inner.show_seed().to_string()
+        self.inner.node_manager.show_seed().to_string()
     }
 
     /// Returns the network of the wallet.
     #[wasm_bindgen]
     pub fn get_network(&self) -> String {
-        self.inner.get_network().to_string()
+        self.inner.node_manager.get_network().to_string()
     }
 
     /// Gets a new bitcoin address from the wallet.
@@ -110,13 +109,13 @@ impl NodeManager {
     /// It is recommended to create a new address for every transaction.
     #[wasm_bindgen]
     pub fn get_new_address(&self) -> Result<String, MutinyJsError> {
-        Ok(self.inner.get_new_address()?.to_string())
+        Ok(self.inner.node_manager.get_new_address()?.to_string())
     }
 
     /// Gets the current balance of the on-chain wallet.
     #[wasm_bindgen]
     pub fn get_wallet_balance(&self) -> Result<u64, MutinyJsError> {
-        Ok(self.inner.get_wallet_balance()?)
+        Ok(self.inner.node_manager.get_wallet_balance()?)
     }
 
     /// Creates a BIP 21 invoice. This creates a new address and a lightning invoice.
@@ -126,7 +125,12 @@ impl NodeManager {
         amount: Option<u64>,
         description: Option<String>,
     ) -> Result<MutinyBip21RawMaterials, MutinyJsError> {
-        Ok(self.inner.create_bip21(amount, description).await?.into())
+        Ok(self
+            .inner
+            .node_manager
+            .create_bip21(amount, description)
+            .await?
+            .into())
     }
 
     /// Sends an on-chain transaction to the given address.
@@ -143,6 +147,7 @@ impl NodeManager {
         let send_to = Address::from_str(&destination_address)?;
         Ok(self
             .inner
+            .node_manager
             .send_to_address(send_to, amount, fee_rate)
             .await?
             .to_string())
@@ -161,6 +166,7 @@ impl NodeManager {
         let send_to = Address::from_str(&destination_address)?;
         Ok(self
             .inner
+            .node_manager
             .sweep_wallet(send_to, fee_rate)
             .await?
             .to_string())
@@ -177,7 +183,7 @@ impl NodeManager {
     ) -> Result<JsValue /* Option<TransactionDetails> */, MutinyJsError> {
         let address = Address::from_str(&address)?;
         Ok(JsValue::from_serde(
-            &self.inner.check_address(&address).await?,
+            &self.inner.node_manager.check_address(&address).await?,
         )?)
     }
 
@@ -185,7 +191,9 @@ impl NodeManager {
     /// These are sorted by confirmation time.
     #[wasm_bindgen]
     pub fn list_onchain(&self) -> Result<JsValue /* Vec<TransactionDetails> */, MutinyJsError> {
-        Ok(JsValue::from_serde(&self.inner.list_onchain()?)?)
+        Ok(JsValue::from_serde(
+            &self.inner.node_manager.list_onchain()?,
+        )?)
     }
 
     /// Gets the details of a specific on-chain transaction.
@@ -195,7 +203,9 @@ impl NodeManager {
         txid: String,
     ) -> Result<JsValue /* Option<TransactionDetails> */, MutinyJsError> {
         let txid = Txid::from_str(&txid)?;
-        Ok(JsValue::from_serde(&self.inner.get_transaction(txid)?)?)
+        Ok(JsValue::from_serde(
+            &self.inner.node_manager.get_transaction(txid)?,
+        )?)
     }
 
     /// Gets the current balance of the wallet.
@@ -204,13 +214,13 @@ impl NodeManager {
     /// This will not include any funds in an unconfirmed lightning channel.
     #[wasm_bindgen]
     pub async fn get_balance(&self) -> Result<MutinyBalance, MutinyJsError> {
-        Ok(self.inner.get_balance().await?.into())
+        Ok(self.inner.node_manager.get_balance().await?.into())
     }
 
     /// Lists all the UTXOs in the wallet.
     #[wasm_bindgen]
     pub fn list_utxos(&self) -> Result<JsValue, MutinyJsError> {
-        Ok(JsValue::from_serde(&self.inner.list_utxos()?)?)
+        Ok(JsValue::from_serde(&self.inner.node_manager.list_utxos()?)?)
     }
 
     /// Syncs the on-chain wallet and lightning wallet.
@@ -221,33 +231,35 @@ impl NodeManager {
     /// This also updates the fee estimates.
     #[wasm_bindgen]
     pub async fn sync(&self) -> Result<(), MutinyJsError> {
-        Ok(self.inner.sync().await?)
+        Ok(self.inner.node_manager.sync().await?)
     }
 
     /// Gets a fee estimate for an average priority transaction.
     /// Value is in sat/vbyte.
     #[wasm_bindgen]
     pub fn estimate_fee_normal(&self) -> u32 {
-        self.inner.estimate_fee_normal()
+        self.inner.node_manager.estimate_fee_normal()
     }
 
     /// Gets a fee estimate for an high priority transaction.
     /// Value is in sat/vbyte.
     #[wasm_bindgen]
     pub fn estimate_fee_high(&self) -> u32 {
-        self.inner.estimate_fee_high()
+        self.inner.node_manager.estimate_fee_high()
     }
 
     /// Creates a new lightning node and adds it to the manager.
     #[wasm_bindgen]
     pub async fn new_node(&self) -> Result<NodeIdentity, MutinyJsError> {
-        Ok(self.inner.new_node().await?.into())
+        Ok(self.inner.node_manager.new_node().await?.into())
     }
 
     /// Lists the pubkeys of the lightning node in the manager.
     #[wasm_bindgen]
     pub async fn list_nodes(&self) -> Result<JsValue /* Vec<String> */, MutinyJsError> {
-        Ok(JsValue::from_serde(&self.inner.list_nodes().await?)?)
+        Ok(JsValue::from_serde(
+            &self.inner.node_manager.list_nodes().await?,
+        )?)
     }
 
     /// Attempts to connect to a peer from the selected node.
@@ -261,6 +273,7 @@ impl NodeManager {
         let self_node_pubkey = PublicKey::from_str(&self_node_pubkey)?;
         Ok(self
             .inner
+            .node_manager
             .connect_to_peer(&self_node_pubkey, &connection_string, label)
             .await?)
     }
@@ -274,7 +287,11 @@ impl NodeManager {
     ) -> Result<(), MutinyJsError> {
         let self_node_pubkey = PublicKey::from_str(&self_node_pubkey)?;
         let peer = PublicKey::from_str(&peer)?;
-        Ok(self.inner.disconnect_peer(&self_node_pubkey, peer).await?)
+        Ok(self
+            .inner
+            .node_manager
+            .disconnect_peer(&self_node_pubkey, peer)
+            .await?)
     }
 
     /// Deletes a peer from the selected node.
@@ -288,7 +305,11 @@ impl NodeManager {
     ) -> Result<(), MutinyJsError> {
         let self_node_pubkey = PublicKey::from_str(&self_node_pubkey)?;
         let peer = NodeId::from_str(&peer)?;
-        Ok(self.inner.delete_peer(&self_node_pubkey, &peer).await?)
+        Ok(self
+            .inner
+            .node_manager
+            .delete_peer(&self_node_pubkey, &peer)
+            .await?)
     }
 
     /// Sets the label of a peer from the selected node.
@@ -299,7 +320,7 @@ impl NodeManager {
         label: Option<String>,
     ) -> Result<(), MutinyJsError> {
         let node_id = NodeId::from_str(&node_id)?;
-        self.inner.label_peer(&node_id, label).await?;
+        self.inner.node_manager.label_peer(&node_id, label).await?;
         Ok(())
     }
 
@@ -315,7 +336,12 @@ impl NodeManager {
         amount: Option<u64>,
         description: Option<String>,
     ) -> Result<MutinyInvoice, MutinyJsError> {
-        Ok(self.inner.create_invoice(amount, description).await?.into())
+        Ok(self
+            .inner
+            .node_manager
+            .create_invoice(amount, description)
+            .await?
+            .into())
     }
 
     /// Pays a lightning invoice from the selected node.
@@ -332,6 +358,7 @@ impl NodeManager {
         let invoice = Invoice::from_str(&invoice_str)?;
         Ok(self
             .inner
+            .node_manager
             .pay_invoice(&from_node, &invoice, amt_sats)
             .await?
             .into())
@@ -350,6 +377,7 @@ impl NodeManager {
         let to_node = PublicKey::from_str(&to_node)?;
         Ok(self
             .inner
+            .node_manager
             .keysend(&from_node, to_node, amt_sats)
             .await?
             .into())
@@ -360,7 +388,12 @@ impl NodeManager {
     #[wasm_bindgen]
     pub async fn decode_invoice(&self, invoice: String) -> Result<MutinyInvoice, MutinyJsError> {
         let invoice = Invoice::from_str(&invoice)?;
-        Ok(self.inner.decode_invoice(invoice).await?.into())
+        Ok(self
+            .inner
+            .node_manager
+            .decode_invoice(invoice)
+            .await?
+            .into())
     }
 
     /// Calls upon a LNURL to get the parameters for it.
@@ -368,7 +401,7 @@ impl NodeManager {
     #[wasm_bindgen]
     pub async fn decode_lnurl(&self, lnurl: String) -> Result<LnUrlParams, MutinyJsError> {
         let lnurl = LnUrl::from_str(&lnurl)?;
-        Ok(self.inner.decode_lnurl(lnurl).await?.into())
+        Ok(self.inner.node_manager.decode_lnurl(lnurl).await?.into())
     }
 
     /// Calls upon a LNURL and pays it.
@@ -384,6 +417,7 @@ impl NodeManager {
         let lnurl = LnUrl::from_str(&lnurl)?;
         Ok(self
             .inner
+            .node_manager
             .lnurl_pay(&from_node, &lnurl, amount_sats)
             .await?
             .into())
@@ -398,19 +432,25 @@ impl NodeManager {
         amount_sats: u64,
     ) -> Result<bool, MutinyJsError> {
         let lnurl = LnUrl::from_str(&lnurl)?;
-        Ok(self.inner.lnurl_withdraw(&lnurl, amount_sats).await?)
+        Ok(self
+            .inner
+            .node_manager
+            .lnurl_withdraw(&lnurl, amount_sats)
+            .await?)
     }
 
     /// Creates a new LNURL-auth profile.
     #[wasm_bindgen]
     pub fn create_lnurl_auth_profile(&self, name: String) -> Result<u32, MutinyJsError> {
-        Ok(self.inner.create_lnurl_auth_profile(name)?)
+        Ok(self.inner.node_manager.create_lnurl_auth_profile(name)?)
     }
 
     /// Gets all the LNURL-auth profiles.
     #[wasm_bindgen]
     pub fn get_lnurl_auth_profiles(&self) -> Result<JsValue /*<Vec<AuthProfile> */, MutinyJsError> {
-        Ok(JsValue::from_serde(&self.inner.get_lnurl_auth_profiles()?)?)
+        Ok(JsValue::from_serde(
+            &self.inner.node_manager.get_lnurl_auth_profiles()?,
+        )?)
     }
 
     /// Authenticates with a LNURL-auth for the given profile.
@@ -421,7 +461,11 @@ impl NodeManager {
         lnurl: String,
     ) -> Result<(), MutinyJsError> {
         let lnurl = LnUrl::from_str(&lnurl)?;
-        Ok(self.inner.lnurl_auth(profile_index, lnurl).await?)
+        Ok(self
+            .inner
+            .node_manager
+            .lnurl_auth(profile_index, lnurl)
+            .await?)
     }
 
     /// Gets an invoice from the node manager.
@@ -429,7 +473,7 @@ impl NodeManager {
     #[wasm_bindgen]
     pub async fn get_invoice(&self, invoice: String) -> Result<MutinyInvoice, MutinyJsError> {
         let invoice = Invoice::from_str(&invoice)?;
-        Ok(self.inner.get_invoice(&invoice).await?.into())
+        Ok(self.inner.node_manager.get_invoice(&invoice).await?.into())
     }
 
     /// Gets an invoice from the node manager.
@@ -437,14 +481,21 @@ impl NodeManager {
     #[wasm_bindgen]
     pub async fn get_invoice_by_hash(&self, hash: String) -> Result<MutinyInvoice, MutinyJsError> {
         let hash: sha256::Hash = sha256::Hash::from_str(&hash)?;
-        Ok(self.inner.get_invoice_by_hash(&hash).await?.into())
+        Ok(self
+            .inner
+            .node_manager
+            .get_invoice_by_hash(&hash)
+            .await?
+            .into())
     }
 
     /// Gets an invoice from the node manager.
     /// This includes sent and received invoices.
     #[wasm_bindgen]
     pub async fn list_invoices(&self) -> Result<JsValue /* Vec<MutinyInvoice> */, MutinyJsError> {
-        Ok(JsValue::from_serde(&self.inner.list_invoices().await?)?)
+        Ok(JsValue::from_serde(
+            &self.inner.node_manager.list_invoices().await?,
+        )?)
     }
 
     /// Opens a channel from our selected node to the given pubkey.
@@ -463,6 +514,7 @@ impl NodeManager {
         let to_pubkey = PublicKey::from_str(&to_pubkey)?;
         Ok(self
             .inner
+            .node_manager
             .open_channel(&from_node, to_pubkey, amount)
             .await?
             .into())
@@ -473,19 +525,23 @@ impl NodeManager {
     pub async fn close_channel(&self, outpoint: String) -> Result<(), MutinyJsError> {
         let outpoint: OutPoint =
             OutPoint::from_str(&outpoint).map_err(|_| MutinyJsError::InvalidArgumentsError)?;
-        Ok(self.inner.close_channel(&outpoint).await?)
+        Ok(self.inner.node_manager.close_channel(&outpoint).await?)
     }
 
     /// Lists all the channels for all the nodes in the node manager.
     #[wasm_bindgen]
     pub async fn list_channels(&self) -> Result<JsValue /* Vec<MutinyChannel> */, MutinyJsError> {
-        Ok(JsValue::from_serde(&self.inner.list_channels().await?)?)
+        Ok(JsValue::from_serde(
+            &self.inner.node_manager.list_channels().await?,
+        )?)
     }
 
     /// Lists all the peers for all the nodes in the node manager.
     #[wasm_bindgen]
     pub async fn list_peers(&self) -> Result<JsValue /* Vec<MutinyPeer> */, MutinyJsError> {
-        Ok(JsValue::from_serde(&self.inner.list_peers().await?)?)
+        Ok(JsValue::from_serde(
+            &self.inner.node_manager.list_peers().await?,
+        )?)
     }
 
     /// Initiates a redshift
@@ -520,6 +576,7 @@ impl NodeManager {
         Ok(JsValue::from_serde(
             &self
                 .inner
+                .node_manager
                 .init_redshift(
                     outpoint,
                     redshift_recipient,
@@ -538,19 +595,21 @@ impl NodeManager {
     ) -> Result<JsValue /* Vec<Redshift> */, MutinyJsError> {
         let outpoint: OutPoint =
             OutPoint::from_str(&outpoint).map_err(|_| MutinyJsError::InvalidArgumentsError)?;
-        Ok(JsValue::from_serde(&self.inner.get_redshift(outpoint)?)?)
+        Ok(JsValue::from_serde(
+            &self.inner.node_manager.get_redshift(outpoint)?,
+        )?)
     }
 
     /// Gets the current bitcoin price in USD.
     #[wasm_bindgen]
     pub async fn get_bitcoin_price(&self) -> Result<f32, MutinyJsError> {
-        Ok(self.inner.get_bitcoin_price().await?)
+        Ok(self.inner.node_manager.get_bitcoin_price().await?)
     }
 
     /// Exports the current state of the node manager to a json object.
     #[wasm_bindgen]
     pub async fn export_json(&self) -> Result<String, MutinyJsError> {
-        let json = self.inner.export_json().await?;
+        let json = self.inner.node_manager.export_json().await?;
         Ok(serde_json::to_string(&json)?)
     }
 
@@ -578,7 +637,7 @@ impl NodeManager {
 #[cfg(test)]
 mod tests {
     use crate::utils::test::*;
-    use crate::NodeManager;
+    use crate::MutinyManager;
     use mutiny_core::test_utils::*;
 
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
@@ -586,11 +645,11 @@ mod tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[test]
-    async fn create_node_manager() {
-        log!("creating node manager!");
+    async fn create_mutiny_manager() {
+        log!("creating mutiny manager!");
 
-        assert!(!NodeManager::has_node_manager().await);
-        NodeManager::new(
+        assert!(!MutinyManager::has_node_manager().await);
+        MutinyManager::new(
             "password".to_string(),
             None,
             None,
@@ -600,8 +659,8 @@ mod tests {
             None,
         )
         .await
-        .expect("node manager should initialize");
-        assert!(NodeManager::has_node_manager().await);
+        .expect("mutiny manager should initialize");
+        assert!(MutinyManager::has_node_manager().await);
 
         cleanup_wallet_test().await;
     }
@@ -614,7 +673,7 @@ mod tests {
         getrandom::getrandom(&mut entropy).unwrap();
         let seed = bip39::Mnemonic::from_entropy(&entropy).unwrap();
 
-        let nm = NodeManager::new(
+        let nm = MutinyManager::new(
             "password".to_string(),
             Some(seed.to_string()),
             None,
@@ -626,7 +685,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(NodeManager::has_node_manager().await);
+        assert!(MutinyManager::has_node_manager().await);
         assert_eq!(seed.to_string(), nm.show_seed());
 
         cleanup_wallet_test().await;
@@ -640,7 +699,7 @@ mod tests {
         getrandom::getrandom(&mut entropy).unwrap();
         let seed = bip39::Mnemonic::from_entropy(&entropy).unwrap();
 
-        let nm = NodeManager::new(
+        let nm = MutinyManager::new(
             "password".to_string(),
             Some(seed.to_string()),
             None,
@@ -650,7 +709,7 @@ mod tests {
             None,
         )
         .await
-        .expect("node manager should initialize");
+        .expect("mutiny manager should initialize");
 
         let node_identity = nm.new_node().await.expect("should create new node");
         assert_ne!("", node_identity.uuid());


### PR DESCRIPTION
For the hackathon we were doing weird stuff having `NodeManager::new` return an `Arc` of itself so we can start the redshifts thread. This refactors so we have a `MutinyManager` that holds an `Arc<NodeManager>`, this gives us a little bit better of an abstraction so we can have `NodeManager` functions reference itself without having to do too many weird things.

I image we can one day eventually refactor so `MutinyManager` handles things like the mnemonic, lnurl auth, nostr, etc and keep the `NodeManager to purely just bitcoin and lightning.