### PR TITLE
Prevent multiple devices with lock

### DIFF
--- a/mutiny-core/src/fees.rs
+++ b/mutiny-core/src/fees.rs
@@ -208,7 +208,7 @@ mod test {
 
     #[cfg(not(target_arch = "wasm32"))]
     async fn create_fee_estimator() -> MutinyFeeEstimator<MemoryStorage> {
-        let storage = MemoryStorage::new(None, None);
+        let storage = MemoryStorage::default();
         let esplora = Arc::new(
             Builder::new("https://mutinynet.com/api")
                 .build_async()

--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -268,7 +268,7 @@ mod tests {
         );
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let db = MemoryStorage::new(Some(pass), Some(cipher));
+        let db = MemoryStorage::new(Some(pass), Some(cipher), None);
         let logger = Arc::new(MutinyLogger::default());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -74,6 +74,7 @@ pub struct MutinyWalletConfig {
     auth_client: Option<Arc<MutinyAuthClient>>,
     subscription_url: Option<String>,
     do_not_connect_peers: bool,
+    skip_device_lock: bool,
 }
 
 impl MutinyWalletConfig {
@@ -87,6 +88,7 @@ impl MutinyWalletConfig {
         lsp_url: Option<String>,
         auth_client: Option<Arc<MutinyAuthClient>>,
         subscription_url: Option<String>,
+        skip_device_lock: bool,
     ) -> Self {
         Self {
             xprivkey,
@@ -99,6 +101,7 @@ impl MutinyWalletConfig {
             auth_client,
             subscription_url,
             do_not_connect_peers: false,
+            skip_device_lock,
         }
     }
 
@@ -396,7 +399,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher));
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfig::new(
             xpriv,
@@ -408,6 +411,7 @@ mod tests {
             None,
             None,
             None,
+            false,
         );
         let mw = MutinyWallet::new(storage.clone(), config)
             .await
@@ -424,7 +428,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher));
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfig::new(
             xpriv,
@@ -436,6 +440,7 @@ mod tests {
             None,
             None,
             None,
+            false,
         );
         let mut mw = MutinyWallet::new(storage.clone(), config)
             .await
@@ -457,7 +462,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher));
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
 
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfig::new(
@@ -470,6 +475,7 @@ mod tests {
             None,
             None,
             None,
+            false,
         );
         let mut mw = MutinyWallet::new(storage.clone(), config)
             .await
@@ -493,7 +499,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher));
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfig::new(
             xpriv,
@@ -505,6 +511,7 @@ mod tests {
             None,
             None,
             None,
+            false,
         );
         let mw = MutinyWallet::new(storage.clone(), config)
             .await
@@ -515,7 +522,7 @@ mod tests {
         // create a second mw and make sure it has a different seed
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage2 = MemoryStorage::new(Some(pass), Some(cipher));
+        let storage2 = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage2.clone()));
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &[0; 32]).unwrap();
         let mut config2 = MutinyWalletConfig::new(
@@ -528,6 +535,7 @@ mod tests {
             None,
             None,
             None,
+            false,
         );
         let mw2 = MutinyWallet::new(storage2.clone(), config2.clone())
             .await
@@ -541,7 +549,7 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage3 = MemoryStorage::new(Some(pass), Some(cipher));
+        let storage3 = MemoryStorage::new(Some(pass), Some(cipher), None);
         MutinyWallet::restore_mnemonic(storage3.clone(), mnemonic.clone())
             .await
             .expect("mutiny wallet should restore");

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -117,7 +117,7 @@ impl MutinyWalletConfig {
 /// bitcoin and the lightning functionality.
 pub struct MutinyWallet<S: MutinyStorage> {
     config: MutinyWalletConfig,
-    storage: S,
+    pub storage: S,
     pub node_manager: Arc<NodeManager<S>>,
     pub nostr: Arc<NostrManager<S>>,
 }

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -514,7 +514,7 @@ mod test {
         let xprivkey =
             ExtendedPrivKey::new_master(Network::Bitcoin, &mnemonic.to_seed("")).unwrap();
 
-        let storage = MemoryStorage::new(None, None);
+        let storage = MemoryStorage::new(None, None, None);
 
         NostrManager::from_mnemonic(xprivkey, storage).unwrap()
     }

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -568,7 +568,7 @@ mod tests {
         );
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let db = MemoryStorage::new(Some(pass), Some(cipher));
+        let db = MemoryStorage::new(Some(pass), Some(cipher), None);
         let logger = Arc::new(MutinyLogger::default());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -1,8 +1,8 @@
 use crate::encrypt::{decrypt_with_password, encrypt, encryption_key_from_pass, Cipher};
 use crate::error::{MutinyError, MutinyStorageError};
 use crate::ldkstorage::CHANNEL_MANAGER_KEY;
-use crate::nodemanager::NodeStorage;
-use crate::utils::spawn;
+use crate::nodemanager::{NodeStorage, DEVICE_LOCK_INTERVAL_SECS};
+use crate::utils::{now, spawn};
 use crate::vss::{MutinyVssClient, VssKeyValueItem};
 use bdk::chain::{Append, PersistBackend};
 use bip39::Mnemonic;
@@ -12,12 +12,15 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use uuid::Uuid;
 
 pub const KEYCHAIN_STORE_KEY: &str = "bdk_keychain";
 pub(crate) const MNEMONIC_KEY: &str = "mnemonic";
 pub const NODES_KEY: &str = "nodes";
 const FEE_ESTIMATES_KEY: &str = "fee_estimates";
 const FIRST_SYNC_KEY: &str = "first_sync";
+pub(crate) const DEVICE_ID_KEY: &str = "device_id";
+pub const DEVICE_LOCK_KEY: &str = "device_lock";
 
 fn needs_encryption(key: &str) -> bool {
     match key {
@@ -67,6 +70,22 @@ pub fn decrypt_value(
 pub struct VersionedValue {
     pub version: u32,
     pub value: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeviceLock {
+    pub time: u32,
+    pub device: String,
+}
+
+impl DeviceLock {
+    /// Check if the device is locked
+    /// This is determined if the time is less than 2 minutes ago
+    pub fn is_locked(&self, id: &str) -> bool {
+        let now = now().as_secs();
+        let diff = now - self.time as u64;
+        diff < DEVICE_LOCK_INTERVAL_SECS * 2 && self.device != id
+    }
 }
 
 pub trait MutinyStorage: Clone + Sized + 'static {
@@ -269,6 +288,34 @@ pub trait MutinyStorage: Clone + Sized + 'static {
     fn set_done_first_sync(&self) -> Result<(), MutinyError> {
         self.set_data(FIRST_SYNC_KEY, true, None)
     }
+
+    fn get_device_id(&self) -> Result<String, MutinyError> {
+        match self.get_data(DEVICE_ID_KEY)? {
+            Some(id) => Ok(id),
+            None => {
+                let new_id = Uuid::new_v4().to_string();
+                self.set_data(DEVICE_ID_KEY, &new_id, None)?;
+                Ok(new_id)
+            }
+        }
+    }
+
+    fn get_device_lock(&self) -> Result<Option<DeviceLock>, MutinyError> {
+        self.get_data(DEVICE_LOCK_KEY)
+    }
+
+    fn set_device_lock(&self) -> Result<(), MutinyError> {
+        let device = self.get_device_id()?;
+        if let Some(lock) = self.get_device_lock()? {
+            if lock.is_locked(&device) {
+                return Err(MutinyError::AlreadyRunning);
+            }
+        }
+
+        let time = now().as_secs() as u32;
+        let lock = DeviceLock { time, device };
+        self.set_data(DEVICE_LOCK_KEY, lock, Some(time))
+    }
 }
 
 #[derive(Clone)]
@@ -276,21 +323,45 @@ pub struct MemoryStorage {
     pub password: Option<String>,
     pub cipher: Option<Cipher>,
     pub memory: Arc<RwLock<HashMap<String, Value>>>,
+    pub vss_client: Option<Arc<MutinyVssClient>>,
 }
 
 impl MemoryStorage {
-    pub fn new(password: Option<String>, cipher: Option<Cipher>) -> Self {
+    pub fn new(
+        password: Option<String>,
+        cipher: Option<Cipher>,
+        vss_client: Option<Arc<MutinyVssClient>>,
+    ) -> Self {
         Self {
             cipher,
             password,
             memory: Arc::new(RwLock::new(HashMap::new())),
+            vss_client,
         }
+    }
+
+    pub async fn load_from_vss(&self) -> Result<(), MutinyError> {
+        if let Some(vss) = self.vss_client() {
+            let keys = vss.list_key_versions(None).await?;
+            let mut items = HashMap::new();
+            for key in keys {
+                let obj = vss.get_object(&key.key).await?;
+                items.insert(key.key, obj.value);
+            }
+            let mut map = self
+                .memory
+                .try_write()
+                .map_err(|e| MutinyError::write_err(e.into()))?;
+            map.extend(items);
+        }
+
+        Ok(())
     }
 }
 
 impl Default for MemoryStorage {
     fn default() -> Self {
-        Self::new(None, None)
+        Self::new(None, None, None)
     }
 }
 
@@ -304,7 +375,7 @@ impl MutinyStorage for MemoryStorage {
     }
 
     fn vss_client(&self) -> Option<Arc<MutinyVssClient>> {
-        None
+        self.vss_client.clone()
     }
 
     fn set<T>(&self, key: impl AsRef<str>, value: T) -> Result<(), MutinyError>
@@ -501,6 +572,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::test_utils::*;
+    use crate::utils::sleep;
     use crate::{encrypt::encryption_key_from_pass, storage::MemoryStorage};
     use crate::{keymanager, storage::MutinyStorage};
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
@@ -514,7 +586,7 @@ mod tests {
 
         let seed = keymanager::generate_seed(12).unwrap();
 
-        let storage = MemoryStorage::new(None, None);
+        let storage = MemoryStorage::default();
         let mnemonic = storage.insert_mnemonic(seed).unwrap();
 
         let stored_mnemonic = storage.get_mnemonic().unwrap();
@@ -530,11 +602,57 @@ mod tests {
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher));
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
 
         let mnemonic = storage.insert_mnemonic(seed).unwrap();
 
         let stored_mnemonic = storage.get_mnemonic().unwrap();
         assert_eq!(Some(mnemonic), stored_mnemonic);
+    }
+
+    #[test]
+    async fn test_device_lock() {
+        let test_name = "test_device_lock";
+        log!("{}", test_name);
+
+        let vss = std::sync::Arc::new(create_vss_client().await);
+        let storage = MemoryStorage::new(None, None, Some(vss.clone()));
+        storage.load_from_vss().await.unwrap();
+
+        let id = storage.get_device_id().unwrap();
+        let lock = storage.get_device_lock().unwrap();
+        assert_eq!(None, lock);
+
+        storage.set_device_lock().unwrap();
+        // sleep 1 second to make sure it writes to VSS
+        sleep(1_000).await;
+
+        let lock = storage.get_device_lock().unwrap();
+        assert!(lock.is_some());
+        assert!(!lock.clone().unwrap().is_locked(&id));
+        assert!(lock.clone().unwrap().is_locked("different_id"));
+        assert_eq!(lock.unwrap().device, id);
+
+        // make sure we can set lock again, should work because same device id
+        storage.set_device_lock().unwrap();
+        // sleep 1 second to make sure it writes to VSS
+        sleep(1_000).await;
+
+        // create new storage with new device id and make sure we can't set lock
+        let storage = MemoryStorage::new(None, None, Some(vss));
+        storage.load_from_vss().await.unwrap();
+
+        let new_id = storage.get_device_id().unwrap();
+        assert_ne!(id, new_id);
+
+        let lock = storage.get_device_lock().unwrap();
+        assert!(lock.is_some());
+        // not locked for active device
+        assert!(!lock.clone().unwrap().is_locked(&id));
+        // is locked for new device
+        assert!(lock.clone().unwrap().is_locked(&new_id));
+        assert_eq!(lock.unwrap().device, id);
+
+        assert!(storage.set_device_lock().is_err())
     }
 }

--- a/mutiny-core/src/test_utils.rs
+++ b/mutiny-core/src/test_utils.rs
@@ -5,6 +5,36 @@ pub fn create_manager() -> AuthManager {
     AuthManager::new(xprivkey).unwrap()
 }
 
+pub async fn create_vss_client() -> MutinyVssClient {
+    // Set up test auth client
+    let auth_manager = create_manager();
+    let lnurl_client = Arc::new(
+        lnurl::Builder::default()
+            .build_async()
+            .expect("failed to make lnurl client"),
+    );
+    let logger = Arc::new(MutinyLogger::default());
+    let url = "https://auth-staging.mutinywallet.com";
+
+    let auth_client =
+        MutinyAuthClient::new(auth_manager, lnurl_client, logger.clone(), url.to_string());
+
+    // Test authenticate method
+    match auth_client.authenticate().await {
+        Ok(_) => assert!(auth_client.is_authenticated().is_some()),
+        Err(e) => panic!("Authentication failed with error: {:?}", e),
+    };
+
+    let encryption_key = SecretKey::from_slice(&[2; 32]).unwrap();
+
+    MutinyVssClient::new(
+        Arc::new(auth_client),
+        "https://storage-staging.mutinywallet.com".to_string(),
+        encryption_key,
+        logger,
+    )
+}
+
 #[allow(unused_macros)]
 macro_rules! log {
         ( $( $t:tt )* ) => {
@@ -14,8 +44,13 @@ macro_rules! log {
             println!( $( $t )* );
         }
     }
+use bitcoin::secp256k1::SecretKey;
 use bitcoin::{util::bip32::ExtendedPrivKey, Network};
 #[allow(unused_imports)]
 pub(crate) use log;
+use std::sync::Arc;
 
+use crate::auth::MutinyAuthClient;
+use crate::logging::MutinyLogger;
+use crate::vss::MutinyVssClient;
 use crate::{generate_seed, lnurlauth::AuthManager};

--- a/mutiny-core/src/vss.rs
+++ b/mutiny-core/src/vss.rs
@@ -158,44 +158,11 @@ impl MutinyVssClient {
 #[cfg(not(target_arch = "wasm32"))]
 mod tests {
     use super::*;
-    use crate::auth::MutinyAuthClient;
-    use crate::logging::MutinyLogger;
     use crate::test_utils::*;
-    use std::sync::Arc;
-
-    async fn create_client() -> MutinyVssClient {
-        // Set up test auth client
-        let auth_manager = create_manager();
-        let lnurl_client = Arc::new(
-            lnurl::Builder::default()
-                .build_async()
-                .expect("failed to make lnurl client"),
-        );
-        let logger = Arc::new(MutinyLogger::default());
-        let url = "https://auth-staging.mutinywallet.com";
-
-        let auth_client =
-            MutinyAuthClient::new(auth_manager, lnurl_client, logger.clone(), url.to_string());
-
-        // Test authenticate method
-        match auth_client.authenticate().await {
-            Ok(_) => assert!(auth_client.is_authenticated().is_some()),
-            Err(e) => panic!("Authentication failed with error: {:?}", e),
-        };
-
-        let encryption_key = SecretKey::from_slice(&[2; 32]).unwrap();
-
-        MutinyVssClient::new(
-            Arc::new(auth_client),
-            "https://storage-staging.mutinywallet.com".to_string(),
-            encryption_key,
-            logger,
-        )
-    }
 
     #[tokio::test]
     async fn test_vss() {
-        let client = create_client().await;
+        let client = create_vss_client().await;
 
         let key = "hello".to_string();
         let value: Value = serde_json::from_str("\"world\"").unwrap();
@@ -219,7 +186,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_vss_versions() {
-        let client = create_client().await;
+        let client = create_vss_client().await;
 
         let key = "hello".to_string();
         let value: Value = serde_json::from_str("\"world\"").unwrap();

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -1212,6 +1212,15 @@ impl MutinyWallet {
         Ok(())
     }
 
+    /// Clears storage and deletes all data.
+    ///
+    /// All data in VSS persists but the device lock is cleared.
+    #[wasm_bindgen]
+    pub async fn delete_all(&self) -> Result<(), MutinyJsError> {
+        self.inner.storage.delete_all().await?;
+        Ok(())
+    }
+
     /// Restore's the mnemonic after deleting the previous state.
     ///
     /// Backup the state beforehand. Does not restore lightning data.

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -74,6 +74,7 @@ impl MutinyWallet {
         subscription_url: Option<String>,
         storage_url: Option<String>,
         do_not_connect_peers: Option<bool>,
+        skip_device_lock: Option<bool>,
     ) -> Result<MutinyWallet, MutinyJsError> {
         utils::set_panic_hook();
         let logger = Arc::new(MutinyLogger::default());
@@ -153,6 +154,7 @@ impl MutinyWallet {
             lsp_url,
             auth_client,
             subscription_url,
+            skip_device_lock.unwrap_or(false),
         );
 
         if let Some(true) = do_not_connect_peers {
@@ -1297,6 +1299,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("mutiny wallet should initialize");
@@ -1321,6 +1324,7 @@ mod tests {
             Some(seed.to_string()),
             None,
             Some("regtest".to_owned()),
+            None,
             None,
             None,
             None,
@@ -1355,6 +1359,7 @@ mod tests {
             Some(seed.to_string()),
             None,
             Some("regtest".to_owned()),
+            None,
             None,
             None,
             None,


### PR DESCRIPTION
This creates a device specific lock that just uses VSS. Each device generates a uuid to identify itself and then when running every minute will send the current time to claim the lock. On boot it will check that this hasn't happened for 2 minutes so be sure it is safe to startup as no other device is running.