### PR TITLE
Unfilter force cloes balance

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -27,3 +27,6 @@ Things to test before cutting a release:
 - Restoring with an encryption password
 - Export logs
   - Try with and without encryption password
+- Mutual Close Channel
+  - Known Issue: balance will be double counted until 6 confirmations
+- Force Close Channel

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -37,7 +37,6 @@ use bitcoin::{Address, Network, OutPoint, Transaction, Txid};
 use core::time::Duration;
 use esplora_client::Builder;
 use futures::{future::join_all, lock::Mutex};
-use lightning::chain::channelmonitor::Balance;
 use lightning::chain::Confirm;
 use lightning::events::ClosureReason;
 use lightning::ln::channelmanager::{ChannelDetails, PhantomRouteHints};
@@ -1357,13 +1356,14 @@ impl<S: MutinyStorage> NodeManager<S> {
                 n.chain_monitor.get_claimable_balances(&ignored_channels)
             })
             // need to filter out pending mutual closes, these are counted in the on-chain balance
-            .filter(|b| {
-                !matches!(
-                    b,
-                    Balance::ClaimableOnChannelClose { .. }
-                        | Balance::ClaimableAwaitingConfirmations { .. }
-                )
-            })
+            // comment out for now until https://github.com/lightningdevkit/rust-lightning/issues/2738
+            // .filter(|b| {
+            //     !matches!(
+            //         b,
+            //         Balance::ClaimableOnChannelClose { .. }
+            //             | Balance::ClaimableAwaitingConfirmations { .. }
+            //     )
+            // })
             .map(|bal| bal.claimable_amount_satoshis())
             .sum();
 


### PR DESCRIPTION
Closes #862

This was a bug from #825 turns out this counts towards both mutual closes and force closes. https://github.com/lightningdevkit/rust-lightning/issues/2738 will allow us to truly fix.

Force closes are more common (and scary) in Mutiny so for now would be better to have the bug be around mutual closes.

Don't think we can write a test for this without mocking `chain_monitor` and `channel_manager`