### PR TITLE
Segregate testing databases for concurrency runs

### DIFF
--- a/mutiny-core/src/auth.rs
+++ b/mutiny-core/src/auth.rs
@@ -216,7 +216,7 @@ impl AuthManager {
 #[cfg(test)]
 mod test {
     use crate::keymanager::generate_seed;
-    use crate::test_utils::cleanup_all;
+    use crate::test_utils::*;
     use bitcoin::hashes::hex::FromHex;
     use bitcoin::Network;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
@@ -224,10 +224,10 @@ mod test {
 
     use super::*;
 
-    async fn create_manager() -> AuthManager {
-        cleanup_all().await;
-
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+    async fn create_manager(db_prefix: String) -> AuthManager {
+        let storage = MutinyStorage::new("".to_string(), Some(db_prefix))
+            .await
+            .unwrap();
         let mnemonic = generate_seed(12).unwrap();
         let seed = mnemonic.to_seed("");
         let xprivkey = ExtendedPrivKey::new_master(Network::Regtest, &seed).unwrap();
@@ -261,7 +261,10 @@ mod test {
 
     #[test]
     async fn test_create_signature() {
-        let auth = create_manager().await;
+        let test_name = "test_create_signature";
+        log!("{}", test_name);
+
+        let auth = create_manager(test_name.to_string()).await;
 
         let k1 = [0; 32];
 
@@ -272,13 +275,14 @@ mod test {
         auth.context
             .verify_ecdsa(&Message::from_slice(&k1).unwrap(), &sig, &pk)
             .unwrap();
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_add_used_service() {
-        let auth = create_manager().await;
+        let test_name = "test_add_used_service";
+        log!("{}", test_name);
+
+        let auth = create_manager(test_name.to_string()).await;
 
         let url = Url::parse("https://mutinywallet.com").unwrap();
 
@@ -290,13 +294,14 @@ mod test {
             .unwrap()
             .used_services
             .contains(&url.host().unwrap().to_string()));
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_add_profile() {
-        let auth = create_manager().await;
+        let test_name = "test_add_profile";
+        log!("{}", test_name);
+
+        let auth = create_manager(test_name.to_string()).await;
 
         let url = Url::parse("https://mutinywallet.com").unwrap();
         let k1 = [0; 32];
@@ -311,7 +316,5 @@ mod test {
 
         let profiles = auth.get_profiles().unwrap();
         assert_eq!(profiles.len(), 2);
-
-        cleanup_all().await;
     }
 }

--- a/mutiny-core/src/fees.rs
+++ b/mutiny-core/src/fees.rs
@@ -170,8 +170,10 @@ mod test {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    async fn create_fee_estimator() -> MutinyFeeEstimator {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+    async fn create_fee_estimator(db_prefix: String) -> MutinyFeeEstimator {
+        let storage = MutinyStorage::new("".to_string(), Some(db_prefix))
+            .await
+            .unwrap();
         let esplora = Arc::new(
             Builder::new("https://mutinynet.com/api")
                 .build_async()
@@ -213,7 +215,10 @@ mod test {
 
     #[test]
     async fn test_update_fee_estimates() {
-        let fee_estimator = create_fee_estimator().await;
+        let test_name = "test_update_fee_estimates";
+        log!("{}", test_name);
+
+        let fee_estimator = create_fee_estimator(test_name.to_string()).await;
         fee_estimator.update_fee_estimates().await.unwrap();
 
         let fee_estimates = fee_estimator.storage.get_fee_estimates().unwrap().unwrap();
@@ -221,13 +226,14 @@ mod test {
         assert!(fee_estimates.get("3").is_some());
         assert!(fee_estimates.get("6").is_some());
         assert!(fee_estimates.get("12").is_some());
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_get_est_sat_per_1000_weight() {
-        let fee_estimator = create_fee_estimator().await;
+        let test_name = "test_get_est_sat_per_1000_weight";
+        log!("{}", test_name);
+
+        let fee_estimator = create_fee_estimator(test_name.to_string()).await;
         // set up the cache
         let mut fee_estimates = HashMap::new();
         fee_estimates.insert("6".to_string(), 10_f64);
@@ -251,13 +257,14 @@ mod test {
             fee_estimator.get_est_sat_per_1000_weight(ConfirmationTarget::HighPriority),
             5000
         );
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_estimate_expected_fee() {
-        let fee_estimator = create_fee_estimator().await;
+        let test_name = "test_estimate_expected_fee";
+        log!("{}", test_name);
+
+        let fee_estimator = create_fee_estimator(test_name.to_string()).await;
 
         assert_eq!(
             fee_estimator.calculate_expected_fee(

--- a/mutiny-core/src/gossip.rs
+++ b/mutiny-core/src/gossip.rs
@@ -662,8 +662,6 @@ mod test {
     use uuid::Uuid;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-    use crate::test_utils::*;
-
     use super::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
@@ -734,8 +732,6 @@ mod test {
 
         assert!(data.is_some());
         assert!(data.unwrap().last_sync_timestamp > 0);
-
-        cleanup_all().await;
     }
 
     #[test]
@@ -761,8 +757,6 @@ mod test {
         let read = read_peer_info(&node_id).await.unwrap();
 
         assert!(read.is_none());
-
-        cleanup_all().await;
     }
 
     #[test]
@@ -786,7 +780,5 @@ mod test {
 
         assert!(read.is_some());
         assert_eq!(read.unwrap(), expected);
-
-        cleanup_all().await;
     }
 }

--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -219,7 +219,8 @@ mod tests {
 
     #[test]
     async fn derive_pubkey_child_from_seed() {
-        log!("creating pubkeys from a child seed");
+        let test_name = "derive_pubkey_child_from_seed";
+        log!("{}", test_name);
 
         let mnemonic = Mnemonic::from_str("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about").expect("could not generate");
         let esplora = Arc::new(
@@ -227,7 +228,9 @@ mod tests {
                 .build_async()
                 .unwrap(),
         );
-        let db = MutinyStorage::new("".to_string()).await.unwrap();
+        let db = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let logger = Arc::new(MutinyLogger::default());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),
@@ -257,6 +260,5 @@ mod tests {
         let second_pubkey_again = pubkey_from_keys_manager(&km);
 
         assert_eq!(second_pubkey, second_pubkey_again);
-        cleanup_all().await;
     }
 }

--- a/mutiny-core/src/labels.rs
+++ b/mutiny-core/src/labels.rs
@@ -354,12 +354,12 @@ impl LabelStorage for NodeManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::*;
     use bitcoin::Address;
     use lightning_invoice::Invoice;
     use std::collections::HashMap;
     use std::str::FromStr;
 
-    use crate::test_utils::cleanup_all;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
     wasm_bindgen_test_configure!(run_in_browser);
 
@@ -463,7 +463,12 @@ mod tests {
 
     #[test]
     async fn test_get_address_labels() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let test_name = "test_get_address_labels";
+        log!("{}", test_name);
+
+        let storage = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let labels_map = create_test_address_labels_map();
         storage
             .set(ADDRESS_LABELS_MAP_KEY, labels_map.clone())
@@ -471,13 +476,16 @@ mod tests {
 
         let result = storage.get_address_labels();
         assert_eq!(result.unwrap(), labels_map);
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_get_invoice_labels() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let test_name = "test_get_invoice_labels";
+        log!("{}", test_name);
+
+        let storage = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let labels_map = create_test_invoice_labels_map();
         storage
             .set(INVOICE_LABELS_MAP_KEY, labels_map.clone())
@@ -485,13 +493,16 @@ mod tests {
 
         let result = storage.get_invoice_labels();
         assert_eq!(result.unwrap(), labels_map);
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_get_labels() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let test_name = "test_get_labels";
+        log!("{}", test_name);
+
+        let storage = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let labels = create_test_labels();
         for (label, label_item) in labels.clone() {
             storage.set(get_label_item_key(label), label_item).unwrap();
@@ -506,13 +517,16 @@ mod tests {
         labels.sort_by(|a, b| a.0.cmp(&b.0));
 
         assert_eq!(result, labels);
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_get_label() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let test_name = "test_get_label";
+        log!("{}", test_name);
+
+        let storage = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let labels = create_test_labels();
         for (label, label_item) in labels.clone() {
             storage.set(get_label_item_key(label), label_item).unwrap();
@@ -521,13 +535,16 @@ mod tests {
         let label = "test_label".to_string();
         let result = storage.get_label(&label);
         assert_eq!(result.unwrap(), labels.get(&label).cloned());
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_set_address_labels() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let test_name = "test_set_address_labels";
+        log!("{}", test_name);
+
+        let storage = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let address = Address::from_str("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa").unwrap();
         let labels = vec!["label1".to_string(), "label2".to_string()];
 
@@ -536,13 +553,16 @@ mod tests {
 
         let address_labels = storage.get_address_labels().unwrap();
         assert_eq!(address_labels.get(&address), Some(&labels));
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_set_invoice_labels() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let test_name = "test_set_invoice_labels";
+        log!("{}", test_name);
+
+        let storage = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let invoice = Invoice::from_str("lnbc923720n1pj9nr6zpp5xmvlq2u5253htn52mflh2e6gn7pk5ht0d4qyhc62fadytccxw7hqhp5l4s6qwh57a7cwr7zrcz706qx0qy4eykcpr8m8dwz08hqf362egfscqzzsxqzfvsp5pr7yjvcn4ggrf6fq090zey0yvf8nqvdh2kq7fue0s0gnm69evy6s9qyyssqjyq0fwjr22eeg08xvmz88307yqu8tqqdjpycmermks822fpqyxgshj8hvnl9mkh6srclnxx0uf4ugfq43d66ak3rrz4dqcqd23vxwpsqf7dmhm").unwrap();
         let labels = vec!["label1".to_string(), "label2".to_string()];
 
@@ -551,13 +571,16 @@ mod tests {
 
         let invoice_labels = storage.get_invoice_labels().unwrap();
         assert_eq!(invoice_labels.get(&invoice), Some(&labels));
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_get_contacts() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let test_name = "test_get_contacts";
+        log!("{}", test_name);
+
+        let storage = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let contacts = create_test_contacts();
         for (id, contact) in contacts.clone() {
             storage.set(get_contact_key(id), contact).unwrap();
@@ -572,13 +595,16 @@ mod tests {
         contacts.sort_by(|a, b| a.0.cmp(&b.0));
 
         assert_eq!(result, contacts);
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_get_contact() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let test_name = "test_get_contact";
+        log!("{}", test_name);
+
+        let storage = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let contact = Contact {
             name: "Satoshi Nakamoto".to_string(),
             npub: None,
@@ -588,15 +614,18 @@ mod tests {
         };
         let id = storage.create_new_contact(contact.clone()).unwrap();
 
-        let result = storage.get_contact(&id).unwrap();
+        let result = storage.get_contact(id).unwrap();
         assert_eq!(result.unwrap(), contact);
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_create_contact_from_label() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let test_name = "test_create_contact_from_label";
+        log!("{}", test_name);
+
+        let storage = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let address = Address::from_str("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa").unwrap();
         let invoice = Invoice::from_str("lnbc923720n1pj9nr6zpp5xmvlq2u5253htn52mflh2e6gn7pk5ht0d4qyhc62fadytccxw7hqhp5l4s6qwh57a7cwr7zrcz706qx0qy4eykcpr8m8dwz08hqf362egfscqzzsxqzfvsp5pr7yjvcn4ggrf6fq090zey0yvf8nqvdh2kq7fue0s0gnm69evy6s9qyyssqjyq0fwjr22eeg08xvmz88307yqu8tqqdjpycmermks822fpqyxgshj8hvnl9mkh6srclnxx0uf4ugfq43d66ak3rrz4dqcqd23vxwpsqf7dmhm").unwrap();
         let label = "test_label".to_string();
@@ -644,13 +673,16 @@ mod tests {
         // verify we deleted the old label
         let label_item = storage.get_label(&label).unwrap();
         assert!(label_item.is_none());
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_create_new_contact() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let test_name = "test_create_new_contact";
+        log!("{}", test_name);
+
+        let storage = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let contact = create_test_contacts().iter().next().unwrap().1.to_owned();
 
         let result = storage.create_new_contact(contact.clone());
@@ -659,13 +691,16 @@ mod tests {
         let id = result.unwrap();
         let stored_contact = storage.get_contact(id).unwrap();
         assert_eq!(stored_contact, Some(contact));
-
-        cleanup_all().await;
     }
 
     #[test]
     async fn test_get_tag_items() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let test_name = "test_get_tag_items";
+        log!("{}", test_name);
+
+        let storage = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let contacts = create_test_contacts();
         for (id, contact) in contacts.clone() {
             storage.set(get_contact_key(id), contact).unwrap();
@@ -694,7 +729,5 @@ mod tests {
         expected_tag_items.sort();
 
         assert_eq!(result, expected_tag_items);
-
-        cleanup_all().await;
     }
 }

--- a/mutiny-core/src/redshift.rs
+++ b/mutiny-core/src/redshift.rs
@@ -508,7 +508,12 @@ mod test {
 
     #[test]
     async fn test_redshift_persistence() {
-        let storage = MutinyStorage::new("".to_string()).await.unwrap();
+        let test_name = "test_create_signature";
+        log!("{}", test_name);
+
+        let storage = MutinyStorage::new("".to_string(), Some(test_name.to_string()))
+            .await
+            .unwrap();
         let rs = dummy_redshift();
 
         assert!(storage.get_redshifts().unwrap().is_empty());
@@ -520,7 +525,5 @@ mod test {
 
         let all = storage.get_redshifts().unwrap();
         assert_eq!(all, vec![rs]);
-
-        cleanup_all().await;
     }
 }

--- a/mutiny-core/src/test_utils.rs
+++ b/mutiny-core/src/test_utils.rs
@@ -8,6 +8,7 @@ macro_rules! log {
     }
 #[allow(unused_imports)]
 pub(crate) use log;
+
 use rexie::Rexie;
 
 use crate::indexed_db::MutinyStorage;
@@ -17,18 +18,18 @@ async fn cleanup_gossip_test() {
     Rexie::delete(GOSSIP_DATABASE_NAME).await.unwrap();
 }
 
-async fn cleanup_wallet_test() {
-    MutinyStorage::clear().await.unwrap();
+async fn cleanup_wallet_test(db_prefix: Option<String>) {
+    MutinyStorage::clear(db_prefix).await.unwrap();
 }
 
-async fn cleanup_logging_test() {
-    logging::clear().await.unwrap();
+async fn cleanup_logging_test(db_prefix: Option<String>) {
+    logging::clear(db_prefix).await.unwrap();
 }
 
-pub async fn cleanup_all() {
+pub async fn cleanup_all(db_prefix: Option<String>) {
     let cleanup_gossip = cleanup_gossip_test();
-    let cleanup_wallet = cleanup_wallet_test();
-    let cleanup_logging = cleanup_logging_test();
+    let cleanup_wallet = cleanup_wallet_test(db_prefix.clone());
+    let cleanup_logging = cleanup_logging_test(db_prefix.clone());
 
     join!(cleanup_gossip, cleanup_wallet, cleanup_logging);
 }

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -755,7 +755,7 @@ mod tests {
         .expect("mutiny wallet should initialize");
         assert!(MutinyWallet::has_node_manager().await);
 
-        cleanup_all().await;
+        cleanup_all(None).await;
     }
 
     #[test]
@@ -781,7 +781,7 @@ mod tests {
         assert!(MutinyWallet::has_node_manager().await);
         assert_eq!(seed.to_string(), nm.show_seed());
 
-        cleanup_all().await;
+        cleanup_all(None).await;
     }
 
     #[test]
@@ -816,6 +816,6 @@ mod tests {
         assert_ne!("", node_identity.uuid());
         assert_ne!("", node_identity.pubkey());
 
-        cleanup_all().await;
+        cleanup_all(None).await;
     }
 }


### PR DESCRIPTION
This allows a prefix to be added to the DB builders with the enforcement of setting a prefix under `test` instances of the node manager / mutiny wallet. Does not allow setting a prefix when not under test.

Allowed to remove all the cleanup code and fixed the specific logging test I was doing. Ran a few times locally, wondering how it behaves in CI. I am going to run it a few times as part of this PR. 