### PR TITLE
demo wasm-bindgen-serde and tsify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,8 +1250,10 @@ dependencies = [
  "once_cell",
  "rexie",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "thiserror",
+ "tsify",
  "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1897,10 +1899,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2229,6 +2253,31 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "tsify"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b26cf145f2f3b9ff84e182c448eaf05468e247f148cf3d2a7d67d78ff023a0"
+dependencies = [
+ "gloo-utils",
+ "serde",
+ "serde_json",
+ "tsify-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-macros"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a94b0f0954b3e59bfc2c246b4c8574390d94a4ad4ad246aaf2fb07d7dfd3b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.39",
+]
 
 [[package]]
 name = "tungstenite"

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -21,6 +21,7 @@ mutiny-core = { path = "../mutiny-core" }
 anyhow = "1.0"
 wasm-bindgen = "0.2.88"
 wasm-bindgen-futures = "0.4.38"
+serde-wasm-bindgen = "0.4"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 bitcoin = { version = "0.29.2", default-features = false, features = ["std", "serde", "secp-recovery", "rand"] }
@@ -40,6 +41,7 @@ getrandom = { version = "0.2", features = ["js"] }
 futures = "0.3.25"
 urlencoding = "2.1.2"
 once_cell = "1.18.0"
+tsify = "0.4.5"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/mutiny-wasm/src/models.rs
+++ b/mutiny-wasm/src/models.rs
@@ -62,6 +62,56 @@ impl ActivityItem {
     }
 }
 
+use tsify::Tsify;
+
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum TestEnum {
+    Nope,
+    Yep,
+    Alright(u64),
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct TestSerde {
+    pub kind: String,
+    pub num: Option<u64>,
+    pub kinds: TestEnum,
+    pub array_of_complex: Vec<Complex>,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct Complex {
+    pub a: u64,
+    pub b: u64,
+    pub c: TestEnum,
+}
+
+#[wasm_bindgen]
+pub fn test_serde_to_js() -> Result<TestSerde, JsValue> {
+    let example = TestSerde {
+        kind: "Hey".to_string(),
+        num: Some(1234),
+        kinds: TestEnum::Yep,
+        array_of_complex: vec![
+            Complex {
+                a: 123,
+                b: 456,
+                c: TestEnum::Alright(123),
+            },
+            Complex {
+                a: 789,
+                b: 999,
+                c: TestEnum::Nope,
+            },
+        ],
+    };
+
+    Ok(example)
+}
+
 impl From<nodemanager::ActivityItem> for ActivityItem {
     fn from(a: nodemanager::ActivityItem) -> Self {
         let kind = match a {


### PR DESCRIPTION
got curious about https://github.com/cloudflare/serde-wasm-bindgen ... apparently it's the blessed way to do bindings

> It provides much smaller code size overhead than JSON, and, in most common cases, provides much faster serialization/deserialization as well.

don't get out-of-the box typescript with this (a JsValue is an "any" on the typescript side), but they recommend Tsify which was really easy to use: https://github.com/madonoharu/tsify

an added perk of tsify is the code can go from

```rust
#[wasm_bindgen]
pub fn send_example_to_js() -> Result<JsValue, JsValue> {
    let example = Example {
        ...
    };

    Ok(serde_wasm_bindgen::to_value(&example)?)
}
```

to this:
```rust
#[wasm_bindgen]
pub fn send_example_to_js() -> Result<Example, JsValue> {
    let example = Example {
        ...
    };

    Ok(example)
}

I think it's because of this `#[tsify(into_wasm_abi, from_wasm_abi)]`
