### PR TITLE
Move syncing to a background thread

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -119,6 +119,8 @@ impl<S: MutinyStorage> MutinyWallet<S> {
 
         let node_manager = Arc::new(NodeManager::new(config.clone(), storage.clone()).await?);
 
+        NodeManager::start_sync(node_manager.clone());
+
         // create nostr manager
         let seed = node_manager.show_seed().to_seed("");
         let xprivkey = ExtendedPrivKey::new_master(node_manager.get_network(), &seed)?;
@@ -138,6 +140,7 @@ impl<S: MutinyStorage> MutinyWallet<S> {
     pub async fn start(&mut self) -> Result<(), MutinyError> {
         self.node_manager =
             Arc::new(NodeManager::new(self.config.clone(), self.storage.clone()).await?);
+        NodeManager::start_sync(self.node_manager.clone());
         NodeManager::start_redshifts(self.node_manager.clone());
         Ok(())
     }

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -298,17 +298,6 @@ impl MutinyWallet {
         Ok(JsValue::from_serde(&self.inner.node_manager.list_utxos()?)?)
     }
 
-    /// Syncs the on-chain wallet and lightning wallet.
-    /// This will update the on-chain wallet with any new
-    /// transactions and update the lightning wallet with
-    /// any channels that have been opened or closed.
-    ///
-    /// This also updates the fee estimates.
-    #[wasm_bindgen]
-    pub async fn sync(&self) -> Result<(), MutinyJsError> {
-        Ok(self.inner.node_manager.sync().await?)
-    }
-
     /// Gets a fee estimate for an average priority transaction.
     /// Value is in sat/vbyte.
     #[wasm_bindgen]


### PR DESCRIPTION
Closes #543

This should hopefully help make it easier for the front end to implement. Now the node manager will manage syncing on it's own.

Also made it only update on-chain fees every 10 minutes instead of every sync. Hopefully this will cause us to not be updating channel state so often and maybe less force closes?