### PR TITLE
Use alternative retry method for async storage

### DIFF
--- a/mutiny-core/src/utils.rs
+++ b/mutiny-core/src/utils.rs
@@ -178,7 +178,7 @@ where
 
 /// Returns the version of a channel monitor from a serialized version
 /// of a channel monitor.
-pub fn get_monitor_version(bytes: Vec<u8>) -> u64 {
+pub fn get_monitor_version(bytes: &[u8]) -> u64 {
     // first two bytes are the version
     // next 8 bytes are the version number
     u64::from_be_bytes(bytes[2..10].try_into().unwrap())

--- a/mutiny-wasm/src/indexed_db.rs
+++ b/mutiny-wasm/src/indexed_db.rs
@@ -258,12 +258,12 @@ impl IndexedDbStorage {
             match current.get::<Vec<u8>>(&key)? {
                 Some(bytes) => {
                     // check first byte is 1, then take u64 from next 8 bytes
-                    let current_version = utils::get_monitor_version(bytes);
+                    let current_version = utils::get_monitor_version(&bytes);
 
                     let obj: Value = LocalStorage::get(&key).unwrap();
                     let value = decrypt_value(&key, obj, current.password())?;
                     if let Ok(local_bytes) = serde_json::from_value::<Vec<u8>>(value.clone()) {
-                        let local_version = utils::get_monitor_version(local_bytes);
+                        let local_version = utils::get_monitor_version(&local_bytes);
 
                         // if the current version is less than the version from local storage
                         // then we want to use the local storage version
@@ -372,7 +372,7 @@ impl IndexedDbStorage {
                     // we can get versions from monitors, so we should compare
                     match current.get::<Vec<u8>>(&kv.key)? {
                         Some(bytes) => {
-                            let current_version = utils::get_monitor_version(bytes);
+                            let current_version = utils::get_monitor_version(&bytes);
 
                             // if the current version is less than the version from vss, then we want to use the vss version
                             if current_version < kv.version as u64 {


### PR DESCRIPTION
@TonyGiorgio and some other people have been reporting some issues with storage getting stuck. Not entirely sure what the issue is but this could be a fix. Changes the storage retries to be done by listing all the pending updates and persisting them in a loop rather than continually retrying on an individual update. This also lets us persist locally for retries since we are persisting the current monitor for retries, instead of the one that failed, so we don't have to worry about a race condition.