### PR TITLE
Handle bad metadata when syncing nostr contacts

### DIFF
--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -128,6 +128,9 @@ pub enum MutinyError {
     /// Error getting the bitcoin price
     #[error("Failed to get the bitcoin price.")]
     BitcoinPriceError,
+    /// Error getting nostr data
+    #[error("Failed to get nostr data.")]
+    NostrError,
     /// Incorrect password entered.
     #[error("Incorrect password entered.")]
     IncorrectPassword,
@@ -351,5 +354,11 @@ impl From<bdk_chain::local_chain::InsertBlockNotMatchingError> for MutinyError {
 impl From<bdk::wallet::InsertTxError> for MutinyError {
     fn from(_e: bdk::wallet::InsertTxError) -> Self {
         Self::WalletSyncError
+    }
+}
+
+impl From<nostr_sdk::client::Error> for MutinyError {
+    fn from(_e: nostr_sdk::client::Error) -> Self {
+        Self::NostrError
     }
 }

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -354,17 +354,14 @@ impl<S: MutinyStorage> MutinyWallet<S> {
         let client = Client::new(&keys);
 
         #[cfg(target_arch = "wasm32")]
-        client.add_relay("wss://relay.damus.io").await.unwrap();
+        client.add_relay("wss://relay.damus.io").await?;
 
         #[cfg(not(target_arch = "wasm32"))]
-        client
-            .add_relay("wss://relay.damus.io", None)
-            .await
-            .unwrap();
+        client.add_relay("wss://relay.damus.io", None).await?;
 
         client.connect().await;
 
-        let mut metadata = client.get_contact_list_metadata(timeout).await.unwrap();
+        let mut metadata = nostr::get_contact_list_metadata(&client, timeout).await?;
 
         let contacts = self.storage.get_contacts()?;
 
@@ -392,7 +389,7 @@ impl<S: MutinyStorage> MutinyWallet<S> {
             self.storage.create_new_contact(contact)?;
         }
 
-        client.disconnect().await.unwrap();
+        client.disconnect().await?;
         Ok(())
     }
 

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -113,6 +113,9 @@ pub enum MutinyJsError {
     /// Node pubkey given is invalid
     #[error("The given node pubkey is invalid.")]
     PubkeyInvalid,
+    /// Error getting nostr data
+    #[error("Failed to get nostr data.")]
+    NostrError,
     /// Error getting the bitcoin price
     #[error("Failed to get the bitcoin price.")]
     BitcoinPriceError,
@@ -173,6 +176,7 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::PubkeyInvalid => MutinyJsError::PubkeyInvalid,
             MutinyError::IncorrectLnUrlFunction => MutinyJsError::IncorrectLnUrlFunction,
             MutinyError::BadAmountError => MutinyJsError::BadAmountError,
+            MutinyError::NostrError => MutinyJsError::NostrError,
             MutinyError::BitcoinPriceError => MutinyJsError::BitcoinPriceError,
             MutinyError::IncorrectPassword => MutinyJsError::IncorrectPassword,
             MutinyError::Other(_) => MutinyJsError::UnknownError,


### PR DESCRIPTION
There is a bug in the nostr-sdk with parsing some user's metadata. This gets around it by skipping those profiles instead of erroring out on the entire sync. To do this I needed to copy some code from the nostr-sdk. Also better handled the errors instead of unwrapping.