### PR TITLE
Use `saturating_sub` for device lock comparison

### DIFF
--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -86,7 +86,7 @@ impl DeviceLock {
     /// This is determined if the time is less than 2 minutes ago
     pub fn is_locked(&self, id: &str) -> bool {
         let now = now().as_secs();
-        let diff = now - self.time as u64;
+        let diff = now.saturating_sub(self.time as u64);
         diff < DEVICE_LOCK_INTERVAL_SECS * 2 && self.device != id
     }
 }


### PR DESCRIPTION
If somehow our clock was before what was in the device lock, we would underflow. Probably won't catch a bug but this is more correct / safe