### PR TITLE
Handle specific errors from the LSP upon invoice

### DIFF
--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -51,8 +51,15 @@ pub enum MutinyError {
     /// Failed to call on the given LNURL
     #[error("Failed to call on the given LNURL.")]
     LnUrlFailure,
-    #[error("Failed to connect to LSP.")]
-    LspFailure,
+    /// Could not make a request to the LSP.
+    #[error("Failed to make a request to the LSP.")]
+    LspGenericError,
+    /// LSP indicated it could not fund the channel requested.
+    #[error("Failed to request channel from LSP due to funding error.")]
+    LspFundingError,
+    /// LSP indicated it was not connected to the client node.
+    #[error("Failed to have a connection to the LSP node.")]
+    LspConnectionError,
     /// No route for the given target could be found.
     #[error("Failed to find route.")]
     RoutingFailed,

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -910,6 +910,26 @@ impl<S: MutinyStorage> NodeManager<S> {
     }
 
     /// Creates a BIP 21 invoice. This creates a new address and a lightning invoice.
+    /// The lightning invoice may return errors related to the LSP. Check the error and
+    /// fallback to `get_new_address` and warn the user that Lightning is not available.
+    ///
+    /// Errors that might be returned include:
+    ///
+    /// - [`MutinyError::LspGenericError`]: This is returned for various reasons, including if a
+    ///   request to the LSP server fails for any reason, or if the server returns
+    ///   a status other than 500 that can't be parsed into a `ProposalResponse`.
+    ///
+    /// - [`MutinyError::LspFundingError`]: Returned if the LSP server returns an error with
+    ///   a status of 500, indicating an "Internal Server Error", and a message
+    ///   stating "Cannot fund new channel at this time". This means that the LSP cannot support
+    ///   a new channel at this time.
+    ///
+    /// - [`MutinyError::LspConnectionError`]: Returned if the LSP server returns an error with
+    ///   a status of 500, indicating an "Internal Server Error", and a message that starts with
+    ///   "Failed to connect to peer". This means that the LSP is not connected to our node.
+    ///
+    /// If the server returns a status of 500 with a different error message,
+    /// a [`MutinyError::LspGenericError`] is returned.
     pub async fn create_bip21(
         &self,
         amount: Option<u64>,

--- a/mutiny-core/src/redshift.rs
+++ b/mutiny-core/src/redshift.rs
@@ -192,7 +192,7 @@ impl<S: MutinyStorage> RedshiftManager for NodeManager<S> {
                 let node = self.get_node(&node.pubkey).await?;
                 match &node.lsp_client {
                     Some(lsp) => lsp.pubkey,
-                    None => return Err(MutinyError::LspFailure),
+                    None => return Err(MutinyError::LspGenericError),
                 }
             }
         };

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -46,8 +46,15 @@ pub enum MutinyJsError {
     /// Failed to call on the given LNURL
     #[error("Failed to call on the given LNURL.")]
     LnUrlFailure,
-    #[error("Failed to connect to LSP.")]
-    LspFailure,
+    /// Could not make a request to the LSP.
+    #[error("Failed to make a request to the LSP.")]
+    LspGenericError,
+    /// LSP indicated it could not fund the channel requested.
+    #[error("Failed to request channel from LSP due to funding error.")]
+    LspFundingError,
+    /// LSP indicated it was not connected to the client node.
+    #[error("Failed to have a connection to the LSP node.")]
+    LspConnectionError,
     /// Called incorrect lnurl function, eg calling withdraw on a pay lnurl
     #[error("Called incorrect lnurl function.")]
     IncorrectLnUrlFunction,
@@ -133,7 +140,9 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::ReserveAmountError => MutinyJsError::ReserveAmountError,
             MutinyError::InsufficientBalance => MutinyJsError::InsufficientBalance,
             MutinyError::LnUrlFailure => MutinyJsError::LnUrlFailure,
-            MutinyError::LspFailure => MutinyJsError::LspFailure,
+            MutinyError::LspGenericError => MutinyJsError::LspGenericError,
+            MutinyError::LspFundingError => MutinyJsError::LspFundingError,
+            MutinyError::LspConnectionError => MutinyJsError::LspConnectionError,
             MutinyError::RoutingFailed => MutinyJsError::RoutingFailed,
             MutinyError::PeerInfoParseFailed => MutinyJsError::PeerInfoParseFailed,
             MutinyError::ChannelCreationFailed => MutinyJsError::ChannelCreationFailed,

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -168,6 +168,27 @@ impl MutinyWallet {
     }
 
     /// Creates a BIP 21 invoice. This creates a new address and a lightning invoice.
+    /// The lightning invoice may return errors related to the LSP. Check the error and
+    /// fallback to `get_new_address` and warn the user that Lightning is not available.
+    ///
+    ///
+    /// Errors that might be returned include:
+    ///
+    /// - [`MutinyJsError::LspGenericError`]: This is returned for various reasons, including if a
+    ///   request to the LSP server fails for any reason, or if the server returns
+    ///   a status other than 500 that can't be parsed into a `ProposalResponse`.
+    ///
+    /// - [`MutinyJsError::LspFundingError`]: Returned if the LSP server returns an error with
+    ///   a status of 500, indicating an "Internal Server Error", and a message
+    ///   stating "Cannot fund new channel at this time". This means that the LSP cannot support
+    ///   a new channel at this time.
+    ///
+    /// - [`MutinyJsError::LspConnectionError`]: Returned if the LSP server returns an error with
+    ///   a status of 500, indicating an "Internal Server Error", and a message that starts with
+    ///   "Failed to connect to peer". This means that the LSP is not connected to our node.
+    ///
+    /// If the server returns a status of 500 with a different error message,
+    /// a [`MutinyJsError::LspGenericError`] is returned.
     #[wasm_bindgen]
     pub async fn create_bip21(
         &self,


### PR DESCRIPTION
This will give us more indication of what went wrong during invoice creation. The common reasons are because the user is not connected to the LSP or the LSP has ran out of confirmed funds. 

@futurepaul you should review the API logic here. 

The proposed changes I would like `mutiny-web` to do is to check the error on `create_bip21` for an Lsp related error and fall back to `get_new_address` if that's the case. This is so that you may show the user the connection error or lsp funding error, but still allow them to proceed with receiving on chain funds with that warning in mind.

Relies on https://github.com/voltagecloud/lsp-server/pull/138

Related to https://github.com/MutinyWallet/mutiny-web/issues/249