### PR TITLE
Give InsufficientBalance before trying to send

### DIFF
--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -178,11 +178,7 @@ impl<S: MutinyStorage> OnChainWallet<S> {
         let (checkpoints, spks) = {
             if let Ok(wallet) = self.wallet.try_read() {
                 let checkpoints = wallet.checkpoints();
-                let spks = wallet
-                    .spks_of_all_keychains()
-                    .into_iter()
-                    .map(|(k, spks)| (k, spks))
-                    .collect();
+                let spks = wallet.spks_of_all_keychains();
 
                 (checkpoints.clone(), spks)
             } else {


### PR DESCRIPTION
Closes #816

Before if we had a confirming channel we would still try to send and give a RouteNotFound error which could be confusing.

This fixes by first summing up the balance of our confirmed channels and seeing if we have enough balance. 

We can remove the `is_empty` check because that will sum to `0`