### PR TITLE
Add helper for is nwc profile is active

### DIFF
--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -77,7 +77,7 @@ impl<S: MutinyStorage> NostrManager<S> {
             .read()
             .unwrap()
             .iter()
-            .filter(|x| x.profile.enabled)
+            .filter(|x| x.profile.active())
             .map(|x| x.profile.relay.clone())
             .collect();
 
@@ -93,7 +93,7 @@ impl<S: MutinyStorage> NostrManager<S> {
             .read()
             .unwrap()
             .iter()
-            .filter(|x| x.profile.enabled && !x.profile.archived)
+            .filter(|x| x.profile.active())
             .map(|nwc| nwc.create_nwc_filter())
             .collect()
     }

--- a/mutiny-core/src/nostr/nwc.rs
+++ b/mutiny-core/src/nostr/nwc.rs
@@ -84,6 +84,12 @@ pub(crate) struct Profile {
     pub tag: NwcProfileTag,
 }
 
+impl Profile {
+    pub fn active(&self) -> bool {
+        self.enabled && !self.archived
+    }
+}
+
 impl PartialOrd for Profile {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.index.partial_cmp(&other.index)
@@ -196,7 +202,7 @@ impl NostrWalletConnect {
     ) -> anyhow::Result<(Option<Event>, bool)> {
         let client_pubkey = self.client_key.public_key();
         let mut needs_save = false;
-        if self.profile.enabled
+        if self.profile.active()
             && event.kind == Kind::WalletConnectRequest
             && event.pubkey == client_pubkey
         {


### PR DESCRIPTION
We can have some weird possibilities where a profile is archived but still enabled. This should fix any issues where we would still use that profile.

This would only happen if the front end archived a nwc without disabling it. But still better to handle for now