### PR TITLE
After successful broadcast, insert transcation into bdk 

### DIFF
--- a/mutiny-core/src/chain.rs
+++ b/mutiny-core/src/chain.rs
@@ -1,31 +1,38 @@
 use std::sync::Arc;
 
 use crate::esplora::EsploraSyncClient;
-use bdk_macros::maybe_await;
 use bitcoin::{Script, Transaction, Txid};
 use lightning::chain::chaininterface::BroadcasterInterface;
 use lightning::chain::{Filter, WatchedOutput};
-use lightning::log_error;
+use lightning::log_warn;
 use lightning::util::logger::Logger;
 
 use crate::logging::MutinyLogger;
+use crate::onchain::OnChainWallet;
+use crate::storage::MutinyStorage;
 use crate::utils;
 
-pub struct MutinyChain {
+pub struct MutinyChain<S: MutinyStorage> {
     pub tx_sync: Arc<EsploraSyncClient<Arc<MutinyLogger>>>,
+    pub wallet: Arc<OnChainWallet<S>>,
     logger: Arc<MutinyLogger>,
 }
 
-impl MutinyChain {
+impl<S: MutinyStorage> MutinyChain<S> {
     pub(crate) fn new(
         tx_sync: Arc<EsploraSyncClient<Arc<MutinyLogger>>>,
+        wallet: Arc<OnChainWallet<S>>,
         logger: Arc<MutinyLogger>,
     ) -> Self {
-        Self { tx_sync, logger }
+        Self {
+            tx_sync,
+            wallet,
+            logger,
+        }
     }
 }
 
-impl Filter for MutinyChain {
+impl<S: MutinyStorage> Filter for MutinyChain<S> {
     fn register_tx(&self, txid: &Txid, script_pubkey: &Script) {
         self.tx_sync.register_tx(txid, script_pubkey);
     }
@@ -35,15 +42,15 @@ impl Filter for MutinyChain {
     }
 }
 
-impl BroadcasterInterface for MutinyChain {
+impl<S: MutinyStorage> BroadcasterInterface for MutinyChain<S> {
     fn broadcast_transaction(&self, tx: &Transaction) {
-        let blockchain = self.tx_sync.clone();
         let tx_clone = tx.clone();
+        let wallet = self.wallet.clone();
         let logger = self.logger.clone();
         utils::spawn(async move {
-            maybe_await!(blockchain.client().broadcast(&tx_clone)).unwrap_or_else(|_| {
-                log_error!(logger, "failed to broadcast tx! {}", tx_clone.txid())
-            })
+            if let Err(e) = wallet.broadcast_transaction(tx_clone).await {
+                log_warn!(logger, "Error broadcasting transaction: {e}")
+            }
         });
     }
 }

--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -568,7 +568,7 @@ impl<S: MutinyStorage> EventHandler<S> {
             )
             .map_err(|_| anyhow!("Failed to spend spendable outputs"))?;
 
-        self.wallet.blockchain.broadcast(&spending_tx).await?;
+        self.wallet.broadcast_transaction(spending_tx).await?;
 
         Ok(())
     }

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -49,7 +49,7 @@ const FAILED_SPENDABLE_OUTPUT_DESCRIPTOR_KEY: &str = "failed_spendable_outputs";
 
 pub(crate) type PhantomChannelManager<S: MutinyStorage> = LdkChannelManager<
     Arc<ChainMonitor<S>>,
-    Arc<MutinyChain>,
+    Arc<MutinyChain<S>>,
     Arc<PhantomKeysManager<S>>,
     Arc<PhantomKeysManager<S>>,
     Arc<PhantomKeysManager<S>>,
@@ -159,7 +159,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
         &self,
         network: Network,
         chain_monitor: Arc<ChainMonitor<S>>,
-        mutiny_chain: Arc<MutinyChain>,
+        mutiny_chain: Arc<MutinyChain<S>>,
         fee_estimator: Arc<MutinyFeeEstimator<S>>,
         mutiny_logger: Arc<MutinyLogger>,
         keys_manager: Arc<PhantomKeysManager<S>>,
@@ -447,7 +447,7 @@ impl<S: MutinyStorage>
     Persister<
         '_,
         Arc<ChainMonitor<S>>,
-        Arc<MutinyChain>,
+        Arc<MutinyChain<S>>,
         Arc<PhantomKeysManager<S>>,
         Arc<PhantomKeysManager<S>>,
         Arc<PhantomKeysManager<S>>,

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -99,7 +99,7 @@ pub(crate) type MessageHandler<S: MutinyStorage> = LdkMessageHandler<
 pub(crate) type ChainMonitor<S: MutinyStorage> = chainmonitor::ChainMonitor<
     InMemorySigner,
     Arc<dyn Filter + Send + Sync>,
-    Arc<MutinyChain>,
+    Arc<MutinyChain<S>>,
     Arc<MutinyFeeEstimator<S>>,
     Arc<MutinyLogger>,
     Arc<MutinyNodePersister<S>>,
@@ -178,7 +178,7 @@ impl<S: MutinyStorage> Node<S> {
         storage: S,
         gossip_sync: Arc<RapidGossipSync>,
         scorer: Arc<utils::Mutex<ProbScorer>>,
-        chain: Arc<MutinyChain>,
+        chain: Arc<MutinyChain<S>>,
         fee_estimator: Arc<MutinyFeeEstimator<S>>,
         wallet: Arc<OnChainWallet<S>>,
         network: Network,

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -113,12 +113,12 @@ impl MutinyWallet {
     /// Broadcast a transaction to the network.
     /// The transaction is broadcast through the configured esplora server.
     #[wasm_bindgen]
-    pub fn broadcast_transaction(&self, str: String) -> Result<(), MutinyJsError> {
+    pub async fn broadcast_transaction(&self, str: String) -> Result<(), MutinyJsError> {
         let tx_bytes =
             Vec::from_hex(str.as_str()).map_err(|_| MutinyJsError::WalletOperationFailed)?;
         let tx: Transaction =
             deserialize(&tx_bytes).map_err(|_| MutinyJsError::WalletOperationFailed)?;
-        Ok(self.inner.node_manager.broadcast_transaction(&tx)?)
+        Ok(self.inner.node_manager.broadcast_transaction(tx).await?)
     }
 
     /// Returns the mnemonic seed phrase for the wallet.


### PR DESCRIPTION
Closes #569

When opening a channel or sweeping a force close the transaction wouldn't be reflected until we synced because we didn't have BDK finalize the transaction. 

Here we make it so when we broadcast the transaction we insert it into bdk so it is reflected immediately.