### PR TITLE
Initiate cipher inside storage constructor

### DIFF
--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -238,9 +238,7 @@ mod tests {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    use crate::{
-        encrypt::encryption_key_from_pass, keymanager::pubkey_from_keys_manager, test_utils::*,
-    };
+    use crate::{keymanager::pubkey_from_keys_manager, test_utils::*};
 
     use super::create_keys_manager;
     use crate::fees::MutinyFeeEstimator;
@@ -269,8 +267,7 @@ mod tests {
         );
         let esplora = Arc::new(MultiEsploraClient::new(vec![esplora]));
         let pass = uuid::Uuid::new_v4().to_string();
-        let cipher = encryption_key_from_pass(&pass).unwrap();
-        let db = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let db = MemoryStorage::new(Some(pass), None).unwrap();
         let logger = Arc::new(MutinyLogger::default());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -528,10 +528,7 @@ impl<S: MutinyStorage> MutinyWallet<S> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        encrypt::encryption_key_from_pass, generate_seed, nodemanager::NodeManager, MutinyWallet,
-        MutinyWalletConfig,
-    };
+    use crate::{generate_seed, nodemanager::NodeManager, MutinyWallet, MutinyWalletConfig};
     use bitcoin::util::bip32::ExtendedPrivKey;
     use bitcoin::Network;
 
@@ -551,8 +548,7 @@ mod tests {
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &mnemonic.to_seed("")).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), None).unwrap();
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfig::new(
             xpriv,
@@ -581,8 +577,7 @@ mod tests {
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &[0; 32]).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), None).unwrap();
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfig::new(
             xpriv,
@@ -616,8 +611,7 @@ mod tests {
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &[0; 32]).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), None).unwrap();
 
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfig::new(
@@ -654,8 +648,7 @@ mod tests {
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &mnemonic.to_seed("")).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), None).unwrap();
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfig::new(
             xpriv,
@@ -678,8 +671,7 @@ mod tests {
 
         // create a second mw and make sure it has a different seed
         let pass = uuid::Uuid::new_v4().to_string();
-        let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage2 = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage2 = MemoryStorage::new(Some(pass), None).unwrap();
         assert!(!NodeManager::has_node_manager(storage2.clone()));
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &[0; 32]).unwrap();
         let mut config2 = MutinyWalletConfig::new(
@@ -706,8 +698,7 @@ mod tests {
         drop(mw2);
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage3 = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage3 = MemoryStorage::new(Some(pass), None).unwrap();
         MutinyWallet::restore_mnemonic(storage3.clone(), mnemonic.clone())
             .await
             .expect("mutiny wallet should restore");

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2524,11 +2524,8 @@ pub(crate) async fn create_new_node_from_node_manager<S: MutinyStorage>(
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        encrypt::encryption_key_from_pass,
-        nodemanager::{
-            ActivityItem, ChannelClosure, MutinyInvoice, NodeManager, TransactionDetails,
-        },
+    use crate::nodemanager::{
+        ActivityItem, ChannelClosure, MutinyInvoice, NodeManager, TransactionDetails,
     };
     use crate::{keymanager::generate_seed, MutinyWalletConfig};
     use bdk::chain::ConfirmationTime;
@@ -2559,8 +2556,7 @@ mod tests {
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &seed.to_seed("")).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), None).unwrap();
 
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let c = MutinyWalletConfig::new(
@@ -2589,8 +2585,7 @@ mod tests {
         log!("{}", test_name);
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), None).unwrap();
         let seed = generate_seed(12).expect("Failed to gen seed");
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &seed.to_seed("")).unwrap();
         let c = MutinyWalletConfig::new(
@@ -2640,8 +2635,7 @@ mod tests {
         log!("{}", test_name);
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), None).unwrap();
         let seed = generate_seed(12).expect("Failed to gen seed");
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &seed.to_seed("")).unwrap();
         let c = MutinyWalletConfig::new(
@@ -2676,8 +2670,7 @@ mod tests {
         log!("{}", test_name);
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let cipher = encryption_key_from_pass(&pass).unwrap();
-        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let storage = MemoryStorage::new(Some(pass), None).unwrap();
         let seed = generate_seed(12).expect("Failed to gen seed");
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &seed.to_seed("")).unwrap();
         let c = MutinyWalletConfig::new(

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -738,7 +738,7 @@ mod test {
         let xprivkey =
             ExtendedPrivKey::new_master(Network::Bitcoin, &mnemonic.to_seed("")).unwrap();
 
-        let storage = MemoryStorage::new(None, None, None);
+        let storage = MemoryStorage::new(None, None).unwrap();
 
         NostrManager::from_mnemonic(xprivkey, storage).unwrap()
     }

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -632,8 +632,8 @@ pub(crate) fn get_esplora_url(network: Network, user_provided_url: Option<String
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::MemoryStorage;
     use crate::test_utils::*;
-    use crate::{encrypt::encryption_key_from_pass, storage::MemoryStorage};
     use bip39::Mnemonic;
     use bitcoin::Address;
     use esplora_client::Builder;
@@ -650,8 +650,7 @@ mod tests {
         );
         let esplora = Arc::new(MultiEsploraClient::new(vec![esplora]));
         let pass = uuid::Uuid::new_v4().to_string();
-        let cipher = encryption_key_from_pass(&pass).unwrap();
-        let db = MemoryStorage::new(Some(pass), Some(cipher), None);
+        let db = MemoryStorage::new(Some(pass), None).unwrap();
         let logger = Arc::new(MutinyLogger::default());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),

--- a/mutiny-wasm/src/indexed_db.rs
+++ b/mutiny-wasm/src/indexed_db.rs
@@ -41,12 +41,16 @@ pub struct IndexedDbStorage {
 impl IndexedDbStorage {
     pub async fn new(
         password: Option<String>,
-        cipher: Option<Cipher>,
         vss: Option<Arc<MutinyVssClient>>,
         logger: Arc<MutinyLogger>,
     ) -> Result<IndexedDbStorage, MutinyError> {
         let indexed_db = Arc::new(RwLock::new(Some(Self::build_indexed_db_database().await?)));
         let password = password.filter(|p| !p.is_empty());
+        let cipher = password
+            .as_ref()
+            .filter(|p| !p.is_empty())
+            .map(|p| encryption_key_from_pass(p))
+            .transpose()?;
 
         let map = Self::read_all(&indexed_db, password.clone(), vss.as_deref(), &logger).await?;
         let memory = Arc::new(RwLock::new(map));
@@ -174,14 +178,8 @@ impl IndexedDbStorage {
             })?
         };
 
-        let cipher = password
-            .as_ref()
-            .filter(|p| !p.is_empty())
-            .map(|p| encryption_key_from_pass(p))
-            .transpose()?;
-
         // use a memory storage to handle encryption and decryption
-        let map = MemoryStorage::new(password, cipher, None);
+        let map = MemoryStorage::new(password, None)?;
 
         let all_json = store.get_all(None, None, None, None).await.map_err(|e| {
             MutinyError::read_err(anyhow!("Failed to get all from store: {e}").into())
@@ -715,8 +713,8 @@ mod tests {
     use bip39::Mnemonic;
     use bitcoin::hashes::hex::ToHex;
     use gloo_storage::{LocalStorage, Storage};
+    use mutiny_core::logging::MutinyLogger;
     use mutiny_core::storage::MutinyStorage;
-    use mutiny_core::{encrypt::encryption_key_from_pass, logging::MutinyLogger};
     use rexie::TransactionMode;
     use serde_json::json;
     use std::str::FromStr;
@@ -732,7 +730,7 @@ mod tests {
         log!("{test_name}");
 
         let logger = Arc::new(MutinyLogger::default());
-        let storage = IndexedDbStorage::new(Some("".to_string()), None, None, logger)
+        let storage = IndexedDbStorage::new(Some("".to_string()), None, logger)
             .await
             .unwrap();
 
@@ -749,8 +747,7 @@ mod tests {
 
         let logger = Arc::new(MutinyLogger::default());
         let password = "password".to_string();
-        let cipher = encryption_key_from_pass(&password).unwrap();
-        let storage = IndexedDbStorage::new(Some(password), Some(cipher), None, logger)
+        let storage = IndexedDbStorage::new(Some(password), None, logger)
             .await
             .unwrap();
 
@@ -801,8 +798,7 @@ mod tests {
 
         let logger = Arc::new(MutinyLogger::default());
         let password = "password".to_string();
-        let cipher = encryption_key_from_pass(&password).unwrap();
-        let storage = IndexedDbStorage::new(Some(password), Some(cipher), None, logger)
+        let storage = IndexedDbStorage::new(Some(password), None, logger)
             .await
             .unwrap();
 
@@ -826,8 +822,7 @@ mod tests {
 
         let logger = Arc::new(MutinyLogger::default());
         let password = "password".to_string();
-        let cipher = encryption_key_from_pass(&password).unwrap();
-        let storage = IndexedDbStorage::new(Some(password), Some(cipher), None, logger)
+        let storage = IndexedDbStorage::new(Some(password), None, logger)
             .await
             .unwrap();
 
@@ -852,9 +847,7 @@ mod tests {
         let seed = Mnemonic::from_str("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about").expect("could not generate");
 
         let logger = Arc::new(MutinyLogger::default());
-        let storage = IndexedDbStorage::new(None, None, None, logger)
-            .await
-            .unwrap();
+        let storage = IndexedDbStorage::new(None, None, logger).await.unwrap();
         let mnemonic = storage.insert_mnemonic(seed).unwrap();
 
         let stored_mnemonic = storage.get_mnemonic().unwrap();
@@ -873,8 +866,7 @@ mod tests {
 
         let logger = Arc::new(MutinyLogger::default());
         let password = "password".to_string();
-        let cipher = encryption_key_from_pass(&password).unwrap();
-        let storage = IndexedDbStorage::new(Some(password), Some(cipher), None, logger)
+        let storage = IndexedDbStorage::new(Some(password), None, logger)
             .await
             .unwrap();
 
@@ -916,9 +908,7 @@ mod tests {
         tx.done().await.unwrap();
 
         let logger = Arc::new(MutinyLogger::default());
-        let storage = IndexedDbStorage::new(None, None, None, logger)
-            .await
-            .unwrap();
+        let storage = IndexedDbStorage::new(None, None, logger).await.unwrap();
 
         let bytes: [u8; 11] = storage.get(&key).unwrap().unwrap();
 
@@ -971,7 +961,7 @@ mod tests {
             // just use this as dummy data
             value: Value::String(MONITOR_VERSION_MAX.to_hex()),
         };
-        let storage = IndexedDbStorage::new(None, None, None, logger.clone())
+        let storage = IndexedDbStorage::new(None, None, logger.clone())
             .await
             .unwrap();
 
@@ -980,14 +970,8 @@ mod tests {
         utils::sleep(1_000).await;
 
         let password = Some("password".to_string());
-        let cipher = password
-            .as_ref()
-            .filter(|p| !p.is_empty())
-            .map(|p| encryption_key_from_pass(p))
-            .transpose()
-            .unwrap();
 
-        let result = IndexedDbStorage::new(password, cipher, None, logger).await;
+        let result = IndexedDbStorage::new(password, None, logger).await;
 
         match result {
             Err(MutinyError::IncorrectPassword) => (),

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -36,7 +36,7 @@ use mutiny_core::redshift::RedshiftRecipient;
 use mutiny_core::scb::EncryptedSCB;
 use mutiny_core::storage::MutinyStorage;
 use mutiny_core::vss::MutinyVssClient;
-use mutiny_core::{encrypt::encryption_key_from_pass, generate_seed, nostr::nwc::NwcProfile};
+use mutiny_core::{generate_seed, nostr::nwc::NwcProfile};
 use mutiny_core::{labels::LabelStorage, nodemanager::NodeManager};
 use mutiny_core::{logging::MutinyLogger, nostr::ProfileType};
 use nostr::key::XOnlyPublicKey;
@@ -89,18 +89,11 @@ impl MutinyWallet {
         let safe_mode = safe_mode.unwrap_or(false);
         let logger = Arc::new(MutinyLogger::default());
 
-        let cipher = password
-            .as_ref()
-            .filter(|p| !p.is_empty())
-            .map(|p| encryption_key_from_pass(p))
-            .transpose()?;
-
         let network: Network = network_str
             .map(|s| s.parse().expect("Invalid network"))
             .unwrap_or(Network::Bitcoin);
 
-        let storage =
-            IndexedDbStorage::new(password.clone(), cipher.clone(), None, logger.clone()).await?;
+        let storage = IndexedDbStorage::new(password.clone(), None, logger.clone()).await?;
 
         let mnemonic = match mnemonic_str {
             Some(m) => {
@@ -155,7 +148,7 @@ impl MutinyWallet {
             (None, None)
         };
 
-        let storage = IndexedDbStorage::new(password, cipher, vss_client, logger.clone()).await?;
+        let storage = IndexedDbStorage::new(password, vss_client, logger.clone()).await?;
 
         let mut config = mutiny_core::MutinyWalletConfig::new(
             xprivkey,
@@ -191,16 +184,7 @@ impl MutinyWallet {
     #[wasm_bindgen]
     pub async fn has_node_manager(password: Option<String>) -> bool {
         let logger = Arc::new(MutinyLogger::default());
-        let cipher = match password
-            .as_ref()
-            .filter(|p| !p.is_empty())
-            .map(|p| encryption_key_from_pass(p))
-            .transpose()
-        {
-            Ok(c) => c,
-            Err(_) => return false,
-        };
-        let storage = IndexedDbStorage::new(password, cipher, None, logger)
+        let storage = IndexedDbStorage::new(password, None, logger)
             .await
             .expect("Failed to init");
         NodeManager::has_node_manager(storage)
@@ -1089,7 +1073,7 @@ impl MutinyWallet {
     pub async fn get_logs() -> Result<JsValue /* Option<Vec<String>> */, MutinyJsError> {
         let logger = Arc::new(MutinyLogger::default());
         // Password should not be required for logs
-        let storage = IndexedDbStorage::new(None, None, None, logger.clone()).await?;
+        let storage = IndexedDbStorage::new(None, None, logger.clone()).await?;
         let stop = Arc::new(AtomicBool::new(false));
         let logger = Arc::new(MutinyLogger::with_writer(stop.clone(), storage.clone()));
         let res = JsValue::from_serde(&NodeManager::get_logs(storage, logger)?)?;
@@ -1287,13 +1271,8 @@ impl MutinyWallet {
     #[wasm_bindgen]
     pub async fn export_json(password: Option<String>) -> Result<String, MutinyJsError> {
         let logger = Arc::new(MutinyLogger::default());
-        let cipher = password
-            .as_ref()
-            .filter(|p| !p.is_empty())
-            .map(|p| encryption_key_from_pass(p))
-            .transpose()?;
         // todo init vss
-        let storage = IndexedDbStorage::new(password, cipher, None, logger).await?;
+        let storage = IndexedDbStorage::new(password, None, logger).await?;
         if storage.get_mnemonic().is_err() {
             // if we get an error, then we have the wrong password
             return Err(MutinyJsError::IncorrectPassword);
@@ -1329,12 +1308,7 @@ impl MutinyWallet {
         password: Option<String>,
     ) -> Result<(), MutinyJsError> {
         let logger = Arc::new(MutinyLogger::default());
-        let cipher = password
-            .as_ref()
-            .filter(|p| !p.is_empty())
-            .map(|p| encryption_key_from_pass(p))
-            .transpose()?;
-        let storage = IndexedDbStorage::new(password, cipher, None, logger).await?;
+        let storage = IndexedDbStorage::new(password, None, logger).await?;
         mutiny_core::MutinyWallet::<IndexedDbStorage>::restore_mnemonic(
             storage,
             Mnemonic::from_str(&m).map_err(|_| MutinyJsError::InvalidMnemonic)?,


### PR DESCRIPTION
Noticed this when working on some storage stuff. We initialized the `cipher` the same way everywhere but had it outside the constructor. This way you just need to pass the `password` to the storage constructor and it will handle the rest