### PR TITLE
Use saturating_sub in budget_remaining

### DIFF
--- a/mutiny-core/src/nostr/nwc.rs
+++ b/mutiny-core/src/nostr/nwc.rs
@@ -119,7 +119,7 @@ impl BudgetedSpendingConditions {
 
     pub fn budget_remaining(&self) -> u64 {
         let mut clone = self.clone();
-        self.budget - clone.sum_payments()
+        self.budget.saturating_sub(clone.sum_payments())
     }
 }
 


### PR DESCRIPTION
@benalleng found this, we can underflow after a user edits their profile budget to be less than the current budget remaining