### PR TITLE
Properly handle failed channel opens

### DIFF
--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -452,6 +452,13 @@ impl<S: MutinyStorage> EventHandler<S> {
                 reason,
                 user_channel_id,
             } => {
+                // if we still have channel open params, then it was just a failed channel open
+                // we should not persist this as a closed channel and just delete the channel open params
+                if let Ok(Some(_)) = self.persister.get_channel_open_params(user_channel_id) {
+                    let _ = self.persister.delete_channel_open_params(user_channel_id);
+                    return;
+                };
+
                 log_debug!(
                     self.logger,
                     "EVENT: Channel {} closed due to: {:?}",


### PR DESCRIPTION
Closes #628

When a channel fails to open we call `force_close_without_broadcasting_txn` to get it out of our channel manager. This creates a channel closed event that we save. This changes so we don't do that and will just skip saving the channel closed event.