### PR TITLE
VSS migration tool

### DIFF
--- a/mutiny-core/src/vss.rs
+++ b/mutiny-core/src/vss.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub struct MutinyVssClient {
     auth_client: Option<Arc<MutinyAuthClient>>,
     client: Option<reqwest::Client>,
-    url: String,
+    pub url: String,
     store_id: Option<String>,
     encryption_key: SecretKey,
     pub logger: Arc<MutinyLogger>,

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -1392,6 +1392,12 @@ impl MutinyWallet {
         Ok(())
     }
 
+    /// Exports the current state of the node manager to a json object.
+    #[wasm_bindgen]
+    pub async fn migrate_vss(&self, new_storage_url: String) -> Result<(), MutinyJsError> {
+        Ok(self.inner.node_manager.migrate_vss(new_storage_url).await?)
+    }
+
     /// Restore's the mnemonic after deleting the previous state.
     ///
     /// Backup the state beforehand. Does not restore lightning data.


### PR DESCRIPTION
Idea @futurepaul and I had, we could have a simple flow that migrates their cloud storage from one server to another.

This only would not work from transfering from a self hosted back to ours because we use an authenticated client. We could do some matching on the storage url for ours, but I think this is probably sufficient  