### PR TITLE
Use total outbound balance, make new errors for handling failed payments

### DIFF
--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -41,6 +41,13 @@ pub enum MutinyError {
     /// Invoice creation failed.
     #[error("Failed to create invoice.")]
     InvoiceCreationFailed,
+    /// We have enough balance to pay an invoice, but
+    /// the this would take from our reserve amount which is not allowed.
+    #[error("Channel reserve amount is too high.")]
+    ReserveAmountError,
+    /// We do not have enough balance to pay the given amount.
+    #[error("We do not have enough balance to pay the given amount.")]
+    InsufficientBalance,
     /// Failed to call on the given LNURL
     #[error("Failed to call on the given LNURL.")]
     LnUrlFailure,
@@ -141,6 +148,7 @@ impl From<bdk::Error> for MutinyError {
     fn from(e: bdk::Error) -> Self {
         match e {
             bdk::Error::Signer(_) => Self::WalletSigningFailed,
+            bdk::Error::InsufficientFunds { .. } => Self::InsufficientBalance,
             _ => Self::WalletOperationFailed,
         }
     }

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -859,13 +859,13 @@ impl<S: MutinyStorage> NodeManager<S> {
         let lightning_msats: u64 = nodes
             .iter()
             .flat_map(|(_, n)| n.channel_manager.list_channels())
-            .map(|c| c.outbound_capacity_msat)
+            .map(|c| c.balance_msat)
             .sum();
 
         Ok(MutinyBalance {
             confirmed: onchain.confirmed + onchain.trusted_pending,
             unconfirmed: onchain.untrusted_pending + onchain.immature,
-            lightning: lightning_msats / 1000,
+            lightning: lightning_msats / 1_000,
         })
     }
 

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -36,6 +36,13 @@ pub enum MutinyJsError {
     /// Invoice creation failed.
     #[error("Failed to create invoice.")]
     InvoiceCreationFailed,
+    /// We have enough balance to pay an invoice, but
+    /// the this would take from our reserve amount which is not allowed.
+    #[error("Channel reserve amount is too high.")]
+    ReserveAmountError,
+    /// We do not have enough balance to pay the given amount.
+    #[error("We do not have enough balance to pay the given amount.")]
+    InsufficientBalance,
     /// Failed to call on the given LNURL
     #[error("Failed to call on the given LNURL.")]
     LnUrlFailure,
@@ -123,6 +130,8 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::PaymentTimeout => MutinyJsError::PaymentTimeout,
             MutinyError::InvoiceInvalid => MutinyJsError::InvoiceInvalid,
             MutinyError::InvoiceCreationFailed => MutinyJsError::InvoiceCreationFailed,
+            MutinyError::ReserveAmountError => MutinyJsError::ReserveAmountError,
+            MutinyError::InsufficientBalance => MutinyJsError::InsufficientBalance,
             MutinyError::LnUrlFailure => MutinyJsError::LnUrlFailure,
             MutinyError::LspFailure => MutinyJsError::LspFailure,
             MutinyError::RoutingFailed => MutinyJsError::RoutingFailed,


### PR DESCRIPTION
Closes #522

This will also now give the `InsufficientBalance` error for on-chain stuff, this should make it a little more clear for failures there as well.