### PR TITLE
Use Ordering::SeqCst for manager version

### DIFF
--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -189,7 +189,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
                 )?;
 
                 self.manager_version
-                    .swap(versioned_value.version, Ordering::Relaxed);
+                    .swap(versioned_value.version, Ordering::SeqCst);
 
                 Ok(res)
             }
@@ -592,7 +592,7 @@ impl<S: MutinyStorage>
         &self,
         channel_manager: &PhantomChannelManager<S>,
     ) -> Result<(), lightning::io::Error> {
-        let old = self.manager_version.fetch_add(1, Ordering::Relaxed);
+        let old = self.manager_version.fetch_add(1, Ordering::SeqCst);
         let version = old + 1;
         let key = self.get_key(CHANNEL_MANAGER_KEY);
 


### PR DESCRIPTION
Not sure if this will help but it won't hurt. This _should_ give us better guarantees that the manager version will always be increased in the correct order the persists were called