### PR TITLE
Update network graph with unsigned messages

### DIFF
--- a/mutiny-core/src/peermanager.rs
+++ b/mutiny-core/src/peermanager.rs
@@ -188,7 +188,8 @@ impl<S: MutinyStorage> RoutingMessageHandler for GossipMessageHandler<S> {
         }
 
         // because we got the announcement, may as well update our network graph
-        self.network_graph.update_node_from_announcement(msg)?;
+        self.network_graph
+            .update_node_from_unsigned_announcement(&msg.contents)?;
 
         Ok(false)
     }
@@ -199,13 +200,16 @@ impl<S: MutinyStorage> RoutingMessageHandler for GossipMessageHandler<S> {
     ) -> Result<bool, LightningError> {
         // because we got the channel, may as well update our network graph
         self.network_graph
-            .update_channel_from_announcement::<Arc<ErroringUtxoLookup>>(msg, &None)?;
+            .update_channel_from_unsigned_announcement::<Arc<ErroringUtxoLookup>>(
+                &msg.contents,
+                &None,
+            )?;
         Ok(false)
     }
 
     fn handle_channel_update(&self, msg: &msgs::ChannelUpdate) -> Result<bool, LightningError> {
         // because we got the update, may as well update our network graph
-        self.network_graph.update_channel(msg)?;
+        self.network_graph.update_channel_unsigned(&msg.contents)?;
         Ok(false)
     }
 


### PR DESCRIPTION
Switches to updating the network graph with the unsigned versions of the announcements. We don't relay anything so we have no use for the signatures and this will make our saved network graph smaller.

Looks like this does remove the signature verification though, I think that should be an okay tradeoff, we already aren't verifying any for RGS