### PR TITLE
export npub to hexpub function

### DIFF
--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -18,7 +18,7 @@ use crate::models::*;
 use crate::utils::sleep;
 use bip39::Mnemonic;
 use bitcoin::consensus::deserialize;
-use bitcoin::hashes::hex::FromHex;
+use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::hashes::sha256;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::util::bip32::ExtendedPrivKey;
@@ -1522,6 +1522,13 @@ impl MutinyWallet {
     #[wasm_bindgen]
     pub fn convert_sats_to_btc(sats: u64) -> f64 {
         bitcoin::Amount::from_sat(sats).to_btc()
+    }
+
+    /// Convert an npub string to a hex string
+    #[wasm_bindgen]
+    pub async fn npub_to_hexpub(npub: String) -> Result<String, MutinyJsError> {
+        let npub = XOnlyPublicKey::from_bech32(npub)?;
+        Ok(npub.to_hex())
     }
 }
 


### PR DESCRIPTION
this one function can get rid of our entire nostr dep on the frontend, which is a decent size saving: https://bundlephobia.com/package/@nostr-dev-kit/ndk@2.0.3