### PR TITLE
Device Lock Improvements

### DIFF
--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -547,7 +547,7 @@ impl<S: MutinyStorage> NodeManager<S> {
             if let Some(lock) = storage.get_device_lock()? {
                 log_info!(logger, "Current device lock: {lock:?}");
             }
-            storage.set_device_lock()?;
+            storage.set_device_lock().await?;
         }
 
         let storage_clone = storage.clone();
@@ -559,7 +559,7 @@ impl<S: MutinyStorage> NodeManager<S> {
                     break;
                 }
                 sleep((DEVICE_LOCK_INTERVAL_SECS * 1_000) as i32).await;
-                if let Err(e) = storage_clone.set_device_lock() {
+                if let Err(e) = storage_clone.set_device_lock().await {
                     log_error!(logger_clone, "Error setting device lock: {e}");
                 }
             }

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -60,7 +60,7 @@ use std::{collections::HashMap, ops::Deref, sync::Arc};
 use uuid::Uuid;
 
 const BITCOIN_PRICE_CACHE_SEC: u64 = 300;
-pub const DEVICE_LOCK_INTERVAL_SECS: u64 = 60;
+pub const DEVICE_LOCK_INTERVAL_SECS: u64 = 30;
 
 // This is the NodeStorage object saved to the DB
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -82,6 +82,12 @@ pub struct DeviceLock {
 }
 
 impl DeviceLock {
+    pub fn remaining_secs(&self) -> u64 {
+        let now = now().as_secs();
+        let diff = now.saturating_sub(self.time as u64);
+        (DEVICE_LOCK_INTERVAL_SECS * 2).saturating_sub(diff)
+    }
+
     /// Check if the device is locked
     /// This is determined if the time is less than 2 minutes ago
     pub fn is_locked(&self, id: &str) -> bool {

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -391,7 +391,7 @@ pub trait MutinyStorage: Clone + Sized + 'static {
         self.get_data(DEVICE_LOCK_KEY)
     }
 
-    fn set_device_lock(&self) -> Result<(), MutinyError> {
+    async fn set_device_lock(&self) -> Result<(), MutinyError> {
         let device = self.get_device_id()?;
         if let Some(lock) = self.get_device_lock()? {
             if lock.is_locked(&device) {
@@ -401,7 +401,7 @@ pub trait MutinyStorage: Clone + Sized + 'static {
 
         let time = now().as_secs() as u32;
         let lock = DeviceLock { time, device };
-        self.set_data(DEVICE_LOCK_KEY, lock, Some(time))
+        self.set_data_async(DEVICE_LOCK_KEY, lock, Some(time)).await
     }
 
     async fn fetch_device_lock(&self) -> Result<Option<DeviceLock>, MutinyError>;
@@ -720,7 +720,7 @@ mod tests {
         let lock = storage.get_device_lock().unwrap();
         assert_eq!(None, lock);
 
-        storage.set_device_lock().unwrap();
+        storage.set_device_lock().await.unwrap();
         // sleep 1 second to make sure it writes to VSS
         sleep(1_000).await;
 
@@ -731,7 +731,7 @@ mod tests {
         assert_eq!(lock.unwrap().device, id);
 
         // make sure we can set lock again, should work because same device id
-        storage.set_device_lock().unwrap();
+        storage.set_device_lock().await.unwrap();
         // sleep 1 second to make sure it writes to VSS
         sleep(1_000).await;
 
@@ -750,6 +750,9 @@ mod tests {
         assert!(lock.clone().unwrap().is_locked(&new_id));
         assert_eq!(lock.unwrap().device, id);
 
-        assert!(storage.set_device_lock().is_err())
+        assert_eq!(
+            storage.set_device_lock().await,
+            Err(crate::MutinyError::AlreadyRunning)
+        );
     }
 }

--- a/mutiny-wasm/src/indexed_db.rs
+++ b/mutiny-wasm/src/indexed_db.rs
@@ -133,6 +133,11 @@ impl IndexedDbStorage {
         key: &str,
         data: &Value,
     ) -> Result<(), MutinyError> {
+        // Device lock is only saved to VSS
+        if key == DEVICE_LOCK_KEY {
+            return Ok(());
+        }
+
         let tx = indexed_db
             .try_write()
             .map_err(|e| MutinyError::read_err(e.into()))


### PR DESCRIPTION
Broken up into 3 commits. 

First allows us to get the remaining time in the device lock.

Second makes it so we only write the lock to VSS instead of to both VSS and indexeddb. This should let us reduce our  timer between writes because we won't be running into limits with browser storage.

Last commit reduces the timer to 30 seconds, this way the user only has to max wait 60 seconds to startup instead of 120.