### PR TITLE
Ensure rand is used for rust-bitcoin

### DIFF
--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -12,11 +12,11 @@ homepage = "https://mutinywallet.com"
 repository = "https://github.com/mutinywallet/mutiny-node"
 
 [dependencies]
-lnurl-rs = { version = "0.2.4", default-features = false, features = ["async", "async-https"] }
+lnurl-rs = { version = "=0.2.4", default-features = false, features = ["async", "async-https"] }
 
 cfg-if = "1.0.0"
 bip39 = { version = "2.0.0" }
-bitcoin = { version = "0.29.2", default-features = false, features = ["serde", "secp-recovery"] }
+bitcoin = { version = "0.29.2", default-features = false, features = ["serde", "secp-recovery", "rand"] }
 bdk = { git = "https://github.com/MutinyWallet/bdk.git", branch = "mutiny-no-std", default-features = false }
 bdk_esplora = { git = "https://github.com/MutinyWallet/bdk.git", branch = "mutiny-no-std", default-features = false, features = ["async-https"] }
 bdk-macros = "0.6.0"

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -23,7 +23,7 @@ wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.33"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bitcoin = { version = "0.29.2", default-features = false, features = ["serde", "secp-recovery"] }
+bitcoin = { version = "0.29.2", default-features = false, features = ["serde", "secp-recovery", "rand"] }
 lightning = { version = "0.0.115", default-features = false, features = ["no-std"] }
 lightning-invoice = { version = "0.23", default-features = false, features = ["no-std"] }
 thiserror = "1.0"


### PR DESCRIPTION
BDK is one of the only libraries helping ensure that the `rand` feature of `rust-bitcoin` uses `secp256k1/rand` which uses `rand` which uses `getrandom`, and since we turn on `js` for `getrandom` for wasm, that should use the web crypto api for generating randomness for all of those packages. Perhaps it wouldn't compile otherwise, but think it's good to put in there to ensure that. 