### PR TITLE
Fix borrowed mut bug

### DIFF
--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -555,6 +555,9 @@ impl<S: MutinyStorage> Node<S> {
         let retry_stop = stop.clone();
         let retry_chain_monitor = chain_monitor.clone();
         utils::spawn(async move {
+            // sleep 3 seconds before checking, we won't have any pending updates on startup
+            sleep(3_000).await;
+
             loop {
                 if retry_stop.load(Ordering::Relaxed) {
                     break;


### PR DESCRIPTION
Fixes the already borrowed error that was happening on debug builds. My guess is that sometimes on startup we were grabbing the monitors at the same time as ldk so it would be borrowed twice once. The 3 second sleep at the beginning should prevent this.

Not sure why this never happened to me when testing #797, maybe something merged to master since then interfered?

![image](https://github.com/MutinyWallet/mutiny-node/assets/15256660/6cb580e6-f094-478d-aa94-dead0529edf8)
