### PR TITLE
Auto approve NWC with budget

### DIFF
--- a/mutiny-core/rust-toolchain.toml
+++ b/mutiny-core/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-default = "nightly"
+channel = "nightly"

--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -250,7 +250,7 @@ impl<S: MutinyStorage> EventHandler<S> {
                 };
                 match self
                     .persister
-                    .read_payment_info(&payment_hash, true, &self.logger)
+                    .read_payment_info(&payment_hash.0, true, &self.logger)
                 {
                     Some(mut saved_payment_info) => {
                         let payment_preimage = payment_preimage.map(|p| p.0);
@@ -261,7 +261,7 @@ impl<S: MutinyStorage> EventHandler<S> {
                         saved_payment_info.amt_msat = MillisatAmount(Some(amount_msat));
                         saved_payment_info.last_update = crate::utils::now().as_secs();
                         match self.persister.persist_payment_info(
-                            &payment_hash,
+                            &payment_hash.0,
                             &saved_payment_info,
                             true,
                         ) {
@@ -288,7 +288,7 @@ impl<S: MutinyStorage> EventHandler<S> {
                             last_update,
                         };
                         match self.persister.persist_payment_info(
-                            &payment_hash,
+                            &payment_hash.0,
                             &payment_info,
                             true,
                         ) {
@@ -315,7 +315,7 @@ impl<S: MutinyStorage> EventHandler<S> {
 
                 match self
                     .persister
-                    .read_payment_info(&payment_hash, false, &self.logger)
+                    .read_payment_info(&payment_hash.0, false, &self.logger)
                 {
                     Some(mut saved_payment_info) => {
                         saved_payment_info.status = HTLCStatus::Succeeded;
@@ -323,7 +323,7 @@ impl<S: MutinyStorage> EventHandler<S> {
                         saved_payment_info.fee_paid_msat = fee_paid_msat;
                         saved_payment_info.last_update = crate::utils::now().as_secs();
                         match self.persister.persist_payment_info(
-                            &payment_hash,
+                            &payment_hash.0,
                             &saved_payment_info,
                             false,
                         ) {
@@ -408,13 +408,13 @@ impl<S: MutinyStorage> EventHandler<S> {
 
                 match self
                     .persister
-                    .read_payment_info(&payment_hash, false, &self.logger)
+                    .read_payment_info(&payment_hash.0, false, &self.logger)
                 {
                     Some(mut saved_payment_info) => {
                         saved_payment_info.status = HTLCStatus::Failed;
                         saved_payment_info.last_update = crate::utils::now().as_secs();
                         match self.persister.persist_payment_info(
-                            &payment_hash,
+                            &payment_hash.0,
                             &saved_payment_info,
                             false,
                         ) {

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -322,7 +322,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
 
     pub(crate) fn persist_payment_info(
         &self,
-        payment_hash: &PaymentHash,
+        payment_hash: &[u8; 32],
         payment_info: &PaymentInfo,
         inbound: bool,
     ) -> io::Result<()> {
@@ -334,7 +334,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
 
     pub(crate) fn read_payment_info(
         &self,
-        payment_hash: &PaymentHash,
+        payment_hash: &[u8; 32],
         inbound: bool,
         logger: &MutinyLogger,
     ) -> Option<PaymentInfo> {
@@ -558,18 +558,18 @@ impl ChannelOpenParams {
     }
 }
 
-fn payment_key(inbound: bool, payment_hash: &PaymentHash) -> String {
+fn payment_key(inbound: bool, payment_hash: &[u8; 32]) -> String {
     if inbound {
         format!(
             "{}{}",
             PAYMENT_INBOUND_PREFIX_KEY,
-            payment_hash.0.to_hex().as_str()
+            payment_hash.to_hex().as_str()
         )
     } else {
         format!(
             "{}{}",
             PAYMENT_OUTBOUND_PREFIX_KEY,
-            payment_hash.0.to_hex().as_str()
+            payment_hash.to_hex().as_str()
         )
     }
 }
@@ -734,10 +734,10 @@ mod test {
             secret: None,
             last_update: utils::now().as_secs(),
         };
-        let result = persister.persist_payment_info(&payment_hash, &payment_info, true);
+        let result = persister.persist_payment_info(&payment_hash.0, &payment_info, true);
         assert!(result.is_ok());
 
-        let result = persister.read_payment_info(&payment_hash, true, &MutinyLogger::default());
+        let result = persister.read_payment_info(&payment_hash.0, true, &MutinyLogger::default());
 
         assert!(result.is_some());
         assert_eq!(result.clone().unwrap().preimage, Some(preimage));
@@ -748,7 +748,7 @@ mod test {
         assert_eq!(list[0].0, payment_hash);
         assert_eq!(list[0].1.preimage, Some(preimage));
 
-        let result = persister.read_payment_info(&payment_hash, true, &MutinyLogger::default());
+        let result = persister.read_payment_info(&payment_hash.0, true, &MutinyLogger::default());
 
         assert!(result.is_some());
         assert_eq!(result.clone().unwrap().preimage, Some(preimage));

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -266,16 +266,16 @@ impl<S: MutinyStorage> NostrManager<S> {
             }
             // Ensure normal profiles start from 1000
             ProfileType::Normal { name } => {
-                let normal_profiles_count = profiles
+                let next_index = profiles
                     .iter()
                     .filter(|&nwc| nwc.profile.index >= USER_NWC_PROFILE_START_INDEX)
-                    .count() as u32;
+                    .max_by(|a, b| a.profile.index.cmp(&b.profile.index))
+                    .map(|nwc| nwc.profile.index + 1)
+                    .unwrap_or(USER_NWC_PROFILE_START_INDEX);
 
-                (
-                    name,
-                    normal_profiles_count + USER_NWC_PROFILE_START_INDEX,
-                    Some(get_random_bip32_child_index()),
-                )
+                debug_assert!(next_index >= USER_NWC_PROFILE_START_INDEX);
+
+                (name, next_index, Some(get_random_bip32_child_index()))
             }
         };
 

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -218,10 +218,17 @@ impl<S: MutinyStorage> NostrManager<S> {
             .find(|nwc| nwc.profile.index == profile_index)
             .ok_or(MutinyError::NotFound)?;
 
+        let payments = if let SpendingConditions::Budget(budget) = &nwc.profile.spending_conditions
+        {
+            budget.payments.clone()
+        } else {
+            vec![]
+        };
+
         nwc.profile.spending_conditions = SpendingConditions::Budget(BudgetedSpendingConditions {
             budget: budget_sats,
             single_max: single_max_sats,
-            payments: vec![],
+            payments,
             period: budget_period,
         });
 

--- a/mutiny-core/src/nostr/nwc.rs
+++ b/mutiny-core/src/nostr/nwc.rs
@@ -1,13 +1,15 @@
 use crate::error::MutinyError;
+use crate::event::HTLCStatus;
 use crate::nodemanager::NodeManager;
 use crate::nostr::NostrManager;
 use crate::storage::MutinyStorage;
 use crate::utils;
 use anyhow::anyhow;
+use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::secp256k1::{PublicKey, Secp256k1, Signing};
 use bitcoin::util::bip32::ExtendedPrivKey;
+use chrono::{DateTime, Datelike, Duration, NaiveDateTime, Utc};
 use core::fmt;
-use futures_util::lock::Mutex;
 use lightning::util::logger::Logger;
 use lightning::{log_error, log_warn};
 use lightning_invoice::Bolt11Invoice;
@@ -28,10 +30,105 @@ pub struct SingleUseSpendingConditions {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TrackedPayment {
+    /// Time in seconds since epoch
+    pub time: u64,
+    /// Amount in sats
+    pub amt: u64,
+    /// Payment hash
+    pub hash: String,
+}
+
+/// When payments for a given payment expire
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum BudgetPeriod {
+    /// Resets daily at midnight UTC
+    Day,
+    /// Resets every week on sunday, midnight UTC
+    Week,
+    /// Resets every month on the first, midnight UTC
+    Month,
+    /// Resets every year on the January 1st, midnight UTC
+    Year,
+    /// Payments not older than the given number of seconds are counted
+    Seconds(u64),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BudgetedSpendingConditions {
+    /// Amount in sats for the allotted budget period
+    pub budget: u64,
+    /// Max amount in sats for a single payment
+    pub single_max: Option<u64>,
+    /// Payment history
+    pub payments: Vec<TrackedPayment>,
+    /// Time period the budget is for
+    pub period: BudgetPeriod,
+}
+
+impl BudgetedSpendingConditions {
+    pub fn add_payment(&mut self, invoice: &Bolt11Invoice) {
+        let time = utils::now().as_secs();
+        let payment = TrackedPayment {
+            time,
+            amt: invoice.amount_milli_satoshis().unwrap_or_default() / 1_000,
+            hash: invoice.payment_hash().to_hex(),
+        };
+
+        self.payments.push(payment);
+    }
+
+    pub fn remove_payment(&mut self, invoice: &Bolt11Invoice) {
+        self.payments
+            .retain(|p| p.hash != invoice.payment_hash().to_hex());
+    }
+
+    fn clean_old_payments(&mut self, now: DateTime<Utc>) {
+        let period_start = match self.period {
+            BudgetPeriod::Day => now.date_naive().and_hms_opt(0, 0, 0).unwrap(),
+            BudgetPeriod::Week => (now
+                - Duration::days((now.weekday().num_days_from_sunday()) as i64))
+            .date_naive()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+            BudgetPeriod::Month => now
+                .date_naive()
+                .with_day(1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+            BudgetPeriod::Year => NaiveDateTime::new(
+                now.date_naive().with_ordinal(1).unwrap(),
+                chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+            ),
+            BudgetPeriod::Seconds(secs) => now
+                .checked_sub_signed(Duration::seconds(secs as i64))
+                .unwrap()
+                .naive_utc(),
+        };
+
+        self.payments
+            .retain(|p| p.time > period_start.timestamp() as u64)
+    }
+
+    pub fn sum_payments(&mut self) -> u64 {
+        let now = Utc::now();
+        self.clean_old_payments(now);
+        self.payments.iter().map(|p| p.amt).sum()
+    }
+
+    pub fn budget_remaining(&self) -> u64 {
+        let mut clone = self.clone();
+        self.budget - clone.sum_payments()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SpendingConditions {
     SingleUse(SingleUseSpendingConditions),
     /// Require approval before sending a payment
     RequireApproval,
+    Budget(BudgetedSpendingConditions),
 }
 
 impl Default for SpendingConditions {
@@ -194,14 +291,14 @@ impl NostrWalletConnect {
 
     /// Handle a Nostr Wallet Connect request
     ///
-    /// Returns a response event if one is needed and if the profile needs to be saved to disk
+    /// Returns a response event if one is needed
     pub async fn handle_nwc_request<S: MutinyStorage>(
         &mut self,
         event: Event,
         node_manager: &NodeManager<S>,
         from_node: &PublicKey,
-        pending_nwc_lock: &Mutex<()>,
-    ) -> anyhow::Result<(Option<Event>, bool)> {
+        nostr_manager: &NostrManager<S>,
+    ) -> anyhow::Result<Option<Event>> {
         let client_pubkey = self.client_key.public_key();
         let mut needs_save = false;
         if self.profile.active()
@@ -215,7 +312,7 @@ impl NostrWalletConnect {
 
             // only respond to pay invoice requests
             if req.method != Method::PayInvoice {
-                return Ok((None, needs_save));
+                return Ok(None);
             }
 
             let invoice = match req.params {
@@ -226,7 +323,7 @@ impl NostrWalletConnect {
 
             // if the invoice has expired, skip it
             if invoice.would_expire(utils::now()) {
-                return Ok((None, needs_save));
+                return Ok(None);
             }
 
             // if the invoice has no amount, we cannot pay it
@@ -235,13 +332,13 @@ impl NostrWalletConnect {
                     node_manager.logger,
                     "NWC Invoice amount not set, cannot pay: {invoice}"
                 );
-                return Ok((None, needs_save));
+                return Ok(None);
             }
 
             // if we have already paid this invoice, skip it
             let node = node_manager.get_node(from_node).await?;
             if node.get_invoice(&invoice).is_ok_and(|i| i.paid()) {
-                return Ok((None, needs_save));
+                return Ok(None);
             }
             drop(node);
 
@@ -318,7 +415,11 @@ impl NostrWalletConnect {
                         EventBuilder::new(Kind::WalletConnectResponse, encrypted, &[p_tag, e_tag])
                             .to_event(&self.server_key)?;
 
-                    return Ok((Some(response), needs_save));
+                    if needs_save {
+                        nostr_manager.save_nwc_profile(self.clone())?;
+                    }
+
+                    return Ok(Some(response));
                 }
                 SpendingConditions::RequireApproval => {
                     let pending = PendingNwcInvoice {
@@ -327,7 +428,7 @@ impl NostrWalletConnect {
                         event_id: event.id,
                         pubkey: event.pubkey,
                     };
-                    pending_nwc_lock.lock().await;
+                    nostr_manager.pending_nwc_lock.lock().await;
 
                     let mut current: Vec<PendingNwcInvoice> = node_manager
                         .storage
@@ -342,12 +443,127 @@ impl NostrWalletConnect {
                             .set_data(PENDING_NWC_EVENTS_KEY, current, None)?;
                     }
 
-                    return Ok((None, needs_save));
+                    if needs_save {
+                        nostr_manager.save_nwc_profile(self.clone())?;
+                    }
+
+                    return Ok(None);
+                }
+                SpendingConditions::Budget(mut budget) => {
+                    let sats = invoice.amount_milli_satoshis().unwrap() / 1_000;
+
+                    let budget_err = if budget.single_max.is_some_and(|max| sats > max) {
+                        Some("Invoice amount too high.")
+                    } else if budget.sum_payments() + sats > budget.budget {
+                        let node = node_manager.get_node(from_node).await?;
+                        // budget might not actually be exceeded, we should verify that the payments
+                        // all went through, and if not, remove them from the budget
+                        budget.payments.retain(|p| {
+                            let hash: [u8; 32] = FromHex::from_hex(&p.hash).unwrap();
+                            match node.persister.read_payment_info(
+                                &hash,
+                                false,
+                                &node_manager.logger,
+                            ) {
+                                Some(info) => info.status != HTLCStatus::Failed, // remove failed payments from budget
+                                None => true, // if we can't find the payment, keep it to be safe
+                            }
+                        });
+
+                        // update budget with removed payments
+                        self.profile.spending_conditions =
+                            SpendingConditions::Budget(budget.clone());
+
+                        // try again with cleaned budget
+                        if budget.sum_payments() + sats > budget.budget {
+                            Some("Budget exceeded.")
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+
+                    let content = match budget_err {
+                        Some(err) => {
+                            log_warn!(node_manager.logger, "Attempted to exceed budget: {err}");
+                            Response {
+                                result_type: Method::PayInvoice,
+                                error: Some(NIP47Error {
+                                    code: ErrorCode::QuotaExceeded,
+                                    message: err.to_string(),
+                                }),
+                                result: None,
+                            }
+                        }
+                        None => {
+                            // add payment to budget
+                            budget.add_payment(&invoice);
+                            self.profile.spending_conditions =
+                                SpendingConditions::Budget(budget.clone());
+                            // persist budget before payment to protect against it not saving after
+                            nostr_manager.save_nwc_profile(self.clone())?;
+
+                            // attempt to pay invoice
+                            match self
+                                .pay_nwc_invoice(node_manager, from_node, &invoice)
+                                .await
+                            {
+                                Ok(resp) => resp,
+                                Err(e) => {
+                                    // remove payment if it failed
+                                    match e {
+                                        MutinyError::PaymentTimeout => {
+                                            log_warn!(
+                                                node_manager.logger,
+                                                "Payment timeout, not removing payment from budget"
+                                            );
+                                        }
+                                        _ => {
+                                            log_warn!(
+                                                node_manager.logger,
+                                                "Failed to pay invoice: {e}, removing payment from budget"
+                                            );
+
+                                            budget.remove_payment(&invoice);
+                                            self.profile.spending_conditions =
+                                                SpendingConditions::Budget(budget.clone());
+
+                                            nostr_manager.save_nwc_profile(self.clone())?;
+                                        }
+                                    }
+
+                                    Response {
+                                        result_type: Method::PayInvoice,
+                                        error: Some(NIP47Error {
+                                            code: ErrorCode::InsufficientBalance,
+                                            message: format!("Failed to pay invoice: {e}"),
+                                        }),
+                                        result: None,
+                                    }
+                                }
+                            }
+                        }
+                    };
+
+                    let encrypted = encrypt(&server_key, &client_pubkey, content.as_json())?;
+
+                    let p_tag = Tag::PubKey(event.pubkey, None);
+                    let e_tag = Tag::Event(event.id, None, None);
+                    let response =
+                        EventBuilder::new(Kind::WalletConnectResponse, encrypted, &[p_tag, e_tag])
+                            .to_event(&self.server_key)?;
+
+                    return Ok(Some(response));
                 }
             }
         }
 
-        Ok((None, needs_save))
+        if needs_save {
+            nostr_manager.save_nwc_profile(self.clone())?;
+        }
+
+        Ok(None)
     }
 
     pub fn nwc_profile(&self) -> NwcProfile {
@@ -426,5 +642,276 @@ impl Ord for PendingNwcInvoice {
 impl PendingNwcInvoice {
     pub fn is_expired(&self) -> bool {
         self.invoice.would_expire(utils::now())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use chrono::Days;
+
+    #[test]
+    fn test_clean_old_payments_seconds() {
+        let mut budget = BudgetedSpendingConditions {
+            budget: 100,
+            single_max: None,
+            payments: vec![
+                TrackedPayment {
+                    time: 91,
+                    amt: 10,
+                    hash: "1".to_string(),
+                },
+                TrackedPayment {
+                    time: 95,
+                    amt: 20,
+                    hash: "2".to_string(),
+                },
+                TrackedPayment {
+                    time: 97,
+                    amt: 30,
+                    hash: "3".to_string(),
+                },
+            ],
+            period: BudgetPeriod::Seconds(10),
+        };
+
+        let time = NaiveDateTime::from_timestamp_opt(100, 0).unwrap().and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 3);
+
+        let time = time.checked_add_signed(Duration::seconds(2)).unwrap();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 2);
+
+        let time = time.checked_add_signed(Duration::seconds(3)).unwrap();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 1);
+
+        let time = time.checked_add_signed(Duration::seconds(10)).unwrap();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 0);
+    }
+
+    #[test]
+    fn test_clean_old_days() {
+        let zero = NaiveDateTime::default();
+        let mut budget = BudgetedSpendingConditions {
+            budget: 100,
+            single_max: None,
+            payments: vec![
+                TrackedPayment {
+                    time: zero.checked_add_days(Days::new(1)).unwrap().timestamp() as u64,
+                    amt: 10,
+                    hash: "1".to_string(),
+                },
+                TrackedPayment {
+                    time: zero.checked_add_days(Days::new(5)).unwrap().timestamp() as u64,
+                    amt: 20,
+                    hash: "2".to_string(),
+                },
+                TrackedPayment {
+                    time: zero.checked_add_days(Days::new(7)).unwrap().timestamp() as u64,
+                    amt: 30,
+                    hash: "3".to_string(),
+                },
+            ],
+            period: BudgetPeriod::Day,
+        };
+
+        let time = NaiveDateTime::from_timestamp_opt(100, 0).unwrap().and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 3);
+
+        let time = time.checked_add_signed(Duration::days(2)).unwrap();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 2);
+
+        let time = time.checked_add_signed(Duration::days(3)).unwrap();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 1);
+
+        let time = time.checked_add_signed(Duration::days(10)).unwrap();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 0);
+    }
+
+    #[test]
+    fn test_clean_old_weeks() {
+        let mut budget = BudgetedSpendingConditions {
+            budget: 100,
+            single_max: None,
+            payments: vec![
+                TrackedPayment {
+                    time: NaiveDateTime::from_timestamp_opt(1691712000, 0)
+                        .unwrap()
+                        .timestamp() as u64, // 2023-8-11
+                    amt: 10,
+                    hash: "1".to_string(),
+                },
+                TrackedPayment {
+                    time: NaiveDateTime::from_timestamp_opt(1692316800, 0)
+                        .unwrap()
+                        .timestamp() as u64, // 2023-8-18
+                    amt: 20,
+                    hash: "2".to_string(),
+                },
+                TrackedPayment {
+                    time: NaiveDateTime::from_timestamp_opt(1692921600, 0)
+                        .unwrap()
+                        .timestamp() as u64, // 2023-8-25
+                    amt: 30,
+                    hash: "3".to_string(),
+                },
+            ],
+            period: BudgetPeriod::Week,
+        };
+
+        // 2023-8-13
+        let time = NaiveDateTime::from_timestamp_opt(1691798400, 0)
+            .unwrap()
+            .and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 3);
+
+        // 2023-8-14
+        let time = NaiveDateTime::from_timestamp_opt(1691971200, 0)
+            .unwrap()
+            .and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 2);
+
+        // 2023-8-21
+        let time = NaiveDateTime::from_timestamp_opt(1692576000, 0)
+            .unwrap()
+            .and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 1);
+
+        // 2023-8-28
+        let time = NaiveDateTime::from_timestamp_opt(1693180800, 0)
+            .unwrap()
+            .and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 0);
+    }
+
+    #[test]
+    fn test_clean_old_month() {
+        let mut budget = BudgetedSpendingConditions {
+            budget: 100,
+            single_max: None,
+            payments: vec![
+                TrackedPayment {
+                    time: NaiveDateTime::from_timestamp_opt(1683763200, 0)
+                        .unwrap()
+                        .timestamp() as u64, // 2023-5-11
+                    amt: 10,
+                    hash: "1".to_string(),
+                },
+                TrackedPayment {
+                    time: NaiveDateTime::from_timestamp_opt(1686441600, 0)
+                        .unwrap()
+                        .timestamp() as u64, // 2023-6-11
+                    amt: 20,
+                    hash: "2".to_string(),
+                },
+                TrackedPayment {
+                    time: NaiveDateTime::from_timestamp_opt(1689033600, 0)
+                        .unwrap()
+                        .timestamp() as u64, // 2023-7-11
+                    amt: 30,
+                    hash: "3".to_string(),
+                },
+            ],
+            period: BudgetPeriod::Month,
+        };
+
+        // 2023-5-29
+        let time = NaiveDateTime::from_timestamp_opt(1685318400, 0)
+            .unwrap()
+            .and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 3);
+
+        // 2023-6-29
+        let time = NaiveDateTime::from_timestamp_opt(1687996800, 0)
+            .unwrap()
+            .and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 2);
+
+        // 2023-7-29
+        let time = NaiveDateTime::from_timestamp_opt(1690588800, 0)
+            .unwrap()
+            .and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 1);
+
+        // 2023-8-1
+        let time = NaiveDateTime::from_timestamp_opt(1690848000, 0)
+            .unwrap()
+            .and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 0);
+    }
+
+    #[test]
+    fn test_clean_old_year() {
+        let mut budget = BudgetedSpendingConditions {
+            budget: 100,
+            single_max: None,
+            payments: vec![
+                TrackedPayment {
+                    time: NaiveDateTime::from_timestamp_opt(1620691200, 0)
+                        .unwrap()
+                        .timestamp() as u64, // 2021-5-11
+                    amt: 10,
+                    hash: "1".to_string(),
+                },
+                TrackedPayment {
+                    time: NaiveDateTime::from_timestamp_opt(1654905600, 0)
+                        .unwrap()
+                        .timestamp() as u64, // 2022-6-11
+                    amt: 20,
+                    hash: "2".to_string(),
+                },
+                TrackedPayment {
+                    time: NaiveDateTime::from_timestamp_opt(1689033600, 0)
+                        .unwrap()
+                        .timestamp() as u64, // 2023-7-11
+                    amt: 30,
+                    hash: "3".to_string(),
+                },
+            ],
+            period: BudgetPeriod::Year,
+        };
+
+        // 2021-7-11
+        let time = NaiveDateTime::from_timestamp_opt(1625961600, 0)
+            .unwrap()
+            .and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 3);
+
+        // 2022-7-11
+        let time = NaiveDateTime::from_timestamp_opt(1657497600, 0)
+            .unwrap()
+            .and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 2);
+
+        // 2023-9-11
+        let time = NaiveDateTime::from_timestamp_opt(1694390400, 0)
+            .unwrap()
+            .and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 1);
+
+        // 2024-4-20
+        let time = NaiveDateTime::from_timestamp_opt(1713571200, 0)
+            .unwrap()
+            .and_utc();
+        budget.clean_old_payments(time);
+        assert_eq!(budget.payments.len(), 0);
     }
 }

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -1194,6 +1194,17 @@ impl MutinyWallet {
             .into())
     }
 
+    /// Require approval for a NWC Profile
+    #[wasm_bindgen]
+    pub async fn set_nwc_profile_require_approval(
+        &self,
+        profile_index: u32,
+    ) -> Result<models::NwcProfile, MutinyJsError> {
+        let mut profile = self.inner.nostr.get_profile(profile_index)?;
+        profile.spending_conditions = SpendingConditions::RequireApproval;
+        Ok(self.inner.nostr.edit_profile(profile)?.into())
+    }
+
     /// Finds a nostr wallet connect profile by index
     #[wasm_bindgen]
     pub async fn get_nwc_profile(&self, index: u32) -> Result<models::NwcProfile, MutinyJsError> {

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -1178,6 +1178,12 @@ impl MutinyWallet {
         Ok(self.inner.nostr.edit_profile(profile)?.into())
     }
 
+    /// Deletes a nostr wallet connect profile
+    #[wasm_bindgen]
+    pub async fn delete_nwc_profile(&self, profile_index: u32) -> Result<(), MutinyJsError> {
+        Ok(self.inner.nostr.delete_nwc_profile(profile_index)?)
+    }
+
     /// Set budget for a NWC Profile
     #[wasm_bindgen]
     pub async fn set_nwc_profile_budget(

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -36,7 +36,7 @@ use mutiny_core::redshift::RedshiftRecipient;
 use mutiny_core::scb::EncryptedSCB;
 use mutiny_core::storage::MutinyStorage;
 use mutiny_core::vss::MutinyVssClient;
-use mutiny_core::{encrypt::encryption_key_from_pass, generate_seed, nostr::nwc::NwcProfile};
+use mutiny_core::{encrypt::encryption_key_from_pass, generate_seed};
 use mutiny_core::{labels::LabelStorage, nodemanager::NodeManager};
 use mutiny_core::{logging::MutinyLogger, nostr::ProfileType};
 use nostr::key::XOnlyPublicKey;
@@ -1163,19 +1163,6 @@ impl MutinyWallet {
             .create_new_nwc_profile(ProfileType::Normal { name }, sp, NwcProfileTag::General)
             .await?
             .into())
-    }
-
-    /// Edits a nostr wallet connect profile
-    #[wasm_bindgen]
-    pub async fn edit_nwc_profile(
-        &self,
-        profile: &JsValue,
-    ) -> Result<models::NwcProfile, MutinyJsError> {
-        let profile: NwcProfile = profile
-            .into_serde()
-            .map_err(|_| MutinyJsError::InvalidArgumentsError)?;
-
-        Ok(self.inner.nostr.edit_profile(profile)?.into())
     }
 
     /// Deletes a nostr wallet connect profile

--- a/mutiny-wasm/src/models.rs
+++ b/mutiny-wasm/src/models.rs
@@ -904,7 +904,11 @@ impl Serialize for NwcProfile {
             "spending_conditions": json!(self.spending_conditions),
             "nwc_uri": self.nwc_uri,
             "tag": self.tag,
-            "gift_amt": self.gift_amt(),
+            "budget_amount": self.budget_amount(),
+            "budget_period": self.budget_period(),
+            "budget_remaining": self.budget_remaining(),
+            "active_payments": self._active_payments(),
+            "spending_conditions_type": self.spending_conditions_type(),
             "url_suffix": self.url_suffix(),
         });
 
@@ -917,6 +921,15 @@ impl NwcProfile {
     #[wasm_bindgen(getter)]
     pub fn value(&self) -> JsValue {
         JsValue::from_serde(&serde_json::to_value(self).unwrap()).unwrap()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn spending_conditions_type(&self) -> String {
+        match self.spending_conditions {
+            SpendingConditions::SingleUse(_) => "SingleUse".to_string(),
+            SpendingConditions::RequireApproval => "RequireApproval".to_string(),
+            SpendingConditions::Budget(_) => "Budget".to_string(),
+        }
     }
 
     #[wasm_bindgen(getter)]
@@ -940,12 +953,57 @@ impl NwcProfile {
     }
 
     #[wasm_bindgen(getter)]
-    pub fn gift_amt(&self) -> Option<u64> {
-        if let SpendingConditions::SingleUse(ref cond) = self.spending_conditions {
-            Some(cond.amount_sats)
-        } else {
-            None
+    pub fn budget_amount(&self) -> Option<u64> {
+        match &self.spending_conditions {
+            SpendingConditions::Budget(budget) => Some(budget.budget),
+            SpendingConditions::SingleUse(single) => Some(single.amount_sats),
+            SpendingConditions::RequireApproval => None,
         }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn budget_period(&self) -> Option<String> {
+        match &self.spending_conditions {
+            SpendingConditions::Budget(budget) => match budget.period {
+                nostr::nwc::BudgetPeriod::Day => Some("Day".to_string()),
+                nostr::nwc::BudgetPeriod::Week => Some("Week".to_string()),
+                nostr::nwc::BudgetPeriod::Month => Some("Month".to_string()),
+                nostr::nwc::BudgetPeriod::Year => Some("Year".to_string()),
+                nostr::nwc::BudgetPeriod::Seconds(secs) => Some(format!("{secs} Seconds")),
+            },
+            SpendingConditions::SingleUse(_) => None,
+            SpendingConditions::RequireApproval => None,
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn budget_remaining(&self) -> Option<u64> {
+        match &self.spending_conditions {
+            SpendingConditions::Budget(budget) => Some(budget.budget_remaining()),
+            SpendingConditions::SingleUse(single) => {
+                if single.spent {
+                    Some(0)
+                } else {
+                    Some(single.amount_sats)
+                }
+            }
+            SpendingConditions::RequireApproval => None,
+        }
+    }
+
+    fn _active_payments(&self) -> Vec<String> {
+        match &self.spending_conditions {
+            SpendingConditions::Budget(budget) => {
+                budget.payments.iter().map(|x| x.hash.clone()).collect()
+            }
+            SpendingConditions::SingleUse(_) => vec![],
+            SpendingConditions::RequireApproval => vec![],
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn active_payments(&self) -> JsValue /* Vec<String> */ {
+        JsValue::from_serde(&serde_json::to_value(self._active_payments()).unwrap()).unwrap()
     }
 
     #[wasm_bindgen(getter)]
@@ -973,6 +1031,7 @@ impl From<nostr::nwc::NwcProfile> for NwcProfile {
                 }
             }
             SpendingConditions::RequireApproval => (true, 0),
+            SpendingConditions::Budget(budget) => (false, budget.single_max.unwrap_or_default()),
         };
 
         NwcProfile {
@@ -1049,6 +1108,40 @@ impl From<nodemanager::Plan> for Plan {
         Plan {
             id: m.id,
             amount_sat: m.amount_sat,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[wasm_bindgen]
+pub enum BudgetPeriod {
+    Day,
+    Week,
+    Month,
+    Year,
+}
+
+impl From<BudgetPeriod> for nostr::nwc::BudgetPeriod {
+    fn from(value: BudgetPeriod) -> Self {
+        match value {
+            BudgetPeriod::Day => Self::Day,
+            BudgetPeriod::Week => Self::Week,
+            BudgetPeriod::Month => Self::Month,
+            BudgetPeriod::Year => Self::Year,
+        }
+    }
+}
+
+impl TryFrom<nostr::nwc::BudgetPeriod> for BudgetPeriod {
+    type Error = ();
+
+    fn try_from(value: nostr::nwc::BudgetPeriod) -> Result<Self, Self::Error> {
+        match value {
+            nostr::nwc::BudgetPeriod::Day => Ok(Self::Day),
+            nostr::nwc::BudgetPeriod::Week => Ok(Self::Week),
+            nostr::nwc::BudgetPeriod::Month => Ok(Self::Month),
+            nostr::nwc::BudgetPeriod::Year => Ok(Self::Year),
+            nostr::nwc::BudgetPeriod::Seconds(_) => Err(()),
         }
     }
 }

--- a/mutiny-wasm/src/models.rs
+++ b/mutiny-wasm/src/models.rs
@@ -879,8 +879,6 @@ pub struct NwcProfile {
     /// Maximum amount of sats that can be sent in a single payment
     pub max_single_amt_sats: u64,
     relay: String,
-    pub enabled: bool,
-    pub archived: bool,
     /// Require approval before sending a payment
     pub require_approval: bool,
     spending_conditions: SpendingConditions,
@@ -898,8 +896,6 @@ impl Serialize for NwcProfile {
             "index": self.index,
             "max_single_amt_sats": self.max_single_amt_sats,
             "relay": self.relay,
-            "enabled": self.enabled,
-            "archived": self.archived,
             "require_approval": self.require_approval,
             "spending_conditions": json!(self.spending_conditions),
             "nwc_uri": self.nwc_uri,
@@ -981,7 +977,7 @@ impl NwcProfile {
         match &self.spending_conditions {
             SpendingConditions::Budget(budget) => Some(budget.budget_remaining()),
             SpendingConditions::SingleUse(single) => {
-                if single.spent {
+                if single.payment_hash.is_some() {
                     Some(0)
                 } else {
                     Some(single.amount_sats)
@@ -1024,7 +1020,7 @@ impl From<nostr::nwc::NwcProfile> for NwcProfile {
     fn from(value: nostr::nwc::NwcProfile) -> Self {
         let (require_approval, max_single_amt_sats) = match value.spending_conditions.clone() {
             SpendingConditions::SingleUse(single) => {
-                if single.spent {
+                if single.payment_hash.is_some() {
                     (false, 0)
                 } else {
                     (false, single.amount_sats)
@@ -1039,8 +1035,6 @@ impl From<nostr::nwc::NwcProfile> for NwcProfile {
             index: value.index,
             relay: value.relay,
             max_single_amt_sats,
-            enabled: value.enabled,
-            archived: value.archived,
             require_approval,
             spending_conditions: value.spending_conditions,
             nwc_uri: value.nwc_uri,


### PR DESCRIPTION
Closes #724

First commit fixes some types up to make it easier to lookup invoices without having to convert between `PaymentHash` and `sha256::Hash` which were used interchangeably 

2nd commit is the meat. This adds the auto approval with a budget. The idea is we save payments that we've made (or attempted) over the given time period. The most complicated part is handling payment timeouts. To handle that we save the payment hash of invoices and when we are checking our budget, we only filter out ones that are explicitly failed, making sure inflight payments are counted to budget.

test with https://github.com/MutinyWallet/mutiny-web/pull/501