### PR TITLE
List balance of all lightning channels

### DIFF
--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -631,7 +631,7 @@ impl NodeManager {
         let nodes = self.nodes.lock().await;
         let lightning_msats: u64 = nodes
             .iter()
-            .flat_map(|(_, n)| n.channel_manager.list_usable_channels())
+            .flat_map(|(_, n)| n.channel_manager.list_channels())
             .map(|c| c.outbound_capacity_msat)
             .sum();
 


### PR DESCRIPTION
This was kinda bad UX where we wouldn't show a channel as part of your balance until the channel was back online. This can make it so the first 5 seconds your money is gone. If we use list_channels it will show all of it, this should make the user feel safer. We can show the fine grained, online or not on an advanced screen.