### PR TITLE
Fix compile for latest lnurl version

### DIFF
--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://mutinywallet.com"
 repository = "https://github.com/mutinywallet/mutiny-node"
 
 [dependencies]
-lnurl-rs = { version = "0.2.6", default-features = false, features = ["async", "async-https"] }
+lnurl-rs = { version = "0.2.7", default-features = false, features = ["async", "async-https"] }
 
 cfg-if = "1.0.0"
 bip39 = { version = "2.0.0" }
@@ -27,7 +27,7 @@ serde_json = { version = "^1.0" }
 uuid = { version = "1.1.2", features = ["v4"] }
 esplora-client = { version = "0.5", default-features = false }
 lightning = { version = "0.0.116", default-features = false, features = ["max_level_trace", "grind_signatures", "no-std"] }
-lightning-invoice = { version = "0.24.0", default-features = false, features = ["no-std"] }
+lightning-invoice = { version = "0.24.0", default-features = false, features = ["no-std", "serde"] }
 lightning-rapid-gossip-sync = { version = "0.0.116", default-features = false, features = ["no-std"] }
 chrono = "0.4.22"
 futures-util = { version = "0.3", default-features = false }

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1783,8 +1783,9 @@ impl<S: MutinyStorage> NodeManager<S> {
                     .get_invoice(&pay, msats, zap_request)
                     .await?;
 
-                self.pay_invoice(from_node, &invoice.invoice(), None, labels)
-                    .await
+                let invoice = Bolt11Invoice::from_str(&invoice.invoice())?;
+
+                self.pay_invoice(from_node, &invoice, None, labels).await
             }
             LnUrlResponse::LnUrlWithdrawResponse(_) => Err(MutinyError::IncorrectLnUrlFunction),
             LnUrlResponse::LnUrlChannelResponse(_) => Err(MutinyError::IncorrectLnUrlFunction),


### PR DESCRIPTION
I updated lnurl-rs to not have `lightning-invoice` has a dep so I don't need to keep updating for every ldk update.

This broke backwards compat so just updating here