### PR TITLE
Don't cache bdk keychain

### DIFF
--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-const KEYCHAIN_STORE_KEY: &str = "keychain_store";
+pub const KEYCHAIN_STORE_KEY: &str = "keychain_store";
 pub(crate) const MNEMONIC_KEY: &str = "mnemonic";
 const NODES_KEY: &str = "nodes";
 const AUTH_PROFILES_KEY: &str = "auth_profiles";

--- a/mutiny-wasm/src/indexed_db.rs
+++ b/mutiny-wasm/src/indexed_db.rs
@@ -6,7 +6,7 @@ use lightning::{log_debug, log_error};
 use log::error;
 use mutiny_core::error::{MutinyError, MutinyStorageError};
 use mutiny_core::logging::MutinyLogger;
-use mutiny_core::storage::MutinyStorage;
+use mutiny_core::storage::{MutinyStorage, KEYCHAIN_STORE_KEY};
 use mutiny_core::*;
 use rexie::{ObjectStore, Rexie, TransactionMode};
 use serde::{Deserialize, Serialize};
@@ -228,7 +228,7 @@ impl IndexedDbStorage {
 fn used_once(key: &str) -> bool {
     matches!(
         key,
-        NETWORK_GRAPH_KEY | PROB_SCORER_KEY | GOSSIP_SYNC_TIME_KEY
+        NETWORK_GRAPH_KEY | PROB_SCORER_KEY | GOSSIP_SYNC_TIME_KEY | KEYCHAIN_STORE_KEY
     )
 }
 


### PR DESCRIPTION
this is another thing we only need to read on startup, this should reduce the memory overhead required.