### PR TITLE
Add subscription client

### DIFF
--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -60,6 +60,12 @@ pub enum MutinyError {
     /// LSP indicated it was not connected to the client node.
     #[error("Failed to have a connection to the LSP node.")]
     LspConnectionError,
+    /// Subscription Client Not Configured
+    #[error("Subscription Client Not Configured")]
+    SubscriptionClientNotConfigured,
+    /// Invalid Arguments were given
+    #[error("Invalid Arguments were given")]
+    InvalidArgumentsError,
     /// No route for the given target could be found.
     #[error("Failed to find route.")]
     RoutingFailed,

--- a/mutiny-core/src/subscription.rs
+++ b/mutiny-core/src/subscription.rs
@@ -1,0 +1,129 @@
+use std::sync::Arc;
+
+use lightning::log_error;
+use lightning::util::logger::*;
+use reqwest::{Method, StatusCode, Url};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    auth::MutinyAuthClient, error::MutinyError, logging::MutinyLogger, nodemanager::Plan,
+    storage::MutinyStorage,
+};
+
+pub(crate) struct MutinySubscriptionClient<S: MutinyStorage> {
+    auth_client: Arc<MutinyAuthClient<S>>,
+    url: String,
+    logger: Arc<MutinyLogger>,
+}
+
+impl<S: MutinyStorage> MutinySubscriptionClient<S> {
+    pub(crate) fn new(
+        auth_client: Arc<MutinyAuthClient<S>>,
+        url: String,
+        logger: Arc<MutinyLogger>,
+    ) -> Self {
+        Self {
+            auth_client,
+            url,
+            logger,
+        }
+    }
+
+    pub async fn check_subscribed(&self) -> Result<Option<u64>, MutinyError> {
+        let url = Url::parse(&format!("{}/v1/check-subscribed", self.url)).map_err(|e| {
+            log_error!(self.logger, "Error parsing check subscribed url: {e}");
+            MutinyError::ConnectionFailed
+        })?;
+        let res = self
+            .auth_client
+            .request(Method::GET, url, None)
+            .await?
+            .json::<CheckSubscribedResponse>()
+            .await
+            .map_err(|e| {
+                log_error!(self.logger, "Error parsing subscribe response: {e}");
+                MutinyError::ConnectionFailed
+            })?;
+        if let Some(expired) = res.expired_date {
+            Ok(Some(expired))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn get_plans(&self) -> Result<Vec<Plan>, MutinyError> {
+        let url = Url::parse(&format!("{}/v1/plans", self.url)).map_err(|e| {
+            log_error!(self.logger, "Error parsing plan url: {e}");
+            MutinyError::ConnectionFailed
+        })?;
+        let res = self
+            .auth_client
+            .request(Method::GET, url, None)
+            .await?
+            .json::<Vec<Plan>>()
+            .await
+            .map_err(|e| {
+                log_error!(self.logger, "Error parsing plans: {e}");
+                MutinyError::ConnectionFailed
+            })?;
+
+        Ok(res)
+    }
+
+    pub async fn subscribe_to_plan(&self, id: u8) -> Result<String, MutinyError> {
+        let url = Url::parse(&format!("{}/v1/plans/{}/subscribe", self.url, id)).map_err(|e| {
+            log_error!(self.logger, "Error parsing subscribe url: {e}");
+            MutinyError::ConnectionFailed
+        })?;
+        let res = self
+            .auth_client
+            .request(Method::POST, url, None)
+            .await?
+            .json::<UserInvoiceResponse>()
+            .await
+            .map_err(|e| {
+                log_error!(self.logger, "Error parsing subscription invoice: {e}");
+                MutinyError::ConnectionFailed
+            })?;
+
+        Ok(res.inv)
+    }
+
+    pub async fn submit_nwc(&self, wallet_connect_string: String) -> Result<(), MutinyError> {
+        let url = Url::parse(&format!("{}/v1/wallet-connect", self.url)).map_err(|e| {
+            log_error!(self.logger, "Error parsing wallet connect url: {e}");
+            MutinyError::ConnectionFailed
+        })?;
+        let body = serde_json::to_value(WalletConnectRequest {
+            wallet_connect_string,
+        })?;
+
+        let res = self
+            .auth_client
+            .request(Method::POST, url, Some(body))
+            .await?;
+
+        match res.status() {
+            StatusCode::OK => Ok(()), // If status is 200 OK, return Ok(()).
+            status => {
+                log_error!(self.logger, "Unexpected status code: {status}");
+                Err(MutinyError::ConnectionFailed)
+            }
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CheckSubscribedResponse {
+    pub expired_date: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UserInvoiceResponse {
+    inv: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct WalletConnectRequest {
+    wallet_connect_string: String,
+}

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -55,6 +55,12 @@ pub enum MutinyJsError {
     /// LSP indicated it was not connected to the client node.
     #[error("Failed to have a connection to the LSP node.")]
     LspConnectionError,
+    /// Subscription Client Not Configured
+    #[error("Subscription Client Not Configured")]
+    SubscriptionClientNotConfigured,
+    /// When an invalid parameter has been passed in by the user.
+    #[error("Invalid Parameter")]
+    InvalidParameter,
     /// Called incorrect lnurl function, eg calling withdraw on a pay lnurl
     #[error("Called incorrect lnurl function.")]
     IncorrectLnUrlFunction,
@@ -163,6 +169,10 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::BadAmountError => MutinyJsError::BadAmountError,
             MutinyError::BitcoinPriceError => MutinyJsError::BitcoinPriceError,
             MutinyError::Other(_) => MutinyJsError::UnknownError,
+            MutinyError::SubscriptionClientNotConfigured => {
+                MutinyJsError::SubscriptionClientNotConfigured
+            }
+            MutinyError::InvalidArgumentsError => MutinyJsError::InvalidArgumentsError,
         }
     }
 }

--- a/mutiny-wasm/src/models.rs
+++ b/mutiny-wasm/src/models.rs
@@ -889,3 +889,28 @@ impl From<nostr::nwc::PendingNwcInvoice> for PendingNwcInvoice {
         }
     }
 }
+
+// This is a subscription plan for Mutiny+
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
+#[wasm_bindgen]
+pub struct Plan {
+    pub id: u8,
+    pub amount_sat: u64,
+}
+
+#[wasm_bindgen]
+impl Plan {
+    #[wasm_bindgen(getter)]
+    pub fn value(&self) -> JsValue {
+        JsValue::from_serde(&serde_json::to_value(self).unwrap()).unwrap()
+    }
+}
+
+impl From<nodemanager::Plan> for Plan {
+    fn from(m: nodemanager::Plan) -> Self {
+        Plan {
+            id: m.id,
+            amount_sat: m.amount_sat,
+        }
+    }
+}


### PR DESCRIPTION
This adds 4 APIs relating to the subscription client: 

```rust
    /// Checks whether or not the user is subscribed to Mutiny+.
    ///
    /// Returns None if there's no subscription at all.
    /// Returns Some(u64) for their unix expiration timestamp, which may be in the
    /// past or in the future, depending on whether or not it is currently active.
    #[wasm_bindgen]
    pub async fn check_subscribed(&self) -> Result<Option<u64>, MutinyJsError> {
        Ok(self.inner.node_manager.check_subscribed().await?)
    }

    /// Gets the subscription plans for Mutiny+ subscriptions
    #[wasm_bindgen]
    pub async fn get_subscription_plans(&self) -> Result<JsValue /* Vec<Plan> */, MutinyJsError> {
        let plans = self.inner.node_manager.get_subscription_plans().await?;

        Ok(JsValue::from_serde(&plans)?)
    }

    /// Subscribes to a Mutiny+ plan with a specific plan id.
    ///
    /// Returns a lightning invoice so that the plan can be paid for to start it.
    #[wasm_bindgen]
    pub async fn subscribe_to_plan(&self, id: u8) -> Result<MutinyInvoice, MutinyJsError> {
        Ok(self.inner.node_manager.subscribe_to_plan(id).await?.into())
    }

    /// Pay the subscription invoice. This will post a NWC automatically afterwards.
    pub async fn pay_subscription_invoice(&self, inv: &Invoice) -> Result<(), MutinyJsError> {
        Ok(self.inner.pay_subscription_invoice(inv).await?.into())
    }
```

Depends on https://github.com/MutinyWallet/subscriptions-api/pull/6

Only tested the plans API so far but the rest should work. 

Requires a new `subscription_url` to be passed in from the frontend for `node_manager`. 