### PR TITLE
Fix units for fee estimation functions

### DIFF
--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1460,11 +1460,20 @@ impl<S: MutinyStorage> NodeManager<S> {
         }
     }
 
+    /// Gets a fee estimate for a very low priority transaction.
+    /// Value is in sat/vbyte.
+    pub fn estimate_fee_low(&self) -> u32 {
+        self.fee_estimator
+            .get_est_sat_per_1000_weight(ConfirmationTarget::Background)
+            / 250
+    }
+
     /// Gets a fee estimate for an average priority transaction.
     /// Value is in sat/vbyte.
     pub fn estimate_fee_normal(&self) -> u32 {
         self.fee_estimator
             .get_est_sat_per_1000_weight(ConfirmationTarget::Normal)
+            / 250
     }
 
     /// Gets a fee estimate for an high priority transaction.
@@ -1472,6 +1481,7 @@ impl<S: MutinyStorage> NodeManager<S> {
     pub fn estimate_fee_high(&self) -> u32 {
         self.fee_estimator
             .get_est_sat_per_1000_weight(ConfirmationTarget::HighPriority)
+            / 250
     }
 
     /// Creates a new lightning node and adds it to the manager.

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2068,11 +2068,17 @@ impl<S: MutinyStorage> NodeManager<S> {
                         None
                     };
 
+                    // ldk uses background fee rate for closing channels which can be very slow
+                    // so we use normal fee rate instead
+                    let fee_rate = self
+                        .fee_estimator
+                        .get_est_sat_per_1000_weight(ConfirmationTarget::Normal);
+
                     node.channel_manager
                         .close_channel_with_feerate_and_script(
                             &channel.channel_id,
                             &channel.counterparty.node_id,
-                            None,
+                            Some(fee_rate),
                             shutdown_script,
                         )
                         .map_err(|e| {

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -478,7 +478,7 @@ impl<S: MutinyStorage> OnChainWallet<S> {
         let raw_transaction = psbt.extract_tx();
         let txid = raw_transaction.txid();
 
-        self.broadcast_transaction(raw_transaction.clone()).await?;
+        self.broadcast_transaction(raw_transaction).await?;
         log_debug!(self.logger, "Transaction broadcast! TXID: {txid}");
         Ok(txid)
     }
@@ -530,7 +530,7 @@ impl<S: MutinyStorage> OnChainWallet<S> {
         let raw_transaction = psbt.extract_tx();
         let txid = raw_transaction.txid();
 
-        self.broadcast_transaction(raw_transaction.clone()).await?;
+        self.broadcast_transaction(raw_transaction).await?;
         log_debug!(self.logger, "Transaction broadcast! TXID: {txid}");
         Ok(txid)
     }


### PR DESCRIPTION
These functions weren't used anywhere but saw we had designs for something like this. Looks like they were previously returning in sats/kw instead of sats/vbyte like documented, fixed that and added the low priority option too, also fixed some extra clones i saw

![image](https://github.com/MutinyWallet/mutiny-node/assets/15256660/11a5527f-8099-4d84-a581-a79c0703c45f)
