### PR TITLE
Move VSS into mutiny-core

### DIFF
--- a/mutiny-core/src/labels.rs
+++ b/mutiny-core/src/labels.rs
@@ -291,13 +291,13 @@ impl<S: MutinyStorage> LabelStorage for S {
         let contact = self.get_contact(&id)?;
         if let Some(mut contact) = contact {
             contact.archived = Some(true);
-            self.set(get_contact_key(&id), contact, None)?;
+            self.set_data(get_contact_key(&id), contact, None)?;
         }
         Ok(())
     }
 
     fn edit_contact(&self, id: impl AsRef<str>, contact: Contact) -> Result<(), MutinyError> {
-        self.set(get_contact_key(&id), contact, None)
+        self.set_data(get_contact_key(&id), contact, None)
     }
 
     fn get_tag_items(&self) -> Result<Vec<TagItem>, MutinyError> {

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -159,15 +159,16 @@ pub trait MutinyStorage: Clone + Sized + 'static {
     {
         let keys = self.scan_keys(prefix, suffix)?;
 
-        Ok(keys
-            .into_iter()
-            .filter_map(|key| {
-                self.get_data(&key)
-                    .ok()
-                    .flatten()
-                    .map(|value: T| (key, value))
-            })
-            .collect())
+        let mut map = HashMap::with_capacity(keys.len());
+
+        for key in keys {
+            let kv = self.get_data::<T>(&key)?;
+            if let Some(v) = kv {
+                map.insert(key, v);
+            }
+        }
+
+        Ok(map)
     }
 
     /// Insert a mnemonic into the storage

--- a/mutiny-core/src/vss.rs
+++ b/mutiny-core/src/vss.rs
@@ -14,7 +14,7 @@ pub struct MutinyVssClient {
     auth_client: Arc<MutinyAuthClient>,
     url: String,
     encryption_key: SecretKey,
-    logger: Arc<MutinyLogger>,
+    pub logger: Arc<MutinyLogger>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
Closes #652

To fix the backwards compatibility I had to change the channel monitor encoding (luckily we wanted to get this to hex). This _should_ make it so worst case that if a user with a password never opens to get the the update, they will get a restore with a force close.

We should heavily test this