### PR TITLE
Insert broadcasted channels on pending channel event

### DIFF
--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -112,34 +112,39 @@ impl<S: MutinyStorage> EventHandler<S> {
                 };
 
                 let psbt_result = match &params_opt {
-                    None => self.wallet.create_signed_psbt_to_spk(
-                        output_script,
-                        channel_value_satoshis,
-                        None,
-                    ),
-                    Some(params) => {
-                        log_debug!(self.logger, "Opening channel with params: {params:?}");
-                        let psbt = self.wallet.create_sweep_psbt_to_output(
-                            &params.utxos,
+                    None => {
+                        log_warn!(
+                            self.logger,
+                            "WARNING: Could not find channel open params for channel {user_channel_id}"
+                        );
+                        self.wallet.create_signed_psbt_to_spk(
                             output_script,
                             channel_value_satoshis,
-                        );
-
-                        // delete from storage, if it fails, it is fine, just log it.
-                        if let Err(e) = self.persister.delete_channel_open_params(user_channel_id) {
-                            log_warn!(
-                                self.logger,
-                                "ERROR: Could not delete channel open params, but continuing: {e}"
-                            );
+                            None,
+                        )
+                    }
+                    Some(params) => {
+                        log_debug!(self.logger, "Opening channel with params: {params:?}");
+                        if let Some(utxos) = &params.utxos {
+                            self.wallet.create_sweep_psbt_to_output(
+                                utxos,
+                                output_script,
+                                channel_value_satoshis,
+                            )
+                        } else {
+                            self.wallet.create_signed_psbt_to_spk(
+                                output_script,
+                                channel_value_satoshis,
+                                Some(params.sats_per_kw as f32),
+                            )
                         }
-
-                        psbt
                     }
                 };
 
                 let label = format!("LN Channel: {}", counterparty_node_id.to_hex());
                 let labels = params_opt
-                    .and_then(|p| p.labels)
+                    .as_ref()
+                    .and_then(|p| p.labels.clone())
                     .unwrap_or_else(|| vec![label]);
 
                 let psbt = match psbt_result {
@@ -167,16 +172,26 @@ impl<S: MutinyStorage> EventHandler<S> {
                     }
                 };
 
+                let tx = psbt.extract_tx();
+
                 if let Err(e) = self.channel_manager.funding_transaction_generated(
                     &temporary_channel_id,
                     &counterparty_node_id,
-                    psbt.extract_tx(),
+                    tx.clone(),
                 ) {
                     log_error!(
                         self.logger,
                         "ERROR: Could not send funding transaction to channel manager: {e:?}"
                     );
                     return;
+                }
+
+                if let Some(mut params) = params_opt {
+                    params.opening_tx = Some(tx);
+
+                    let _ = self
+                        .persister
+                        .persist_channel_open_params(user_channel_id, params);
                 }
 
                 log_info!(self.logger, "EVENT: FundingGenerationReady success");
@@ -516,6 +531,30 @@ impl<S: MutinyStorage> EventHandler<S> {
                     channel_id.to_hex(),
                     user_channel_id,
                     counterparty_node_id.to_hex());
+
+                if let Ok(Some(params)) = self.persister.get_channel_open_params(user_channel_id) {
+                    if let Some(tx) = params.opening_tx {
+                        if let Err(e) = self
+                            .wallet
+                            .insert_tx(tx, ConfirmationTime::Unconfirmed, None)
+                            .await
+                        {
+                            {
+                                log_warn!(
+                                    self.logger,
+                                    "ERROR: Could not insert opening tx into wallet, but continuing: {e}"
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if let Err(e) = self.persister.delete_channel_open_params(user_channel_id) {
+                    log_warn!(
+                        self.logger,
+                        "ERROR: Could not delete channel open params, but continuing: {e}"
+                    );
+                }
             }
             Event::HTLCIntercepted { .. } => {}
         }

--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -135,7 +135,7 @@ impl<S: MutinyStorage> EventHandler<S> {
                             self.wallet.create_signed_psbt_to_spk(
                                 output_script,
                                 channel_value_satoshis,
-                                Some(params.sats_per_kw as f32),
+                                Some(params.sats_per_vbyte),
                             )
                         }
                     }

--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -8,6 +8,7 @@ use crate::redshift::RedshiftStorage;
 use crate::storage::MutinyStorage;
 use crate::utils::sleep;
 use anyhow::anyhow;
+use bdk::chain::ConfirmationTime;
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::secp256k1::Secp256k1;

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -13,8 +13,8 @@ use crate::utils;
 use anyhow::anyhow;
 use bdk_esplora::esplora_client::AsyncClient;
 use bitcoin::hashes::hex::{FromHex, ToHex};
-use bitcoin::BlockHash;
 use bitcoin::Network;
+use bitcoin::{BlockHash, Transaction};
 use futures::{try_join, TryFutureExt};
 use lightning::chain::channelmonitor::{ChannelMonitor, ChannelMonitorUpdate};
 use lightning::chain::keysinterface::{
@@ -422,9 +422,12 @@ fn channel_open_params_key(id: u128) -> String {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct ChannelOpenParams {
     pub sats_per_kw: u32,
-    pub utxos: Vec<bitcoin::OutPoint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub utxos: Option<Vec<bitcoin::OutPoint>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opening_tx: Option<Transaction>,
 }
 
 fn payment_key(inbound: bool, payment_hash: &PaymentHash) -> String {

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -421,7 +421,7 @@ fn channel_open_params_key(id: u128) -> String {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct ChannelOpenParams {
-    pub sats_per_kw: u32,
+    pub sats_per_vbyte: f32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub utxos: Option<Vec<bitcoin::OutPoint>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1104,6 +1104,10 @@ impl<S: MutinyStorage> Node<S> {
     ) -> Result<OutPoint, MutinyError> {
         let start = utils::now().as_secs();
         loop {
+            if self.stop.load(Ordering::Relaxed) {
+                return Err(MutinyError::NotRunning);
+            }
+
             // We will get a channel closure event if the peer rejects the channel
             // todo return closure reason to user
             if let Ok(Some(_closure)) = self.persister.get_channel_closure(user_channel_id) {
@@ -1116,9 +1120,32 @@ impl<S: MutinyStorage> Node<S> {
                 .find(|c| c.user_channel_id == user_channel_id);
 
             if let Some(outpoint) = channel.and_then(|c| c.funding_txo) {
-                // TODO wait until Event::ChannelPending after funding tx generated
-                sleep(1_000).await;
-                return Ok(outpoint.into_bitcoin_outpoint());
+                let outpoint = outpoint.into_bitcoin_outpoint();
+                log_info!(self.logger, "Channel funding tx found: {}", outpoint);
+                log_debug!(self.logger, "Waiting for Channel Pending event");
+                loop {
+                    // we delete the channel open params on channel pending event
+                    // so if we can't find them, we know the channel is pending
+                    // and we can safely return
+                    if self
+                        .persister
+                        .get_channel_open_params(user_channel_id)
+                        .map(|p| p.is_none())
+                        .unwrap_or(false)
+                    {
+                        return Ok(outpoint);
+                    }
+
+                    let now = utils::now().as_secs();
+                    if now - start > timeout {
+                        return Err(MutinyError::ChannelCreationFailed);
+                    }
+
+                    if self.stop.load(Ordering::Relaxed) {
+                        return Err(MutinyError::NotRunning);
+                    }
+                    sleep(250).await;
+                }
             }
 
             let now = utils::now().as_secs();
@@ -1134,6 +1161,7 @@ impl<S: MutinyStorage> Node<S> {
         &self,
         pubkey: PublicKey,
         amount_sat: u64,
+        fee_rate: Option<f32>,
         user_channel_id: Option<u128>,
     ) -> Result<u128, MutinyError> {
         let mut config = default_user_config();
@@ -1152,6 +1180,25 @@ impl<S: MutinyStorage> Node<S> {
             getrandom::getrandom(&mut user_channel_id_bytes).unwrap();
             u128::from_be_bytes(user_channel_id_bytes)
         });
+
+        let sats_per_kw = if let Some(sats_vbyte) = fee_rate {
+            // convert to sats per kw
+            (sats_vbyte * 250.0) as u32
+        } else {
+            self.wallet
+                .fees
+                .get_est_sat_per_1000_weight(ConfirmationTarget::Normal)
+        };
+
+        // save params to db
+        let params = ChannelOpenParams {
+            sats_per_kw,
+            utxos: None,
+            labels: None,
+            opening_tx: None,
+        };
+        self.persister
+            .persist_channel_open_params(user_channel_id, params)?;
 
         match self.channel_manager.create_channel(
             pubkey,
@@ -1181,11 +1228,12 @@ impl<S: MutinyStorage> Node<S> {
         &self,
         pubkey: PublicKey,
         amount_sat: u64,
+        fee_rate: Option<f32>,
         user_channel_id: Option<u128>,
         timeout: u64,
     ) -> Result<OutPoint, MutinyError> {
         let init = self
-            .init_open_channel(pubkey, amount_sat, user_channel_id)
+            .init_open_channel(pubkey, amount_sat, fee_rate, user_channel_id)
             .await?;
 
         self.await_chan_funding_tx(init, &pubkey, timeout).await
@@ -1247,8 +1295,9 @@ impl<S: MutinyStorage> Node<S> {
         // save params to db
         let params = ChannelOpenParams {
             sats_per_kw,
-            utxos: utxos.to_vec(),
+            utxos: Some(utxos.to_vec()),
             labels: None,
+            opening_tx: None,
         };
         self.persister
             .persist_channel_open_params(user_channel_id, params)?;

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1667,6 +1667,7 @@ impl<S: MutinyStorage> NodeManager<S> {
         from_node: &PublicKey,
         to_pubkey: Option<PublicKey>,
         amount: u64,
+        fee_rate: Option<f32>,
         user_channel_id: Option<u128>,
     ) -> Result<MutinyChannel, MutinyError> {
         let node = self.get_node(from_node).await?;
@@ -1682,7 +1683,7 @@ impl<S: MutinyStorage> NodeManager<S> {
         };
 
         let outpoint = node
-            .open_channel_with_timeout(to_pubkey, amount, user_channel_id, 60)
+            .open_channel_with_timeout(to_pubkey, amount, fee_rate, user_channel_id, 60)
             .await?;
 
         let all_channels = node.channel_manager.list_channels();

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -72,12 +72,14 @@ impl<S: MutinyStorage> OnChainWallet<S> {
             return Err(MutinyError::Other(anyhow!(
                 "Failed to broadcast transaction ({txid}): {e}"
             )));
-        } else if let Err(e) = self
-            .insert_tx(tx, ConfirmationTime::Unconfirmed, None)
-            .await
-        {
-            log_warn!(self.logger, "ERROR: Could not sync broadcasted tx ({txid}), will be synced in next iteration: {e:?}");
         }
+        // todo bring back after bdk alpha1
+        // else if let Err(e) = self
+        //     .insert_tx(tx, ConfirmationTime::Unconfirmed, None)
+        //     .await
+        // {
+        //     log_warn!(self.logger, "ERROR: Could not sync broadcasted tx ({txid}), will be synced in next iteration: {e:?}");
+        // }
 
         Ok(())
     }
@@ -320,7 +322,9 @@ impl<S: MutinyStorage> OnChainWallet<S> {
         let raw_transaction = psbt.extract_tx();
         let txid = raw_transaction.txid();
 
-        self.broadcast_transaction(raw_transaction).await?;
+        self.broadcast_transaction(raw_transaction.clone()).await?;
+        self.insert_tx(raw_transaction, ConfirmationTime::Unconfirmed, None)
+            .await?;
         log_debug!(self.logger, "Transaction broadcast! TXID: {txid}");
         Ok(txid)
     }
@@ -372,7 +376,9 @@ impl<S: MutinyStorage> OnChainWallet<S> {
         let raw_transaction = psbt.extract_tx();
         let txid = raw_transaction.txid();
 
-        self.broadcast_transaction(raw_transaction).await?;
+        self.broadcast_transaction(raw_transaction.clone()).await?;
+        self.insert_tx(raw_transaction, ConfirmationTime::Unconfirmed, None)
+            .await?;
         log_debug!(self.logger, "Transaction broadcast! TXID: {txid}");
         Ok(txid)
     }

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -15,7 +15,7 @@ use bitcoin::{Address, Network, OutPoint, Script, Transaction, Txid};
 use esplora_client::AsyncClient;
 use lightning::chain::chaininterface::{ConfirmationTarget, FeeEstimator};
 use lightning::util::logger::Logger;
-use lightning::{log_debug, log_error, log_warn};
+use lightning::{log_debug, log_error};
 
 use crate::error::MutinyError;
 use crate::fees::MutinyFeeEstimator;

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -640,6 +640,7 @@ impl MutinyWallet {
         from_node: String,
         to_pubkey: Option<String>,
         amount: u64,
+        fee_rate: Option<f32>,
     ) -> Result<MutinyChannel, MutinyJsError> {
         let from_node = PublicKey::from_str(&from_node)?;
 
@@ -653,7 +654,7 @@ impl MutinyWallet {
         Ok(self
             .inner
             .node_manager
-            .open_channel(&from_node, to_pubkey, amount, None)
+            .open_channel(&from_node, to_pubkey, amount, fee_rate, None)
             .await?
             .into())
     }


### PR DESCRIPTION
We originally added calling `insert_tx` when we would broadcast to fix it when we'd open a channel and our on-chain balance wouldn't update immedaitely. However, this is causing issues with other txs being inserted into bdk on broadcast. So instead we change it to not broadcast on broadcast while this issue exists in bdk and use the channel open params to save the tx and insert it on the channel pending event. With this we can also wait until the channel pending event happens by waiting for the channel opening params are deleted.