### PR TITLE
Fixes for reset router

### DIFF
--- a/mutiny-core/src/gossip.rs
+++ b/mutiny-core/src/gossip.rs
@@ -403,7 +403,7 @@ pub(crate) fn delete_peer_info(
     if let Some(mut current) = current {
         current.nodes.retain(|n| n != uuid);
         if current.nodes.is_empty() {
-            storage.delete(&key)?;
+            storage.delete(&[key])?;
         } else {
             storage.set_data(key, current)?;
         }

--- a/mutiny-core/src/labels.rs
+++ b/mutiny-core/src/labels.rs
@@ -265,7 +265,7 @@ impl<S: MutinyStorage> LabelStorage for S {
                 self.set_data(key, contact)?;
 
                 // delete old label item
-                self.delete(get_label_item_key(&label))?;
+                self.delete(&[get_label_item_key(&label)])?;
                 Ok(id)
             }
         }

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -369,7 +369,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
     /// This is used when the failed spendable outputs have been successfully spent
     pub fn clear_failed_spendable_outputs(&self) -> anyhow::Result<()> {
         let key = self.get_key(FAILED_SPENDABLE_OUTPUT_DESCRIPTOR_KEY);
-        self.storage.delete(key)?;
+        self.storage.delete(&[key])?;
 
         Ok(())
     }
@@ -393,7 +393,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
 
     pub(crate) fn delete_channel_open_params(&self, id: u128) -> Result<(), MutinyError> {
         let key = self.get_key(&channel_open_params_key(id));
-        self.storage.delete(key)
+        self.storage.delete(&[key])
     }
 }
 

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -105,8 +105,8 @@ pub trait MutinyStorage: Clone + Sized + 'static {
         }
     }
 
-    /// Delete a value from the storage
-    fn delete(&self, key: impl AsRef<str>) -> Result<(), MutinyError>;
+    /// Delete a set of values from the storage
+    fn delete(&self, keys: &[impl AsRef<str>]) -> Result<(), MutinyError>;
 
     /// Start the storage, this will be called before any other methods
     async fn start(&mut self) -> Result<(), MutinyError>;
@@ -270,14 +270,17 @@ impl MutinyStorage for MemoryStorage {
         }
     }
 
-    fn delete(&self, key: impl AsRef<str>) -> Result<(), MutinyError> {
-        let key = key.as_ref().to_string();
+    fn delete(&self, keys: &[impl AsRef<str>]) -> Result<(), MutinyError> {
+        let keys: Vec<String> = keys.iter().map(|k| k.as_ref().to_string()).collect();
 
         let mut map = self
             .memory
             .try_write()
             .map_err(|e| MutinyError::write_err(e.into()))?;
-        map.remove(&key);
+
+        for key in keys {
+            map.remove(&key);
+        }
 
         Ok(())
     }
@@ -336,7 +339,7 @@ impl MutinyStorage for () {
         Ok(None)
     }
 
-    fn delete(&self, _key: impl AsRef<str>) -> Result<(), MutinyError> {
+    fn delete(&self, _keys: &[impl AsRef<str>]) -> Result<(), MutinyError> {
         Ok(())
     }
 

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -12,6 +12,7 @@ mod utils;
 use crate::error::MutinyJsError;
 use crate::indexed_db::IndexedDbStorage;
 use crate::models::*;
+use crate::utils::sleep;
 use bip39::Mnemonic;
 use bitcoin::consensus::deserialize;
 use bitcoin::hashes::hex::FromHex;
@@ -814,6 +815,8 @@ impl MutinyWallet {
     #[wasm_bindgen]
     pub async fn reset_router(&self) -> Result<(), MutinyJsError> {
         self.inner.node_manager.reset_router().await?;
+        // Sleep to wait for indexed db to finish writing
+        sleep(500).await;
         Ok(())
     }
 


### PR DESCRIPTION
Changed the storage trait to delete with a vector, this should help with db locking issues.

Also found the main bug where we were setting `needs_db_connection` to true when we were connected. Fixed this for `reset_router` and for `export_json`. I think it was fine for export before because we were just reading.