### PR TITLE
De-wasm sleep

### DIFF
--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -63,7 +63,7 @@ gloo-net = "0.2.4"
 gloo-utils = { version = "0.1.6", features = ["serde"] }
 futures = "0.3.25"
 thiserror = "1.0"
-web-sys = { version = "0.3.60", features = ["console"] }
+web-sys = { version = "0.3.60", features = ["console"], optional = true }
 anyhow = "1.0"
 miniscript = { version = "9.0.0", default-features = false, features = ["no-std"] }
 
@@ -77,6 +77,9 @@ default = ["console_error_panic_hook", "async-interface"]
 async-interface = []
 ignored_tests = ["test-utils"]
 test-utils = []
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = { version = "0.3.60", features = ["console"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = true

--- a/mutiny-core/src/utils.rs
+++ b/mutiny-core/src/utils.rs
@@ -8,14 +8,21 @@ use lightning::util::ser::Writeable;
 use lightning::util::ser::Writer;
 
 pub async fn sleep(millis: i32) {
-    let mut cb = |resolve: js_sys::Function, _reject: js_sys::Function| {
-        web_sys::window()
-            .unwrap()
-            .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, millis)
-            .unwrap();
-    };
-    let p = js_sys::Promise::new(&mut cb);
-    wasm_bindgen_futures::JsFuture::from(p).await.unwrap();
+    #[cfg(target_arch = "wasm32")]
+    {
+        let mut cb = |resolve: js_sys::Function, _reject: js_sys::Function| {
+            web_sys::window()
+                .unwrap()
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, millis)
+                .unwrap();
+        };
+        let p = js_sys::Promise::new(&mut cb);
+        wasm_bindgen_futures::JsFuture::from(p).await.unwrap();
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::thread::sleep(Duration::from_millis(millis));
+    }
 }
 
 pub fn now() -> Duration {


### PR DESCRIPTION
Before we were always trying to talk to the browser to sleep. Now we will only do that in a wasm32 build environment, otherwise will use the standard library's version of sleep.

Part of #366