### PR TITLE
Remove prob scorer from export

### DIFF
--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2316,7 +2316,10 @@ impl<S: MutinyStorage> NodeManager<S> {
             // filter out logs and network graph
             // these are really big and not needed for export
             // filter out device id so a new one is generated
-            !matches!(k.as_str(), LOGGING_KEY | NETWORK_GRAPH_KEY | DEVICE_ID_KEY)
+            !matches!(
+                k.as_str(),
+                LOGGING_KEY | NETWORK_GRAPH_KEY | PROB_SCORER_KEY | DEVICE_ID_KEY
+            )
         }));
 
         // shut back down after reading if it was already closed


### PR DESCRIPTION
Since we just download this from the server, no need to have this in the export