### PR TITLE
Create contact for Mutiny+ subscription

### DIFF
--- a/mutiny-core/src/labels.rs
+++ b/mutiny-core/src/labels.rs
@@ -88,7 +88,7 @@ fn get_label_item_key(label: impl AsRef<str>) -> String {
     format!("{}{}", LABEL_PREFIX, label.as_ref())
 }
 
-fn get_contact_key(label: impl AsRef<str>) -> String {
+pub(crate) fn get_contact_key(label: impl AsRef<str>) -> String {
     format!("{}{}", CONTACT_PREFIX, label.as_ref())
 }
 

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -40,10 +40,12 @@ pub enum ReservedProfile {
     MutinySubscription,
 }
 
+pub(crate) const MUTINY_PLUS_SUBSCRIPTION_LABEL: &str = "Mutiny+ Subscription";
+
 impl ReservedProfile {
     pub fn info(&self) -> (&'static str, u32) {
         let (n, i) = match self {
-            ReservedProfile::MutinySubscription => ("Mutiny+ Subscription", 0),
+            ReservedProfile::MutinySubscription => (MUTINY_PLUS_SUBSCRIPTION_LABEL, 0),
         };
         if i >= USER_NWC_PROFILE_START_INDEX {
             panic!("Must not exceed 1000 reserved indexes")
@@ -928,7 +930,7 @@ mod test {
     fn test_create_reserve_profile() {
         let nostr_manager = create_nostr_manager();
 
-        let name = "Mutiny+ Subscription".to_string();
+        let name = MUTINY_PLUS_SUBSCRIPTION_LABEL.to_string();
 
         let profile = nostr_manager
             .create_new_profile(


### PR DESCRIPTION
Makes it so Mutiny+ will have a nice contact icon in the activity. Just used the icon we have on our nostr profile for now. Not sure if @futurepaul has a better image we can use

![image](https://github.com/MutinyWallet/mutiny-node/assets/15256660/f8cd5acb-352b-42cc-b767-4384690e9bc6)
