### PR TITLE
Fix BDK needing resync

### DIFF
--- a/mutiny-wasm/src/indexed_db.rs
+++ b/mutiny-wasm/src/indexed_db.rs
@@ -368,7 +368,7 @@ impl IndexedDbStorage {
 fn used_once(key: &str) -> bool {
     matches!(
         key,
-        NETWORK_GRAPH_KEY | PROB_SCORER_KEY | GOSSIP_SYNC_TIME_KEY | KEYCHAIN_STORE_KEY
+        NETWORK_GRAPH_KEY | PROB_SCORER_KEY | GOSSIP_SYNC_TIME_KEY
     )
 }
 


### PR DESCRIPTION
Finally found the reason why we would always need to resync bdk. We were removing the bdk keychain from memory after reading so we didnt overload memory, however, we needed this because we read the current bdk keychain and merge with the update, if we remove it from our in memory cache, then we have nothing to merge with.

This should let us bring back #690