### PR TITLE
Use max supply of bitcoin instead of u64::MAX

### DIFF
--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1964,8 +1964,11 @@ pub(crate) fn default_user_config() -> UserConfig {
         },
         manually_accept_inbound_channels: true,
         channel_config: ChannelConfig {
+            // Set to max supply of bitcoin.
             // Don't care about dust exposure, we just want to be able to make payments.
-            max_dust_htlc_exposure: MaxDustHTLCExposure::FixedLimitMsat(u64::MAX),
+            max_dust_htlc_exposure: MaxDustHTLCExposure::FixedLimitMsat(
+                21_000_000 * 100_000_000 * 1_000,
+            ),
             ..Default::default()
         },
         ..Default::default()


### PR DESCRIPTION
Seems like there might be an overflow happening with `u64::MAX`, this will allow any payment but shouldn't overflow