### PR TITLE
Don't keep extra network graph in memory

### DIFF
--- a/mutiny-core/src/gossip.rs
+++ b/mutiny-core/src/gossip.rs
@@ -20,9 +20,9 @@ use crate::storage::MutinyStorage;
 use crate::utils;
 
 pub(crate) const LN_PEER_METADATA_KEY_PREFIX: &str = "ln_peer/";
-pub(crate) const GOSSIP_SYNC_TIME_KEY: &str = "last_sync_timestamp";
-pub(crate) const NETWORK_GRAPH_KEY: &str = "network_graph";
-pub(crate) const PROB_SCORER_KEY: &str = "prob_scorer";
+pub const GOSSIP_SYNC_TIME_KEY: &str = "last_sync_timestamp";
+pub const NETWORK_GRAPH_KEY: &str = "network_graph";
+pub const PROB_SCORER_KEY: &str = "prob_scorer";
 
 struct Gossip {
     pub last_sync_timestamp: u32,

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod storage;
 pub mod test_utils;
 mod utils;
 
+pub use crate::gossip::{GOSSIP_SYNC_TIME_KEY, NETWORK_GRAPH_KEY, PROB_SCORER_KEY};
 pub use crate::keymanager::generate_seed;
 
 use crate::error::MutinyError;


### PR DESCRIPTION
We were keeping the network graph in our in-memory cache when we only need when we first read it and then give it to LDK. This will delete it after we first read it so we don't keep it in memory.