### PR TITLE
Revert "Initiate cipher inside storage constructor"

### DIFF
--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -238,7 +238,9 @@ mod tests {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    use crate::{keymanager::pubkey_from_keys_manager, test_utils::*};
+    use crate::{
+        encrypt::encryption_key_from_pass, keymanager::pubkey_from_keys_manager, test_utils::*,
+    };
 
     use super::create_keys_manager;
     use crate::fees::MutinyFeeEstimator;
@@ -267,7 +269,8 @@ mod tests {
         );
         let esplora = Arc::new(MultiEsploraClient::new(vec![esplora]));
         let pass = uuid::Uuid::new_v4().to_string();
-        let db = MemoryStorage::new(Some(pass), None).unwrap();
+        let cipher = encryption_key_from_pass(&pass).unwrap();
+        let db = MemoryStorage::new(Some(pass), Some(cipher), None);
         let logger = Arc::new(MutinyLogger::default());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -542,7 +542,10 @@ impl<S: MutinyStorage> MutinyWallet<S> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{generate_seed, nodemanager::NodeManager, MutinyWallet, MutinyWalletConfig};
+    use crate::{
+        encrypt::encryption_key_from_pass, generate_seed, nodemanager::NodeManager, MutinyWallet,
+        MutinyWalletConfig,
+    };
     use bitcoin::util::bip32::ExtendedPrivKey;
     use bitcoin::Network;
 
@@ -562,7 +565,8 @@ mod tests {
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &mnemonic.to_seed("")).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let storage = MemoryStorage::new(Some(pass), None).unwrap();
+        let cipher = encryption_key_from_pass(&pass).unwrap();
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfig::new(
             xpriv,
@@ -591,7 +595,8 @@ mod tests {
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &[0; 32]).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let storage = MemoryStorage::new(Some(pass), None).unwrap();
+        let cipher = encryption_key_from_pass(&pass).unwrap();
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfig::new(
             xpriv,
@@ -625,7 +630,8 @@ mod tests {
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &[0; 32]).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let storage = MemoryStorage::new(Some(pass), None).unwrap();
+        let cipher = encryption_key_from_pass(&pass).unwrap();
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
 
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfig::new(
@@ -662,7 +668,8 @@ mod tests {
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &mnemonic.to_seed("")).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let storage = MemoryStorage::new(Some(pass), None).unwrap();
+        let cipher = encryption_key_from_pass(&pass).unwrap();
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let config = MutinyWalletConfig::new(
             xpriv,
@@ -685,7 +692,8 @@ mod tests {
 
         // create a second mw and make sure it has a different seed
         let pass = uuid::Uuid::new_v4().to_string();
-        let storage2 = MemoryStorage::new(Some(pass), None).unwrap();
+        let cipher = encryption_key_from_pass(&pass).unwrap();
+        let storage2 = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage2.clone()));
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &[0; 32]).unwrap();
         let mut config2 = MutinyWalletConfig::new(
@@ -712,7 +720,8 @@ mod tests {
         drop(mw2);
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let storage3 = MemoryStorage::new(Some(pass), None).unwrap();
+        let cipher = encryption_key_from_pass(&pass).unwrap();
+        let storage3 = MemoryStorage::new(Some(pass), Some(cipher), None);
         MutinyWallet::restore_mnemonic(storage3.clone(), mnemonic.clone())
             .await
             .expect("mutiny wallet should restore");

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2567,8 +2567,11 @@ pub(crate) async fn create_new_node_from_node_manager<S: MutinyStorage>(
 
 #[cfg(test)]
 mod tests {
-    use crate::nodemanager::{
-        ActivityItem, ChannelClosure, MutinyInvoice, NodeManager, TransactionDetails,
+    use crate::{
+        encrypt::encryption_key_from_pass,
+        nodemanager::{
+            ActivityItem, ChannelClosure, MutinyInvoice, NodeManager, TransactionDetails,
+        },
     };
     use crate::{keymanager::generate_seed, MutinyWalletConfig};
     use bdk::chain::ConfirmationTime;
@@ -2599,7 +2602,8 @@ mod tests {
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &seed.to_seed("")).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let storage = MemoryStorage::new(Some(pass), None).unwrap();
+        let cipher = encryption_key_from_pass(&pass).unwrap();
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
 
         assert!(!NodeManager::has_node_manager(storage.clone()));
         let c = MutinyWalletConfig::new(
@@ -2628,7 +2632,8 @@ mod tests {
         log!("{}", test_name);
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let storage = MemoryStorage::new(Some(pass), None).unwrap();
+        let cipher = encryption_key_from_pass(&pass).unwrap();
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         let seed = generate_seed(12).expect("Failed to gen seed");
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &seed.to_seed("")).unwrap();
         let c = MutinyWalletConfig::new(
@@ -2678,7 +2683,8 @@ mod tests {
         log!("{}", test_name);
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let storage = MemoryStorage::new(Some(pass), None).unwrap();
+        let cipher = encryption_key_from_pass(&pass).unwrap();
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         let seed = generate_seed(12).expect("Failed to gen seed");
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &seed.to_seed("")).unwrap();
         let c = MutinyWalletConfig::new(
@@ -2713,7 +2719,8 @@ mod tests {
         log!("{}", test_name);
 
         let pass = uuid::Uuid::new_v4().to_string();
-        let storage = MemoryStorage::new(Some(pass), None).unwrap();
+        let cipher = encryption_key_from_pass(&pass).unwrap();
+        let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         let seed = generate_seed(12).expect("Failed to gen seed");
         let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &seed.to_seed("")).unwrap();
         let c = MutinyWalletConfig::new(

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -705,7 +705,7 @@ mod test {
         let xprivkey =
             ExtendedPrivKey::new_master(Network::Bitcoin, &mnemonic.to_seed("")).unwrap();
 
-        let storage = MemoryStorage::new(None, None).unwrap();
+        let storage = MemoryStorage::new(None, None, None);
 
         NostrManager::from_mnemonic(xprivkey, storage).unwrap()
     }

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -632,8 +632,8 @@ pub(crate) fn get_esplora_url(network: Network, user_provided_url: Option<String
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::MemoryStorage;
     use crate::test_utils::*;
+    use crate::{encrypt::encryption_key_from_pass, storage::MemoryStorage};
     use bip39::Mnemonic;
     use bitcoin::Address;
     use esplora_client::Builder;
@@ -650,7 +650,8 @@ mod tests {
         );
         let esplora = Arc::new(MultiEsploraClient::new(vec![esplora]));
         let pass = uuid::Uuid::new_v4().to_string();
-        let db = MemoryStorage::new(Some(pass), None).unwrap();
+        let cipher = encryption_key_from_pass(&pass).unwrap();
+        let db = MemoryStorage::new(Some(pass), Some(cipher), None);
         let logger = Arc::new(MutinyLogger::default());
         let fees = Arc::new(MutinyFeeEstimator::new(
             db.clone(),

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -36,7 +36,7 @@ use mutiny_core::redshift::RedshiftRecipient;
 use mutiny_core::scb::EncryptedSCB;
 use mutiny_core::storage::MutinyStorage;
 use mutiny_core::vss::MutinyVssClient;
-use mutiny_core::{generate_seed, nostr::nwc::NwcProfile};
+use mutiny_core::{encrypt::encryption_key_from_pass, generate_seed, nostr::nwc::NwcProfile};
 use mutiny_core::{labels::LabelStorage, nodemanager::NodeManager};
 use mutiny_core::{logging::MutinyLogger, nostr::ProfileType};
 use nostr::key::XOnlyPublicKey;
@@ -89,11 +89,18 @@ impl MutinyWallet {
         let safe_mode = safe_mode.unwrap_or(false);
         let logger = Arc::new(MutinyLogger::default());
 
+        let cipher = password
+            .as_ref()
+            .filter(|p| !p.is_empty())
+            .map(|p| encryption_key_from_pass(p))
+            .transpose()?;
+
         let network: Network = network_str
             .map(|s| s.parse().expect("Invalid network"))
             .unwrap_or(Network::Bitcoin);
 
-        let storage = IndexedDbStorage::new(password.clone(), None, logger.clone()).await?;
+        let storage =
+            IndexedDbStorage::new(password.clone(), cipher.clone(), None, logger.clone()).await?;
 
         let mnemonic = match mnemonic_str {
             Some(m) => {
@@ -148,7 +155,7 @@ impl MutinyWallet {
             (None, None)
         };
 
-        let storage = IndexedDbStorage::new(password, vss_client, logger.clone()).await?;
+        let storage = IndexedDbStorage::new(password, cipher, vss_client, logger.clone()).await?;
 
         let mut config = mutiny_core::MutinyWalletConfig::new(
             xprivkey,
@@ -184,7 +191,16 @@ impl MutinyWallet {
     #[wasm_bindgen]
     pub async fn has_node_manager(password: Option<String>) -> bool {
         let logger = Arc::new(MutinyLogger::default());
-        let storage = IndexedDbStorage::new(password, None, logger)
+        let cipher = match password
+            .as_ref()
+            .filter(|p| !p.is_empty())
+            .map(|p| encryption_key_from_pass(p))
+            .transpose()
+        {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+        let storage = IndexedDbStorage::new(password, cipher, None, logger)
             .await
             .expect("Failed to init");
         NodeManager::has_node_manager(storage)
@@ -1080,7 +1096,7 @@ impl MutinyWallet {
     pub async fn get_logs() -> Result<JsValue /* Option<Vec<String>> */, MutinyJsError> {
         let logger = Arc::new(MutinyLogger::default());
         // Password should not be required for logs
-        let storage = IndexedDbStorage::new(None, None, logger.clone()).await?;
+        let storage = IndexedDbStorage::new(None, None, None, logger.clone()).await?;
         let stop = Arc::new(AtomicBool::new(false));
         let logger = Arc::new(MutinyLogger::with_writer(stop.clone(), storage.clone()));
         let res = JsValue::from_serde(&NodeManager::get_logs(storage, logger)?)?;
@@ -1284,8 +1300,13 @@ impl MutinyWallet {
     #[wasm_bindgen]
     pub async fn export_json(password: Option<String>) -> Result<String, MutinyJsError> {
         let logger = Arc::new(MutinyLogger::default());
+        let cipher = password
+            .as_ref()
+            .filter(|p| !p.is_empty())
+            .map(|p| encryption_key_from_pass(p))
+            .transpose()?;
         // todo init vss
-        let storage = IndexedDbStorage::new(password, None, logger).await?;
+        let storage = IndexedDbStorage::new(password, cipher, None, logger).await?;
         if storage.get_mnemonic().is_err() {
             // if we get an error, then we have the wrong password
             return Err(MutinyJsError::IncorrectPassword);
@@ -1321,7 +1342,12 @@ impl MutinyWallet {
         password: Option<String>,
     ) -> Result<(), MutinyJsError> {
         let logger = Arc::new(MutinyLogger::default());
-        let storage = IndexedDbStorage::new(password, None, logger).await?;
+        let cipher = password
+            .as_ref()
+            .filter(|p| !p.is_empty())
+            .map(|p| encryption_key_from_pass(p))
+            .transpose()?;
+        let storage = IndexedDbStorage::new(password, cipher, None, logger).await?;
         mutiny_core::MutinyWallet::<IndexedDbStorage>::restore_mnemonic(
             storage,
             Mnemonic::from_str(&m).map_err(|_| MutinyJsError::InvalidMnemonic)?,


### PR DESCRIPTION
This reverts commit 8b3c926b7dcbb1fd12426307651f5663fb7f86a6.

I remember why I did it this way, it's because of multiple initializations of things. We call `MemoryStorage::new()` inside of `IndexedDbStorage` so that calls the cipher code twice which is a really heavy operation. Perhaps we can pass it just to `MemoryStorage`, but I want to revert this now before we deploy, I'm investigating a different password issue ATM. 