### PR TITLE
Change invoice expiry to 1 hour

### DIFF
--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -768,7 +768,7 @@ impl<S: MutinyStorage> Node<S> {
                     amount_msat,
                     description,
                     now,
-                    1500,
+                    3600,
                     Some(40),
                 )
             }
@@ -776,7 +776,7 @@ impl<S: MutinyStorage> Node<S> {
                 amount_msat,
                 None,
                 description,
-                1500,
+                3600,
                 r,
                 self.keys_manager.clone(),
                 self.keys_manager.clone(),


### PR DESCRIPTION
IIRC the Voltage LSP has limits around the invoice expiry, we may need to handle that here.

For https://github.com/MutinyWallet/mutiny-web/issues/416