### PR TITLE
Handle restarts for redshifts properly

### DIFF
--- a/mutiny-wasm/src/models.rs
+++ b/mutiny-wasm/src/models.rs
@@ -404,7 +404,9 @@ impl Redshift {
     pub fn status(&self) -> String {
         match self.status {
             RedshiftStatus::ChannelOpening => "ChannelOpening".to_string(),
+            RedshiftStatus::ChannelOpened => "ChannelOpened".to_string(),
             RedshiftStatus::AttemptingPayments => "AttemptingPayments".to_string(),
+            RedshiftStatus::ClosingChannels => "ClosingChannels".to_string(),
             RedshiftStatus::Completed => "Completed".to_string(),
             RedshiftStatus::Failed(_) => "Failed".to_string(),
         }


### PR DESCRIPTION
Before if someone closed mutiny while redshifts were attempting payments they would never be restarted. This fixes by adding a new status and making the `start_redshifts` function a little smarter.

First, added a new statuses called `ChannelOpened` and `ClosingChannels` this is set by the event handler when we get a `ChannelReady` event. This signals to the `start_redshifts` that it can start attempting payments. This also allows us to change it so we can enable handle restarts.

With adding the new statuses we can now handle restarts by only starting to attempt payments on redshifts that have the `ChannelOpened` when polling. We can then only check for redshifts with the status of `AttemptingPayments` at the very beginning to restart them. This makes it so every 10 seconds we are only checking for new redshifts.