### PR TITLE
Skip nwc invoices that are in-flight

### DIFF
--- a/mutiny-core/src/nostr/nwc.rs
+++ b/mutiny-core/src/nostr/nwc.rs
@@ -371,9 +371,12 @@ impl NostrWalletConnect {
                 return Ok(None);
             }
 
-            // if we have already paid this invoice, skip it
+            // if we have already paid or are attempting to pay this invoice, skip it
             let node = node_manager.get_node(from_node).await?;
-            if node.get_invoice(&invoice).is_ok_and(|i| i.paid()) {
+            if node
+                .get_invoice(&invoice)
+                .is_ok_and(|i| matches!(i.status, HTLCStatus::Succeeded | HTLCStatus::InFlight))
+            {
                 return Ok(None);
             }
             drop(node);


### PR DESCRIPTION
Potential fix for duplicate nwc invoices. This will skip ones that we are currently trying to pay rather than only ones we've successfully paid

#808