### PR TITLE
Allow anon zaps to lnurls

### DIFF
--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -637,6 +637,7 @@ impl MutinyWallet {
         from_node: String,
         lnurl: String,
         amount_sats: u64,
+        zap_npub: Option<String>,
         labels: JsValue, /* Vec<String> */
     ) -> Result<MutinyInvoice, MutinyJsError> {
         let from_node = PublicKey::from_str(&from_node)?;
@@ -644,10 +645,18 @@ impl MutinyWallet {
         let labels: Vec<String> = labels
             .into_serde()
             .map_err(|_| MutinyJsError::InvalidArgumentsError)?;
+
+        let zap_npub = match zap_npub.filter(|z| !z.is_empty()) {
+            Some(z) => {
+                Some(XOnlyPublicKey::from_bech32(&z).or_else(|_| XOnlyPublicKey::from_str(&z))?)
+            }
+            None => None,
+        };
+
         Ok(self
             .inner
             .node_manager
-            .lnurl_pay(&from_node, &lnurl, amount_sats, labels)
+            .lnurl_pay(&from_node, &lnurl, amount_sats, zap_npub, labels)
             .await?
             .into())
     }


### PR DESCRIPTION
While we still haven't figured out how to best do the keys for sending zaps (since we don't have the user's nsec), this will send an anonymous zap to the user