### PR TITLE
Await funding transaction on open channel

### DIFF
--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -41,6 +41,7 @@ const MONITORS_PREFIX_KEY: &str = "monitors/";
 const PAYMENT_INBOUND_PREFIX_KEY: &str = "payment_inbound/";
 const PAYMENT_OUTBOUND_PREFIX_KEY: &str = "payment_outbound/";
 const CHANNEL_OPENING_PARAMS_PREFIX: &str = "chan_open_params/";
+const CHANNEL_CLOSURE_PREFIX: &str = "channel_closure/";
 const FAILED_SPENDABLE_OUTPUT_DESCRIPTOR_KEY: &str = "failed_spendable_outputs";
 
 pub(crate) type PhantomChannelManager<S: MutinyStorage> = LdkChannelManager<
@@ -274,7 +275,10 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
         user_channel_id: u128,
         closure: ChannelClosure,
     ) -> Result<(), MutinyError> {
-        let key = self.get_key(&format!("channel_closure_{}", user_channel_id.to_hex()));
+        let key = self.get_key(&format!(
+            "{CHANNEL_CLOSURE_PREFIX}{}",
+            user_channel_id.to_be_bytes().to_hex()
+        ));
         self.storage.set_data(key, closure)?;
         Ok(())
     }
@@ -283,23 +287,28 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
         &self,
         user_channel_id: u128,
     ) -> Result<Option<ChannelClosure>, MutinyError> {
-        let key = self.get_key(&format!("channel_closure_{}", user_channel_id.to_hex()));
+        let key = self.get_key(&format!(
+            "{CHANNEL_CLOSURE_PREFIX}{}",
+            user_channel_id.to_be_bytes().to_hex()
+        ));
         self.storage.get_data(key)
     }
 
     #[allow(dead_code)] // todo expose to front end
     pub(crate) fn list_channel_closures(&self) -> Result<Vec<(u128, ChannelClosure)>, MutinyError> {
-        let prefix = "channel_closure_";
         let suffix = format!("_{}", self.node_id);
-        let map: HashMap<String, ChannelClosure> = self.storage.scan(prefix, Some(&suffix))?;
+        let map: HashMap<String, ChannelClosure> =
+            self.storage.scan(CHANNEL_CLOSURE_PREFIX, Some(&suffix))?;
 
         Ok(map
             .into_iter()
             .map(|(key, value)| {
                 // convert keys to u128
-                let user_channel_id_str = key.trim_start_matches(prefix).trim_end_matches(&suffix);
-                let user_channel_id: [u8; 16] =
-                    FromHex::from_hex(user_channel_id_str).expect("key should be a u128");
+                let user_channel_id_str = key
+                    .trim_start_matches(CHANNEL_CLOSURE_PREFIX)
+                    .trim_end_matches(&suffix);
+                let user_channel_id: [u8; 16] = FromHex::from_hex(user_channel_id_str)
+                    .expect(&format!("key should be a u128 got {user_channel_id_str}"));
 
                 let user_channel_id = u128::from_be_bytes(user_channel_id);
                 (user_channel_id, value)
@@ -358,7 +367,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
 
     /// Clears the failed spendable outputs from storage
     /// This is used when the failed spendable outputs have been successfully spent
-    pub async fn clear_failed_spendable_outputs(&self) -> anyhow::Result<()> {
+    pub fn clear_failed_spendable_outputs(&self) -> anyhow::Result<()> {
         let key = self.get_key(FAILED_SPENDABLE_OUTPUT_DESCRIPTOR_KEY);
         self.storage.delete(key)?;
 
@@ -510,18 +519,18 @@ mod test {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    async fn get_test_persister() -> MutinyNodePersister<MemoryStorage> {
+    fn get_test_persister() -> MutinyNodePersister<MemoryStorage> {
         let id = Uuid::new_v4().to_string();
         let storage = MemoryStorage::default();
         MutinyNodePersister::new(id, storage)
     }
 
     #[test]
-    async fn test_persist_payment_info() {
+    fn test_persist_payment_info() {
         let test_name = "test_persist_payment_info";
         log!("{}", test_name);
 
-        let persister = get_test_persister().await;
+        let persister = get_test_persister();
         let preimage = [1; 32];
         let payment_hash = PaymentHash([0; 32]);
         let pubkey = PublicKey::from_str(
@@ -566,11 +575,11 @@ mod test {
     }
 
     #[test]
-    async fn test_persist_channel_closure() {
+    fn test_persist_channel_closure() {
         let test_name = "test_persist_channel_closure";
         log!("{}", test_name);
 
-        let persister = get_test_persister().await;
+        let persister = get_test_persister();
 
         let user_channel_id: u128 = 123456789;
         let closure = ChannelClosure {
@@ -588,11 +597,11 @@ mod test {
     }
 
     #[test]
-    async fn test_persist_spendable_output_descriptor() {
+    fn test_persist_spendable_output_descriptor() {
         let test_name = "test_persist_spendable_output_descriptor";
         log!("{}", test_name);
 
-        let persister = get_test_persister().await;
+        let persister = get_test_persister();
 
         let static_output_0 = SpendableOutputDescriptor::StaticOutput {
             outpoint: OutPoint {
@@ -620,7 +629,7 @@ mod test {
         let result = persister.get_failed_spendable_outputs().unwrap();
         assert_eq!(result, vec![static_output_0, static_output_1]);
 
-        let result = persister.clear_failed_spendable_outputs().await;
+        let result = persister.clear_failed_spendable_outputs();
         assert!(result.is_ok());
 
         let result = persister.get_failed_spendable_outputs().unwrap();

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -383,7 +383,7 @@ impl<S: MutinyStorage> Node<S> {
             {
                 Ok(_) => {
                     log_info!(logger, "Successfully retried spendable outputs");
-                    persister.clear_failed_spendable_outputs().await?;
+                    persister.clear_failed_spendable_outputs()?;
                 }
                 Err(e) => log_warn!(logger, "Failed to retry spendable outputs {e}"),
             }

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1011,11 +1011,38 @@ impl<S: MutinyStorage> Node<S> {
         self.await_payment(payment_hash, timeout, labels).await
     }
 
-    pub async fn open_channel(
+    async fn await_chan_funding_tx(
+        &self,
+        user_channel_id: u128,
+        pubkey: &PublicKey,
+        timeout: u64,
+    ) -> Result<OutPoint, MutinyError> {
+        let start = utils::now().as_secs();
+        loop {
+            let channels = self.channel_manager.list_channels_with_counterparty(pubkey);
+            let channel = channels
+                .iter()
+                .find(|c| c.user_channel_id == user_channel_id);
+
+            if let Some(outpoint) = channel.and_then(|c| c.funding_txo) {
+                return Ok(outpoint.into_bitcoin_outpoint());
+            }
+
+            let now = utils::now().as_secs();
+            if now - start > timeout {
+                return Err(MutinyError::ChannelCreationFailed);
+            }
+
+            sleep(250).await;
+        }
+    }
+
+    pub async fn init_open_channel(
         &self,
         pubkey: PublicKey,
         amount_sat: u64,
-    ) -> Result<[u8; 32], MutinyError> {
+        user_channel_id: Option<u128>,
+    ) -> Result<u128, MutinyError> {
         let mut config = default_user_config();
 
         // if we are opening channel to LSP, turn off SCID alias until CLN is updated
@@ -1026,16 +1053,26 @@ impl<S: MutinyStorage> Node<S> {
             }
         }
 
-        match self
-            .channel_manager
-            .create_channel(pubkey, amount_sat, 0, 0, Some(config))
-        {
-            Ok(res) => {
+        let user_channel_id = user_channel_id.unwrap_or_else(|| {
+            // generate random user channel id
+            let mut user_channel_id_bytes = [0u8; 16];
+            getrandom::getrandom(&mut user_channel_id_bytes).unwrap();
+            u128::from_be_bytes(user_channel_id_bytes)
+        });
+
+        match self.channel_manager.create_channel(
+            pubkey,
+            amount_sat,
+            0,
+            user_channel_id,
+            Some(config),
+        ) {
+            Ok(_) => {
                 log_info!(
                     self.logger,
                     "SUCCESS: channel initiated with peer: {pubkey:?}"
                 );
-                Ok(res)
+                Ok(user_channel_id)
             }
             Err(e) => {
                 log_error!(
@@ -1047,12 +1084,26 @@ impl<S: MutinyStorage> Node<S> {
         }
     }
 
-    pub async fn sweep_utxos_to_channel(
+    pub async fn open_channel_with_timeout(
+        &self,
+        pubkey: PublicKey,
+        amount_sat: u64,
+        user_channel_id: Option<u128>,
+        timeout: u64,
+    ) -> Result<OutPoint, MutinyError> {
+        let init = self
+            .init_open_channel(pubkey, amount_sat, user_channel_id)
+            .await?;
+
+        self.await_chan_funding_tx(init, &pubkey, timeout).await
+    }
+
+    pub async fn init_sweep_utxos_to_channel(
         &self,
         user_chan_id: Option<u128>,
         utxos: &[OutPoint],
         pubkey: PublicKey,
-    ) -> Result<[u8; 32], MutinyError> {
+    ) -> Result<u128, MutinyError> {
         // Calculate the total value of the selected utxos
         let utxo_value: u64 = {
             // find the wallet utxos
@@ -1116,12 +1167,12 @@ impl<S: MutinyStorage> Node<S> {
             user_channel_id,
             Some(config),
         ) {
-            Ok(res) => {
+            Ok(_) => {
                 log_info!(
                     self.logger,
                     "SUCCESS: channel initiated with peer: {pubkey:?}"
                 );
-                Ok(res)
+                Ok(user_channel_id)
             }
             Err(e) => {
                 log_error!(
@@ -1133,6 +1184,20 @@ impl<S: MutinyStorage> Node<S> {
                 Err(MutinyError::ChannelCreationFailed)
             }
         }
+    }
+
+    pub async fn sweep_utxos_to_channel_with_timeout(
+        &self,
+        user_chan_id: Option<u128>,
+        utxos: &[OutPoint],
+        pubkey: PublicKey,
+        timeout: u64,
+    ) -> Result<OutPoint, MutinyError> {
+        let init = self
+            .init_sweep_utxos_to_channel(user_chan_id, utxos, pubkey)
+            .await?;
+
+        self.await_chan_funding_tx(init, &pubkey, timeout).await
     }
 }
 

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1019,6 +1019,12 @@ impl<S: MutinyStorage> Node<S> {
     ) -> Result<OutPoint, MutinyError> {
         let start = utils::now().as_secs();
         loop {
+            // We will get a channel closure event if the peer rejects the channel
+            // todo return closure reason to user
+            if let Ok(Some(_closure)) = self.persister.get_channel_closure(user_channel_id) {
+                return Err(MutinyError::ChannelCreationFailed);
+            }
+
             let channels = self.channel_manager.list_channels_with_counterparty(pubkey);
             let channel = channels
                 .iter()

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -587,7 +587,7 @@ impl MutinyWallet {
         Ok(self
             .inner
             .node_manager
-            .open_channel(&from_node, to_pubkey, amount)
+            .open_channel(&from_node, to_pubkey, amount, None)
             .await?
             .into())
     }


### PR DESCRIPTION
Similar to #375 but for channels.

Was able to take this logic from redshifts and make the `open_channel` functions better. Now they will await the funding transaction being created, this should give better feedback to the frontend if the channel open actually worked.