### PR TITLE
Auto tag lnurl payments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,14 +1076,17 @@ checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "lnurl-rs"
-version = "0.2.7"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "484ddb262f554ee83de5adf4a1852c433ed095240a6bc8590cc57a5a0cfb64cc"
+checksum = "f4fa42d2e0488393c00b96d0ea170eb6f9acbda7f965690fcd40ce6447517db7"
 dependencies = [
+ "aes",
  "anyhow",
+ "base64 0.13.1",
  "bech32",
  "bitcoin 0.29.2",
  "bitcoin_hashes 0.12.0",
+ "cbc",
  "email_address",
  "reqwest",
  "serde",

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://mutinywallet.com"
 repository = "https://github.com/mutinywallet/mutiny-node"
 
 [dependencies]
-lnurl-rs = { version = "0.2.7", default-features = false, features = ["async", "async-https"] }
+lnurl-rs = { version = "0.3.1", default-features = false, features = ["async", "async-https"] }
 
 cfg-if = "1.0.0"
 bip39 = { version = "2.0.0" }

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1771,7 +1771,7 @@ impl<S: MutinyStorage> NodeManager<S> {
         lnurl: &LnUrl,
         amount_sats: u64,
         zap_npub: Option<XOnlyPublicKey>,
-        labels: Vec<String>,
+        mut labels: Vec<String>,
     ) -> Result<MutinyInvoice, MutinyError> {
         let response = self.lnurl_client.make_request(&lnurl.url).await?;
 
@@ -1808,6 +1808,13 @@ impl<S: MutinyStorage> NodeManager<S> {
                     .amount_milli_satoshis()
                     .is_some_and(|amt| msats == amt)
                 {
+                    // If we have a contact for this lnurl, add it to the labels as the first
+                    if let Some(label) = self.get_contact_for_lnurl(lnurl)? {
+                        if !labels.contains(&label) {
+                            labels.insert(0, label)
+                        }
+                    }
+
                     self.pay_invoice(from_node, &invoice, None, labels).await
                 } else {
                     log_error!(self.logger, "LNURL return invoice with incorrect amount");

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1799,10 +1799,10 @@ impl<S: MutinyStorage> NodeManager<S> {
 
                 let invoice = self
                     .lnurl_client
-                    .get_invoice(&pay, msats, zap_request)
+                    .get_invoice(&pay, msats, zap_request, None)
                     .await?;
 
-                let invoice = Bolt11Invoice::from_str(&invoice.invoice())?;
+                let invoice = Bolt11Invoice::from_str(invoice.invoice())?;
 
                 if invoice
                     .amount_milli_satoshis()

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -28,7 +28,7 @@ lightning = { version = "0.0.118", default-features = false, features = ["std"] 
 lightning-invoice = { version = "0.26.0" }
 thiserror = "1.0"
 instant = { version = "0.1", features = ["wasm-bindgen"] }
-lnurl-rs = { version = "0.2.6", default-features = false }
+lnurl-rs = { version = "0.3.1", default-features = false }
 nostr = { version = "0.24.0", default-features = false }
 wasm-logger = "0.2.0"
 log = "0.4.17"


### PR DESCRIPTION
This makes it so if you are paying an lnurl or lightning address we search your contacts for it and try to tag the transaction.

to test:

1. sync nostr contact, make sure you follow: `npub1qf8e8cvfp60ywrah984zgsn8veggcrsv2cvttdr47tgz05ypf5yszwx308`
2. pay to `mutiny@lnurl-staging.mutinywallet.com` with no tags
3. See that in your payment history it is tagged