### PR TITLE
Specify version for wasm-pack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: 'latest'
+          version: 'v0.12.1'
 
       - name: Build wasm
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: 'latest'
+          version: 'v0.12.1'
 
       - uses: actions/cache@v2
         with:
@@ -85,7 +85,7 @@ jobs:
 
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: 'latest'
+          version: 'v0.12.1'
 
       - name: Setup trunk
         uses: jetli/trunk-action@v0.1.0


### PR DESCRIPTION
For whatever reason, it hiccuped on a recent build of mine and tried to build with `v0.9`. This enforces the version. 