### PR TITLE
Send payjoin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bip21"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9532c632b068e45a478f5e309126b6e2ec1dbf0bbd327b73836f33d9a43ede"
+dependencies = [
+ "bitcoin 0.30.1",
+ "percent-encoding-rfc3986",
+]
+
+[[package]]
 name = "bip39"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +264,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e99ff7289b20a7385f66a0feda78af2fc119d28fb56aea8886a9cd0a4abdd75"
 dependencies = [
+ "base64 0.13.1",
  "bech32",
  "bitcoin-private",
  "bitcoin_hashes 0.12.0",
@@ -1209,6 +1220,7 @@ dependencies = [
  "mockall",
  "nostr",
  "nostr-sdk",
+ "payjoin",
  "pbkdf2",
  "proc-macro2",
  "reqwest",
@@ -1245,6 +1257,7 @@ dependencies = [
  "mutiny-core",
  "nostr",
  "once_cell",
+ "payjoin",
  "rexie",
  "serde",
  "serde_json",
@@ -1441,6 +1454,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "payjoin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac532e6caa3a192dd6017a88446c2a1014d31b66cc68f04c584a846a4cb0373"
+dependencies = [
+ "bip21",
+ "bitcoin 0.30.1",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1482,12 @@ name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "percent-encoding-rfc3986"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3637c05577168127568a64e9dc5a6887da720efef07b3d9472d45f63ab191166"
 
 [[package]]
 name = "pharos"

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -40,6 +40,7 @@ cbc = { version = "0.1", features = ["alloc"] }
 aes = { version = "0.8" }
 jwt-compact = { version = "0.8.0-beta.1", features = ["es256k"] }
 argon2 = { version = "0.5.0", features = ["password-hash", "alloc"] }
+payjoin = { version = "0.10.0", features = ["send", "base64"] }
 
 base64 = "0.13.0"
 pbkdf2 = "0.11"

--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -141,6 +141,15 @@ pub enum MutinyError {
     /// Cannot change password to the same password
     #[error("Cannot change password to the same password.")]
     SamePassword,
+    /// Payjoin request creation failed.
+    #[error("Failed to create payjoin request.")]
+    PayjoinCreateRequest,
+    /// Payjoin response validation failed.
+    #[error("Failed to validate payjoin response.")]
+    PayjoinValidateResponse(payjoin::send::ValidationError),
+    /// Payjoin configuration error
+    #[error("Payjoin configuration failed.")]
+    PayjoinConfigError,
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -444,5 +453,17 @@ impl From<nostr::nips::nip04::Error> for MutinyError {
 impl From<nostr::event::builder::Error> for MutinyError {
     fn from(_e: nostr::event::builder::Error) -> Self {
         Self::NostrError
+    }
+}
+
+impl From<payjoin::send::CreateRequestError> for MutinyError {
+    fn from(_e: payjoin::send::CreateRequestError) -> Self {
+        Self::PayjoinCreateRequest
+    }
+}
+
+impl From<payjoin::send::ValidationError> for MutinyError {
+    fn from(e: payjoin::send::ValidationError) -> Self {
+        Self::PayjoinValidateResponse(e)
     }
 }

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -40,6 +40,7 @@ getrandom = { version = "0.2", features = ["js"] }
 futures = "0.3.25"
 urlencoding = "2.1.2"
 once_cell = "1.18.0"
+payjoin = { version = "0.10.0", features = ["send", "base64"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -141,6 +141,15 @@ pub enum MutinyJsError {
     /// Cannot change password to the same password
     #[error("Cannot change password to the same password.")]
     SamePassword,
+    /// Payjoin request creation failed.
+    #[error("Failed to create payjoin request.")]
+    PayjoinCreateRequest,
+    /// Payjoin response validation failed.
+    #[error("Failed to validate payjoin response.")]
+    PayjoinValidateResponse,
+    /// Payjoin configuration error
+    #[error("Payjoin configuration failed.")]
+    PayjoinConfigError,
     /// Unknown error.
     #[error("Unknown Error")]
     UnknownError,
@@ -194,6 +203,9 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::InvalidArgumentsError => MutinyJsError::InvalidArgumentsError,
             MutinyError::LspAmountTooHighError => MutinyJsError::LspAmountTooHighError,
             MutinyError::NetworkMismatch => MutinyJsError::NetworkMismatch,
+            MutinyError::PayjoinConfigError => MutinyJsError::PayjoinConfigError,
+            MutinyError::PayjoinCreateRequest => MutinyJsError::PayjoinCreateRequest,
+            MutinyError::PayjoinValidateResponse(_) => MutinyJsError::PayjoinValidateResponse,
         }
     }
 }


### PR DESCRIPTION
Here's an outline of what a payjoin implementation might look like. There are a few dangling pieces but the bulk of the happy path is here.

- [-] ~display [BIP 78 well-known errors](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#user-content-Receivers_well_known_errors) in UI and log the rest~ Errors are only logged but no json error from the receiver is parsed into an error to Display yet. Wait for library to update https://github.com/payjoin/rust-payjoin/pull/110 as in this design users will not be phished by an undisplayed message.
- [x] ensure BDK will sign & finalize an actual payjoin response
- [x] Test success case with[ mutiny-web UI draft](https://github.com/MutinyWallet/mutiny-web/pull/572)

A mutinynet payjoin receiver is live and funded when you're ready to test this out by pulling a new payjoin bip21 from https://mutiny.payjoin.org:4433/bip21

Note, this version of payjoin depends on rust-bitcoin v0.30.0 to use the new version of bip21 that disables default features for mutiny. So it duplicates that dependency until Mutiny upgrades.

tag #194, but I don't think it closes it. Send is 1/2 of the equation.