### PR TITLE
wasm opt level z instead of s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 # Tell `rustc` to optimize for small code size.
 [profile.release.package.mutiny-core]
-opt-level = "s"
+opt-level = "z"
 
 [profile.release.package.mutiny-wasm]
-opt-level = "s"
+opt-level = "z"

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -50,7 +50,7 @@ mutiny-core = { path = "../mutiny-core", features = ["test-utils"] }
 wasm-bindgen-test = "0.3.33"
 
 [features]
-default = ["console_error_panic_hook"]
+default = [ ]
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = true


### PR DESCRIPTION
This change should take it from 8.9M to 8.3M. 

If we add in

`wasm-opt -Oz -o output.wasm input.wasm` to our CICD, we can get down to 8.2M but that's not much of an improvement. 