### PR TITLE
Allow fallback for get_bitcoin_price

### DIFF
--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2284,8 +2284,9 @@ impl<S: MutinyStorage> NodeManager<S> {
     }
 
     /// Gets the current bitcoin price in USD.
-    pub async fn get_bitcoin_price(&self, fiat: String) -> Result<f32, MutinyError> {
+    pub async fn get_bitcoin_price(&self, fiat: Option<String>) -> Result<f32, MutinyError> {
         let now = crate::utils::now();
+        let fiat = fiat.unwrap_or("usd".to_string());
 
         let mut bitcoin_price_cache = self.bitcoin_price_cache.lock().await;
 

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -1087,7 +1087,7 @@ impl MutinyWallet {
 
     /// Gets the current bitcoin price in chosen Fiat.
     #[wasm_bindgen]
-    pub async fn get_bitcoin_price(&self, fiat: String) -> Result<f32, MutinyJsError> {
+    pub async fn get_bitcoin_price(&self, fiat: Option<String>) -> Result<f32, MutinyJsError> {
         Ok(self.inner.node_manager.get_bitcoin_price(fiat).await?)
     }
 


### PR DESCRIPTION
Adds a fallback for .get_bitcoin_price() and allows it to be optional

Is it better to use unwrap_or_else()
https://stackoverflow.com/questions/56726571/why-choosing-unwrap-or-else-over-unwrap-or