### PR TITLE
Allow only one instance of mutiny to run in wasm

### DIFF
--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -41,6 +41,7 @@ bip39 = { version = "2.0.0" }
 getrandom = { version = "0.2", features = ["js"] }
 futures = "0.3.25"
 urlencoding = "2.1.2"
+once_cell = "1.18.0"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires


### PR DESCRIPTION
This will make it throw an error if we already have initialized an instance of mutiny wallet, should help 