### PR TITLE
Add 3 second local lock

### DIFF
--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -86,7 +86,7 @@ impl DeviceLock {
     /// This is determined if the time is less than 2 minutes ago
     pub fn is_locked(&self, id: &str) -> bool {
         let now = now().as_secs();
-        let diff = now - self.time as u64;
+        let diff = now.saturating_sub(self.time as u64);
         diff < DEVICE_LOCK_INTERVAL_SECS * 2 && self.device != id
     }
 }


### PR DESCRIPTION
Adds a 3 second lock on the local device, this is to hopefully prevent a second instance of mutiny being created on the same device.

Currently what this does is just throw the `AlreadyRunning`, alternatively what we could do is just loop and keep checking until the lock is gone, this way if the user quickly closes and quickly re-opens they won't have a chance of running into this error.

This interval is short enough where if I refresh the page I am not running into it.