### PR TITLE
Add more tests around fee estimation

### DIFF
--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -121,6 +121,7 @@ impl EventHandler {
                             &params.utxos,
                             output_script,
                             channel_value_satoshis,
+                            params.sats_per_kw,
                             params.labels.unwrap_or(vec![label]),
                         );
 

--- a/mutiny-core/src/fees.rs
+++ b/mutiny-core/src/fees.rs
@@ -1,6 +1,7 @@
 use crate::error::MutinyError;
 use crate::indexed_db::MutinyStorage;
 use crate::logging::MutinyLogger;
+use bdk::FeeRate;
 use esplora_client::AsyncClient;
 use lightning::chain::chaininterface::{
     ConfirmationTarget, FeeEstimator, FEERATE_FLOOR_SATS_PER_KW,
@@ -10,6 +11,14 @@ use lightning::util::logger::Logger;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Arc;
+
+// Constants for overhead, input, and output sizes
+pub(crate) const TX_OVERHEAD: usize = 10;
+pub(crate) const TAPROOT_INPUT_NON_WITNESS_SIZE: usize = 41;
+pub(crate) const TAPROOT_INPUT_WITNESS_SIZE: usize = 67;
+pub(crate) const P2WSH_OUTPUT_SIZE: usize = 43;
+#[allow(dead_code)]
+pub(crate) const TAPROOT_OUTPUT_SIZE: usize = 43;
 
 #[derive(Clone)]
 pub struct MutinyFeeEstimator {
@@ -29,6 +38,32 @@ impl MutinyFeeEstimator {
             esplora,
             logger,
         }
+    }
+
+    /// Calculate the estimated fee in satoshis for a transaction.
+    /// It is assumed that the inputs will be Taproot key spends.
+    pub fn calculate_expected_fee(
+        &self,
+        num_utxos: usize,
+        output_size: usize,
+        change_size: Option<usize>,
+        sats_per_kw: Option<u32>,
+    ) -> u64 {
+        // if no fee rate is provided, use the normal confirmation target
+        let sats_per_kw = sats_per_kw
+            .unwrap_or_else(|| self.get_est_sat_per_1000_weight(ConfirmationTarget::Normal));
+        let expected_weight = {
+            // Calculate the non-witness and witness data sizes
+            let non_witness_size = TX_OVERHEAD
+                + (num_utxos * TAPROOT_INPUT_NON_WITNESS_SIZE)
+                + output_size
+                + change_size.unwrap_or(0);
+            let witness_size = num_utxos * TAPROOT_INPUT_WITNESS_SIZE;
+
+            // Calculate the transaction weight
+            (non_witness_size * 4) + witness_size
+        };
+        FeeRate::from_sat_per_kwu(sats_per_kw as f32).fee_wu(expected_weight)
     }
 }
 
@@ -135,6 +170,18 @@ mod test {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
+    async fn create_fee_estimator() -> MutinyFeeEstimator {
+        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let esplora = Arc::new(
+            Builder::new("https://mutinynet.com/api")
+                .build_async()
+                .unwrap(),
+        );
+        let logger = Arc::new(MutinyLogger::default());
+
+        MutinyFeeEstimator::new(storage, esplora, logger)
+    }
+
     #[test]
     fn test_num_blocks_from_conf_target() {
         assert_eq!(
@@ -166,16 +213,7 @@ mod test {
 
     #[test]
     async fn test_update_fee_estimates() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
-        let esplora = Arc::new(
-            Builder::new("https://mutinynet.com/api")
-                .build_async()
-                .unwrap(),
-        );
-        let logger = Arc::new(MutinyLogger::default());
-
-        let fee_estimator = MutinyFeeEstimator::new(storage, esplora, logger);
-
+        let fee_estimator = create_fee_estimator().await;
         fee_estimator.update_fee_estimates().await.unwrap();
 
         let fee_estimates = fee_estimator.storage.get_fee_estimates().unwrap().unwrap();
@@ -189,18 +227,14 @@ mod test {
 
     #[test]
     async fn test_get_est_sat_per_1000_weight() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let fee_estimator = create_fee_estimator().await;
+        // set up the cache
         let mut fee_estimates = HashMap::new();
         fee_estimates.insert("6".to_string(), 10_f64);
-        storage.insert_fee_estimates(fee_estimates).unwrap();
-        let esplora = Arc::new(
-            Builder::new("https://mutinynet.com/api")
-                .build_async()
-                .unwrap(),
-        );
-
-        let logger = Arc::new(MutinyLogger::default());
-        let fee_estimator = MutinyFeeEstimator::new(storage, esplora, logger);
+        fee_estimator
+            .storage
+            .insert_fee_estimates(fee_estimates)
+            .unwrap();
 
         // test that we get the fee rate from the cache
         assert_eq!(
@@ -219,5 +253,45 @@ mod test {
         );
 
         cleanup_all().await;
+    }
+
+    #[test]
+    async fn test_estimate_expected_fee() {
+        let fee_estimator = create_fee_estimator().await;
+
+        assert_eq!(
+            fee_estimator.calculate_expected_fee(
+                1,
+                TAPROOT_OUTPUT_SIZE,
+                Some(TAPROOT_OUTPUT_SIZE),
+                Some(1_000)
+            ),
+            616
+        );
+
+        assert_eq!(
+            fee_estimator.calculate_expected_fee(1, P2WSH_OUTPUT_SIZE, None, None),
+            888
+        );
+
+        assert_eq!(
+            fee_estimator.calculate_expected_fee(1, P2WSH_OUTPUT_SIZE, None, Some(4000)),
+            1776
+        );
+
+        assert_eq!(
+            fee_estimator.calculate_expected_fee(3, P2WSH_OUTPUT_SIZE, None, None),
+            1816
+        );
+
+        assert_eq!(
+            fee_estimator.calculate_expected_fee(
+                3,
+                P2WSH_OUTPUT_SIZE,
+                Some(TAPROOT_OUTPUT_SIZE),
+                None
+            ),
+            2160
+        );
     }
 }

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -332,6 +332,7 @@ impl OnChainWallet {
         utxos: &[OutPoint],
         spk: Script,
         amount_sats: u64,
+        sat_per_kwu: u32,
         labels: Vec<String>,
     ) -> Result<PartiallySignedTransaction, MutinyError> {
         let mut wallet = self.wallet.try_write()?;
@@ -340,6 +341,7 @@ impl OnChainWallet {
             builder
                 .manually_selected_only()
                 .add_utxos(utxos)?
+                .fee_rate(FeeRate::from_sat_per_kwu(sat_per_kwu as f32))
                 .add_recipient(spk, amount_sats);
             builder.finish()?
         };


### PR DESCRIPTION
Moved the calculating of a transaction size out of the sweep function and made it part of the fee estimator. Also generalized it so it can be used for more than creating sweeps.