### PR TITLE
Pin to bdk alpha1

### DIFF
--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -17,9 +17,9 @@ lnurl-rs = { version = "0.2.7", default-features = false, features = ["async", "
 cfg-if = "1.0.0"
 bip39 = { version = "2.0.0" }
 bitcoin = { version = "0.29.2", default-features = false, features = ["serde", "secp-recovery", "rand"] }
-bdk = { version = "1.0.0-alpha.1", default-features = false }
-bdk_esplora = { version = "0.3.0", default-features = false, features = ["async-https"] }
-bdk_chain = { version = "0.5.0", default-features = false, features = ["hashbrown"] }
+bdk = { version = "=1.0.0-alpha.1", default-features = false }
+bdk_esplora = { version = "=0.3.0", default-features = false, features = ["async-https"] }
+bdk_chain = { version = "=0.5.0", default-features = false, features = ["hashbrown"] }
 bdk-macros = "0.6.0"
 getrandom = { version = "0.2" }
 serde = { version = "^1.0", features = ["derive"] }

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -7,7 +7,6 @@
     clippy::arc_with_non_send_sync,
     type_alias_bounds
 )]
-#![feature(async_fn_in_trait)]
 extern crate core;
 
 // background file is mostly an LDK copy paste

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -4,7 +4,6 @@
     clippy::extra_unused_type_parameters,
     clippy::arc_with_non_send_sync
 )]
-#![feature(async_fn_in_trait)]
 
 extern crate mutiny_core;
 


### PR DESCRIPTION
The lastest bdk release updates rust-bitcoin to 0.30 which breaks some of our stuff with ldk. This pins the bdk version until ldk updates to 0.30