### PR TITLE
Don't persist NetworkGraph

### DIFF
--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -2,7 +2,7 @@ use crate::chain::MutinyChain;
 use crate::error::{MutinyError, MutinyStorageError};
 use crate::event::PaymentInfo;
 use crate::fees::MutinyFeeEstimator;
-use crate::gossip::{NETWORK_GRAPH_KEY, PROB_SCORER_KEY};
+use crate::gossip::PROB_SCORER_KEY;
 use crate::keymanager::PhantomKeysManager;
 use crate::logging::MutinyLogger;
 use crate::multiesplora::MultiEsploraClient;
@@ -606,10 +606,8 @@ impl<S: MutinyStorage>
             .map_err(|_| lightning::io::ErrorKind::Other.into())
     }
 
-    fn persist_graph(&self, network_graph: &NetworkGraph) -> Result<(), lightning::io::Error> {
-        self.storage
-            .set_data(NETWORK_GRAPH_KEY, network_graph.encode().to_hex(), None)
-            .map_err(|_| lightning::io::ErrorKind::Other.into())
+    fn persist_graph(&self, _network_graph: &NetworkGraph) -> Result<(), lightning::io::Error> {
+        Ok(())
     }
 
     fn persist_scorer(

--- a/mutiny-wasm/src/indexed_db.rs
+++ b/mutiny-wasm/src/indexed_db.rs
@@ -194,6 +194,12 @@ impl IndexedDbStorage {
                     "key from indexedDB is not a string"
                 ))))?;
 
+            // we no longer need to read this key,
+            // so we can remove it from memory
+            if key == NETWORK_GRAPH_KEY {
+                continue;
+            }
+
             let json: Value = value.into_serde()?;
             map.set(key, json)?;
         }


### PR DESCRIPTION
We no longer read the graph from storage, we just get it from RGS on boot, so there's no reason to persist it.

We can also not save it in our memory storage because we don't need to read it.

This should help with the memory out of bounds issue