### PR TITLE
Make nwc keys random

### DIFF
--- a/mutiny-core/src/utils.rs
+++ b/mutiny-core/src/utils.rs
@@ -78,6 +78,18 @@ async fn fetch(client: &Client, req: reqwest::Request) -> Result<reqwest::Respon
         .map_err(|_| MutinyError::ConnectionFailed)
 }
 
+pub fn get_random_bip32_child_index() -> u32 {
+    let mut buffer = [0u8; 4];
+    getrandom::getrandom(&mut buffer).unwrap();
+
+    // Convert the byte buffer to u32
+    let random_value = u32::from_le_bytes(buffer);
+
+    // Restrict to [0, 2^31 - 1]
+    let max_value = 2u32.pow(31) - 1;
+    random_value % (max_value + 1)
+}
+
 pub type LockResult<Guard> = Result<Guard, ()>;
 
 pub struct Mutex<T: ?Sized> {


### PR DESCRIPTION
Thought about it and there's really no reason to have determinism with these nwc keys. As long as we save the random child key index, then it should be fine. When these are stored remotely then it should be fine as well.

This allows for backwards compat with existing keys that are based on `index` as before. So no need to recreate NWC profiles. 