### PR TITLE
Background process error won't panic, more logging

### DIFF
--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -76,14 +76,14 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
         format!("{}_{}", key, self.node_id)
     }
 
-    fn persist_value<W: Writeable>(
+    fn persist_local_storage<W: Writeable>(
         &self,
         key: &str,
         object: &W,
     ) -> Result<(), lightning::io::Error> {
         let key_with_node = self.get_key(key);
         self.storage
-            .set_data(key_with_node, object.encode().to_hex())
+            .set_data(key_with_node, object.encode())
             .map_err(|_| lightning::io::ErrorKind::Other.into())
     }
 
@@ -91,26 +91,12 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
     // that has the concatenated node_id
     fn read_value(&self, _key: &str) -> Result<Vec<u8>, MutinyError> {
         let key = self.get_key(_key);
-        // first try to read as hex, then as array of numbers
-        match self.storage.get_data::<String>(&key) {
-            Ok(Some(value)) => {
-                let value = Vec::from_hex(&value).map_err(|_| {
-                    MutinyError::read_err(MutinyStorageError::Other(anyhow!(
-                        "Failed to deserialize value for key: {key}"
-                    )))
-                })?;
-                Ok(value)
-            }
+        match self.storage.get_data(&key) {
+            Ok(Some(value)) => Ok(value),
             Ok(None) => Err(MutinyError::read_err(MutinyStorageError::Other(anyhow!(
                 "No value found for key: {key}"
             )))),
-            Err(_) => match self.storage.get_data(&key) {
-                Ok(Some(value)) => Ok(value),
-                Ok(None) => Err(MutinyError::read_err(MutinyStorageError::Other(anyhow!(
-                    "No value found for key: {key}"
-                )))),
-                Err(e) => Err(e),
-            },
+            Err(e) => Err(e),
         }
     }
 
@@ -457,7 +443,7 @@ impl<S: MutinyStorage>
         &self,
         channel_manager: &PhantomChannelManager<S>,
     ) -> Result<(), lightning::io::Error> {
-        self.persist_value(CHANNEL_MANAGER_KEY, channel_manager)
+        self.persist_local_storage(CHANNEL_MANAGER_KEY, channel_manager)
     }
 
     fn persist_graph(&self, network_graph: &NetworkGraph) -> Result<(), lightning::io::Error> {
@@ -491,7 +477,7 @@ impl<ChannelSigner: WriteableEcdsaChannelSigner, S: MutinyStorage> Persist<Chann
             funding_txo.txid.to_hex(),
             funding_txo.index
         );
-        match self.persist_value(&key, monitor) {
+        match self.persist_local_storage(&key, monitor) {
             Ok(()) => chain::ChannelMonitorUpdateStatus::Completed,
             Err(_) => chain::ChannelMonitorUpdateStatus::PermanentFailure,
         }
@@ -509,7 +495,7 @@ impl<ChannelSigner: WriteableEcdsaChannelSigner, S: MutinyStorage> Persist<Chann
             funding_txo.txid.to_hex(),
             funding_txo.index
         );
-        match self.persist_value(&key, monitor) {
+        match self.persist_local_storage(&key, monitor) {
             Ok(()) => chain::ChannelMonitorUpdateStatus::Completed,
             Err(_) => chain::ChannelMonitorUpdateStatus::PermanentFailure,
         }


### PR DESCRIPTION
1. Encoding LDK channels is broken when refreshing so I reverted that commit. 
2. An expect with the background processor will wreck everything so I made it log errors instead, will retry on the loop and will log properly what happened. Otherwise panics will not get logged and the opportunitty to persist channel manager will go away. 
3. Logs in greater detail what internal error happens when persisting fails

I reproduced channel manager seldomly failing and got the force closure in https://github.com/MutinyWallet/mutiny-node/issues/556

So then I checked how it would behave if it logs error instead and retries again in a loop. Unless background process never completes successfully again, it should have more opportunities to persist the latest state of the channel manger. 