### PR TITLE
Fix incorrect password error not being propogated

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -40,7 +40,7 @@ pub mod vss;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
-mod utils;
+pub mod utils;
 
 pub use crate::gossip::{GOSSIP_SYNC_TIME_KEY, NETWORK_GRAPH_KEY, PROB_SCORER_KEY};
 pub use crate::keymanager::generate_seed;

--- a/mutiny-core/src/utils.rs
+++ b/mutiny-core/src/utils.rs
@@ -125,6 +125,7 @@ impl<T> Mutex<T> {
         }
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn lock(&self) -> LockResult<MutexGuard<'_, T>> {
         Ok(MutexGuard {
             lock: self.inner.borrow_mut(),


### PR DESCRIPTION
The incorrect password error was being swallowed by us failing to parse a json object. This should fix it