### PR TITLE
Lower gap limit of on-chain wallet

### DIFF
--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -115,7 +115,7 @@ impl<S: MutinyStorage> OnChainWallet<S> {
                 spks,
                 core::iter::empty(),
                 core::iter::empty(),
-                50,
+                20,
                 5,
             )
             .await?;


### PR DESCRIPTION
We are sending a lot of requests when syncing, this should speed up syncs and reduce some of the overhead 