### PR TITLE
Handle gifting errors

### DIFF
--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -362,3 +362,15 @@ impl From<nostr_sdk::client::Error> for MutinyError {
         Self::NostrError
     }
 }
+
+impl From<nostr::nips::nip04::Error> for MutinyError {
+    fn from(_e: nostr::nips::nip04::Error) -> Self {
+        Self::NostrError
+    }
+}
+
+impl From<nostr::event::builder::Error> for MutinyError {
+    fn from(_e: nostr::event::builder::Error) -> Self {
+        Self::NostrError
+    }
+}

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -1,22 +1,26 @@
 use crate::nodemanager::NodeManager;
 use crate::nostr::nwc::{
-    NostrWalletConnect, NwcProfile, PendingNwcInvoice, Profile, SingleUseSpendingConditions,
-    SpendingConditions, PENDING_NWC_EVENTS_KEY,
+    NostrWalletConnect, NwcProfile, NwcProfileTag, PendingNwcInvoice, Profile,
+    SingleUseSpendingConditions, SpendingConditions, PENDING_NWC_EVENTS_KEY,
 };
 use crate::storage::MutinyStorage;
+use crate::utils;
 use crate::{error::MutinyError, utils::get_random_bip32_child_index};
-use bitcoin::hashes::sha256;
+use bitcoin::hashes::hex::{FromHex, ToHex};
+use bitcoin::hashes::{sha256, Hash};
 use bitcoin::secp256k1::{PublicKey, Secp256k1, Signing};
 use bitcoin::util::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey};
+use futures::{pin_mut, select, FutureExt};
 use futures_util::lock::Mutex;
 use nostr::key::SecretKey;
 use nostr::nips::nip47::*;
-use nostr::prelude::{encrypt, XOnlyPublicKey};
+use nostr::prelude::{decrypt, encrypt, XOnlyPublicKey};
 use nostr::{Event, EventBuilder, EventId, Filter, Keys, Kind, Metadata, Tag};
-use nostr_sdk::Client;
+use nostr_sdk::{Client, RelayPoolNotification};
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::str::FromStr;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
@@ -148,6 +152,7 @@ impl<S: MutinyStorage> NostrManager<S> {
         &self,
         profile_type: ProfileType,
         spending_conditions: SpendingConditions,
+        tag: NwcProfileTag,
     ) -> Result<NwcProfile, MutinyError> {
         let mut profiles = self.nwc.write().unwrap();
 
@@ -179,6 +184,7 @@ impl<S: MutinyStorage> NostrManager<S> {
             enabled: true,
             archived: false,
             spending_conditions,
+            tag,
         };
         let nwc = NostrWalletConnect::new(&Secp256k1::new(), self.xprivkey, profile)?;
 
@@ -203,8 +209,9 @@ impl<S: MutinyStorage> NostrManager<S> {
         &self,
         profile_type: ProfileType,
         spending_conditions: SpendingConditions,
+        tag: NwcProfileTag,
     ) -> Result<NwcProfile, MutinyError> {
-        let profile = self.create_new_profile(profile_type, spending_conditions)?;
+        let profile = self.create_new_profile(profile_type, spending_conditions, tag)?;
 
         let info_event = self.nwc.read().unwrap().iter().find_map(|nwc| {
             if nwc.profile.index == profile.index {
@@ -247,7 +254,7 @@ impl<S: MutinyStorage> NostrManager<S> {
             amount_sats,
             spent: false,
         });
-        self.create_new_nwc_profile(profile, spending_conditions)
+        self.create_new_nwc_profile(profile, spending_conditions, NwcProfileTag::Gift)
             .await
     }
 
@@ -468,8 +475,9 @@ impl<S: MutinyStorage> NostrManager<S> {
         amount_sats: u64,
         nwc_uri: &str,
         node_manager: &NodeManager<S>,
-    ) -> anyhow::Result<EventId> {
-        let nwc = NostrWalletConnectURI::from_str(nwc_uri)?;
+    ) -> Result<Option<NIP47Error>, MutinyError> {
+        let nwc = NostrWalletConnectURI::from_str(nwc_uri)
+            .map_err(|_| MutinyError::InvalidArgumentsError)?;
         let secret = Keys::new(nwc.secret);
         let client = Client::new(&secret);
 
@@ -485,17 +493,26 @@ impl<S: MutinyStorage> NostrManager<S> {
         let invoice = node_manager
             .create_invoice(Some(amount_sats), vec!["Gift".to_string()])
             .await?;
+        // unwrap is safe, we just created it
+        let bolt11 = invoice.bolt11.unwrap();
 
         let req = Request {
             method: Method::PayInvoice,
             params: RequestParams {
-                invoice: invoice.bolt11.unwrap().to_string(),
+                invoice: bolt11.to_string(),
             },
         };
         let encrypted = encrypt(&nwc.secret, &nwc.public_key, req.as_json())?;
         let p_tag = Tag::PubKey(nwc.public_key, None);
         let request_event =
             EventBuilder::new(Kind::WalletConnectRequest, encrypted, &[p_tag]).to_event(&secret)?;
+
+        let filter = Filter::new()
+            .kind(Kind::WalletConnectResponse)
+            .author(nwc.public_key.to_hex())
+            .pubkey(secret.public_key());
+
+        client.subscribe(vec![filter]).await;
 
         client
             .send_event(request_event.clone())
@@ -504,9 +521,76 @@ impl<S: MutinyStorage> NostrManager<S> {
                 MutinyError::Other(anyhow::anyhow!("Failed to send request event: {e:?}"))
             })?;
 
+        let mut notifications = client.notifications();
+
+        let start_time = utils::now();
+
+        // every second, check for response event, invoice paid, or timeout
+        loop {
+            let now = utils::now();
+            if now - start_time > Duration::from_secs(30) {
+                client.disconnect().await?;
+                return Err(MutinyError::PaymentTimeout);
+            }
+
+            // check if the invoice has been paid, if so, return, otherwise continue
+            // checking for response event
+            if let Ok(invoice) = node_manager.get_invoice(&bolt11).await {
+                if invoice.paid {
+                    break;
+                }
+            }
+
+            let read_fut = notifications.recv().fuse();
+            let delay_fut = Box::pin(utils::sleep(1_000)).fuse();
+
+            pin_mut!(read_fut, delay_fut);
+            select! {
+                notification = read_fut => {
+                    match notification {
+                        Ok(RelayPoolNotification::Event(_url, event)) => {
+                            if event.kind == Kind::WalletConnectResponse && event.verify().is_ok() {
+                                let decrypted = decrypt(&nwc.secret, &nwc.public_key, &event.content)?;
+                                let resp: Response = serde_json::from_str(&decrypted)?;
+
+                                if resp.result_type == Method::PayInvoice {
+                                    client.disconnect().await?;
+
+                                    match resp.result {
+                                        Some(result) => {
+                                            let preimage: Vec<u8> = FromHex::from_hex(&result.preimage)?;
+                                            if sha256::Hash::hash(&preimage) == invoice.payment_hash {
+                                                return Ok(None);
+                                            } else {
+                                                return Ok(Some(NIP47Error {
+                                                    code: ErrorCode::QuotaExceeded,
+                                                    message: "Already Claimed".to_string(),
+                                                }));
+                                            }
+                                        },
+                                        None => return Ok(resp.error),
+                                    }
+                                }
+                            }
+                        },
+                        Ok(RelayPoolNotification::Message(_, _)) => {}, // ignore messages
+                        Ok(RelayPoolNotification::Shutdown) =>
+                            return Err(MutinyError::ConnectionFailed),
+                        Err(_) => return Err(MutinyError::ConnectionFailed),
+                    }
+                }
+                _ = delay_fut => {
+                    if node_manager.stop.load(Ordering::Relaxed) {
+                        client.disconnect().await?;
+                        return Err(MutinyError::NotRunning);
+                    }
+                }
+            }
+        }
+
         client.disconnect().await?;
 
-        Ok(request_event.id)
+        Ok(None)
     }
 
     /// Derives the client and server keys for Nostr Wallet Connect given a profile index
@@ -652,6 +736,7 @@ mod test {
             .create_new_profile(
                 ProfileType::Normal { name: name.clone() },
                 SpendingConditions::default(),
+                Default::default(),
             )
             .unwrap();
 
@@ -684,6 +769,7 @@ mod test {
             .create_new_profile(
                 ProfileType::Reserved(ReservedProfile::MutinySubscription),
                 SpendingConditions::default(),
+                Default::default(),
             )
             .unwrap();
 
@@ -712,6 +798,7 @@ mod test {
             .create_new_profile(
                 ProfileType::Normal { name: name.clone() },
                 SpendingConditions::default(),
+                Default::default(),
             )
             .unwrap();
 
@@ -728,6 +815,7 @@ mod test {
             archived: false,
             child_key_index: None,
             spending_conditions: Default::default(),
+            tag: Default::default(),
         };
         let mut profiles = nostr_manager.nwc.write().unwrap();
         let nwc = NostrWalletConnect::new(
@@ -788,6 +876,7 @@ mod test {
             .create_new_profile(
                 ProfileType::Normal { name: name.clone() },
                 SpendingConditions::default(),
+                Default::default(),
             )
             .unwrap();
 
@@ -824,7 +913,11 @@ mod test {
         let name = "test".to_string();
 
         let profile = nostr_manager
-            .create_new_profile(ProfileType::Normal { name }, SpendingConditions::default())
+            .create_new_profile(
+                ProfileType::Normal { name },
+                SpendingConditions::default(),
+                Default::default(),
+            )
             .unwrap();
 
         let inv = PendingNwcInvoice {

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -91,7 +91,7 @@ impl<S: MutinyStorage> NostrManager<S> {
             .read()
             .unwrap()
             .iter()
-            .filter(|x| x.profile.enabled)
+            .filter(|x| x.profile.enabled && !x.profile.archived)
             .map(|nwc| nwc.create_nwc_filter())
             .collect()
     }

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -147,6 +147,17 @@ impl<S: MutinyStorage> NostrManager<S> {
         Ok(nwc_profile)
     }
 
+    pub fn get_profile(&self, index: u32) -> Result<NwcProfile, MutinyError> {
+        let profiles = self.nwc.read().unwrap();
+
+        let nwc = profiles
+            .iter()
+            .find(|nwc| nwc.profile.index == index)
+            .ok_or(MutinyError::NotFound)?;
+
+        Ok(nwc.nwc_profile())
+    }
+
     /// Creates a new NWC profile and saves to storage
     pub(crate) fn create_new_profile(
         &self,

--- a/mutiny-core/src/nostr/nwc.rs
+++ b/mutiny-core/src/nostr/nwc.rs
@@ -265,7 +265,14 @@ impl NostrWalletConnect {
                                 resp
                             }
                             Err(e) => {
-                                // todo handle timeout errors
+                                if let MutinyError::PaymentTimeout = e {
+                                    needs_save = true;
+                                    log_error!(
+                                        node_manager.logger,
+                                        "Payment timeout, disabling nwc profile"
+                                    );
+                                    self.profile.enabled = false;
+                                }
                                 Response {
                                     result_type: Method::PayInvoice,
                                     error: Some(NIP47Error {

--- a/mutiny-core/src/nostr/nwc.rs
+++ b/mutiny-core/src/nostr/nwc.rs
@@ -6,6 +6,7 @@ use crate::utils;
 use anyhow::anyhow;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, Signing};
 use bitcoin::util::bip32::ExtendedPrivKey;
+use core::fmt;
 use futures_util::lock::Mutex;
 use lightning::util::logger::Logger;
 use lightning::{log_error, log_warn};
@@ -39,6 +40,30 @@ impl Default for SpendingConditions {
     }
 }
 
+/// Type of Nostr Wallet Connect profile
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NwcProfileTag {
+    Subscription,
+    Gift,
+    General,
+}
+
+impl Default for NwcProfileTag {
+    fn default() -> Self {
+        Self::General
+    }
+}
+
+impl fmt::Display for NwcProfileTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Subscription => write!(f, "Subscription"),
+            Self::Gift => write!(f, "Gift"),
+            Self::General => write!(f, "General"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub(crate) struct Profile {
     pub name: String,
@@ -55,6 +80,8 @@ pub(crate) struct Profile {
     /// set to Option so that we keep using `index` for reserved + existing
     #[serde(default)]
     pub child_key_index: Option<u32>,
+    #[serde(default)]
+    pub tag: NwcProfileTag,
 }
 
 impl PartialOrd for Profile {
@@ -210,15 +237,19 @@ impl NostrWalletConnect {
             // if we need approval, just save in the db for later
             match self.profile.spending_conditions.clone() {
                 SpendingConditions::SingleUse(mut single_use) => {
-                    // check if we have already spent
-                    if single_use.spent {
-                        return Ok((None, needs_save));
-                    }
-
                     let msats = invoice.amount_milli_satoshis().unwrap();
 
-                    // verify amount is under our limit
-                    let content = if msats <= single_use.amount_sats * 1_000 {
+                    // check if we have already spent
+                    let content = if single_use.spent {
+                        Response {
+                            result_type: Method::PayInvoice,
+                            error: Some(NIP47Error {
+                                code: ErrorCode::QuotaExceeded,
+                                message: "Already Claimed".to_string(),
+                            }),
+                            result: None,
+                        }
+                    } else if msats <= single_use.amount_sats * 1_000 {
                         match self
                             .pay_nwc_invoice(node_manager, from_node, &invoice)
                             .await
@@ -311,6 +342,7 @@ impl NostrWalletConnect {
             nwc_uri: self.get_nwc_uri().expect("failed to get nwc uri"),
             spending_conditions: self.profile.spending_conditions.clone(),
             child_key_index: self.profile.child_key_index,
+            tag: self.profile.tag,
         }
     }
 }
@@ -329,6 +361,8 @@ pub struct NwcProfile {
     pub spending_conditions: SpendingConditions,
     #[serde(default)]
     pub child_key_index: Option<u32>,
+    #[serde(default)]
+    pub tag: NwcProfileTag,
 }
 
 impl NwcProfile {
@@ -341,6 +375,7 @@ impl NwcProfile {
             enabled: self.enabled,
             spending_conditions: self.spending_conditions.clone(),
             child_key_index: self.child_key_index,
+            tag: self.tag,
         }
     }
 }

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -1123,6 +1123,12 @@ impl MutinyWallet {
         Ok(self.inner.nostr.edit_profile(profile)?.into())
     }
 
+    /// Finds a nostr wallet connect profile by index
+    #[wasm_bindgen]
+    pub async fn get_nwc_profile(&self, index: u32) -> Result<models::NwcProfile, MutinyJsError> {
+        Ok(self.inner.nostr.get_profile(index)?.into())
+    }
+
     /// Create a single use nostr wallet connect profile
     #[wasm_bindgen]
     pub async fn create_single_use_nwc(


### PR DESCRIPTION
Makes it so `claim_single_use_nwc` will wait until the invoice is paid, given a timeout. Will also return an error string if one occurs