### PR TITLE
Use a reference to JsValue in mutiny-wasm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Build wasm
         env:
           RUSTUP_TOOLCHAIN: nightly
-        run: wasm-pack build ./mutiny-wasm --release --target web --scope mutinywallet
+        run: wasm-pack build ./mutiny-wasm --release --weak-refs --target web --scope mutinywallet
 
       - name: Publish wasm
         run: wasm-pack publish --access public -t web

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build wasm package
         env:
           RUSTUP_TOOLCHAIN: nightly
-        run: wasm-pack build ./mutiny-wasm --release --target web
+        run: wasm-pack build ./mutiny-wasm --release --weak-refs --target web
 
   browser_tests:
     name: Browser Tests

--- a/justfile
+++ b/justfile
@@ -1,14 +1,14 @@
 pack:
-    wasm-pack build ./mutiny-wasm --dev --target web --scope mutinywallet
+    wasm-pack build ./mutiny-wasm --dev --weak-refs --target web --scope mutinywallet
 
 link:
-    wasm-pack build ./mutiny-wasm --dev --target web --scope mutinywallet && cd mutiny-wasm/pkg && pnpm link --global
+    wasm-pack build ./mutiny-wasm --dev --weak-refs --target web --scope mutinywallet && cd mutiny-wasm/pkg && pnpm link --global
 
 login:
     wasm-pack login --scope=@mutinywallet
 
 release:
-    wasm-pack build ./mutiny-wasm --release --target web --scope mutinywallet
+    wasm-pack build ./mutiny-wasm --release --weak-refs --target web --scope mutinywallet
 
 publish:
     wasm-pack publish --access public -t web

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -250,7 +250,7 @@ impl MutinyWallet {
     #[wasm_bindgen]
     pub fn get_new_address(
         &self,
-        labels: JsValue, /* Vec<String> */
+        labels: &JsValue, /* Vec<String> */
     ) -> Result<MutinyBip21RawMaterials, MutinyJsError> {
         let labels: Vec<String> = labels
             .into_serde()
@@ -301,7 +301,7 @@ impl MutinyWallet {
     pub async fn create_bip21(
         &self,
         amount: Option<u64>,
-        labels: JsValue, /* Vec<String> */
+        labels: &JsValue, /* Vec<String> */
     ) -> Result<MutinyBip21RawMaterials, MutinyJsError> {
         let labels: Vec<String> = labels
             .into_serde()
@@ -323,7 +323,7 @@ impl MutinyWallet {
         &self,
         destination_address: String,
         amount: u64,
-        labels: JsValue, /* Vec<String> */
+        labels: &JsValue, /* Vec<String> */
         fee_rate: Option<f32>,
     ) -> Result<String, MutinyJsError> {
         let send_to = Address::from_str(&destination_address)?;
@@ -346,7 +346,7 @@ impl MutinyWallet {
     pub async fn sweep_wallet(
         &self,
         destination_address: String,
-        labels: JsValue, /* Vec<String> */
+        labels: &JsValue, /* Vec<String> */
         fee_rate: Option<f32>,
     ) -> Result<String, MutinyJsError> {
         let send_to = Address::from_str(&destination_address)?;
@@ -564,7 +564,7 @@ impl MutinyWallet {
     pub async fn create_invoice(
         &self,
         amount: Option<u64>,
-        labels: JsValue, /* Vec<String> */
+        labels: &JsValue, /* Vec<String> */
     ) -> Result<MutinyInvoice, MutinyJsError> {
         let labels: Vec<String> = labels
             .into_serde()
@@ -586,7 +586,7 @@ impl MutinyWallet {
         from_node: String,
         invoice_str: String,
         amt_sats: Option<u64>,
-        labels: JsValue, /* Vec<String> */
+        labels: &JsValue, /* Vec<String> */
     ) -> Result<MutinyInvoice, MutinyJsError> {
         let from_node = PublicKey::from_str(&from_node)?;
         let invoice = Bolt11Invoice::from_str(&invoice_str)?;
@@ -609,7 +609,7 @@ impl MutinyWallet {
         from_node: String,
         to_node: String,
         amt_sats: u64,
-        labels: JsValue, /* Vec<String> */
+        labels: &JsValue, /* Vec<String> */
     ) -> Result<MutinyInvoice, MutinyJsError> {
         let from_node = PublicKey::from_str(&from_node)?;
         let to_node = PublicKey::from_str(&to_node)?;
@@ -661,7 +661,7 @@ impl MutinyWallet {
         lnurl: String,
         amount_sats: u64,
         zap_npub: Option<String>,
-        labels: JsValue, /* Vec<String> */
+        labels: &JsValue, /* Vec<String> */
     ) -> Result<MutinyInvoice, MutinyJsError> {
         let from_node = PublicKey::from_str(&from_node)?;
         let lnurl = LnUrl::from_str(&lnurl)?;
@@ -975,7 +975,7 @@ impl MutinyWallet {
     pub fn set_address_labels(
         &self,
         address: String,
-        labels: JsValue, /* Vec<String> */
+        labels: &JsValue, /* Vec<String> */
     ) -> Result<(), MutinyJsError> {
         let address = Address::from_str(&address)?;
         let labels: Vec<String> = labels
@@ -1001,7 +1001,7 @@ impl MutinyWallet {
     pub fn set_invoice_labels(
         &self,
         invoice: String,
-        labels: JsValue, /* Vec<String> */
+        labels: &JsValue, /* Vec<String> */
     ) -> Result<(), MutinyJsError> {
         let invoice = Bolt11Invoice::from_str(&invoice)?;
         let labels: Vec<String> = labels
@@ -1137,7 +1137,7 @@ impl MutinyWallet {
     #[wasm_bindgen]
     pub async fn edit_nwc_profile(
         &self,
-        profile: JsValue,
+        profile: &JsValue,
     ) -> Result<models::NwcProfile, MutinyJsError> {
         let profile: NwcProfile = profile
             .into_serde()


### PR DESCRIPTION
Maybe helps with #710 

First commit changes to use `&JsValue` for all our function commands, this seems like it is the standard thing to do for our usecase.

https://rustwasm.github.io/docs/wasm-bindgen/reference/reference-types.html

Second commit enables weak refs for wasm-bindgen, this seems like it will really help. From my understanding, this will make it so after something is returned from rust to the browser, before it would wait for us to call `free()` on it to get rid of it (which we never do). With this it leaves it available to the js garbage collector.

https://rustwasm.github.io/docs/wasm-bindgen/reference/weak-references.html

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef