### PR TITLE
Add LSPS support via `lightning-liquidity` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets",
 ]
@@ -1104,6 +1105,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "lightning-liquidity"
+version = "0.1.0"
+source = "git+https://github.com/lightningdevkit/lightning-liquidity.git?rev=e00d917a8bb17e29493497538c7a4dda00bef151#e00d917a8bb17e29493497538c7a4dda00bef151"
+dependencies = [
+ "bitcoin 0.29.2",
+ "chrono",
+ "lightning",
+ "lightning-invoice",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.118"
 source = "git+https://github.com/MutinyWallet/rust-lightning.git?rev=686a84236f54bf8d7270a5fbec07801e5281691f#686a84236f54bf8d7270a5fbec07801e5281691f"
@@ -1265,6 +1279,7 @@ dependencies = [
  "lightning",
  "lightning-background-processor",
  "lightning-invoice",
+ "lightning-liquidity",
  "lightning-rapid-gossip-sync",
  "lightning-transaction-sync",
  "lnurl-rs",

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -32,6 +32,7 @@ lightning-invoice = { version = "0.26.0", features = ["serde"] }
 lightning-rapid-gossip-sync = { version = "0.0.118" }
 lightning-background-processor = { version = "0.0.118", features = ["futures"] }
 lightning-transaction-sync = { version = "0.0.118", features = ["esplora-async-https"] }
+lightning-liquidity = { git = "https://github.com/lightningdevkit/lightning-liquidity.git", rev = "e00d917a8bb17e29493497538c7a4dda00bef151" }
 chrono = "0.4.22"
 futures-util = { version = "0.3", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }

--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -69,6 +69,9 @@ pub enum MutinyError {
     /// LSP indicated it was not connected to the client node.
     #[error("Failed to have a connection to the LSP node.")]
     LspConnectionError,
+    /// LSP required an invoice and none was provided.
+    #[error("Failed to provide an invoice to the LSP.")]
+    LspInvoiceRequired,
     /// Subscription Client Not Configured
     #[error("Subscription Client Not Configured")]
     SubscriptionClientNotConfigured,

--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -9,7 +9,7 @@ use bitcoin::bech32::u5;
 use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1::ecdsa::RecoverableSignature;
 use bitcoin::secp256k1::ecdsa::Signature;
-use bitcoin::secp256k1::{PublicKey, Scalar, Secp256k1, Signing};
+use bitcoin::secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey, Signing};
 use bitcoin::util::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey};
 use bitcoin::{PackedLockTime, Script, Transaction, TxOut};
 use lightning::ln::msgs::{DecodeError, UnsignedGossipMessage};
@@ -51,6 +51,10 @@ impl<S: MutinyStorage> PhantomKeysManager<S> {
             wallet,
             logger,
         }
+    }
+
+    pub(crate) fn get_node_secret_key(&self) -> SecretKey {
+        self.inner.get_node_secret_key()
     }
 
     /// See [`KeysManager::spend_spendable_outputs`] for documentation on this method.

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -21,7 +21,8 @@ pub mod labels;
 mod ldkstorage;
 pub mod lnurlauth;
 pub mod logging;
-mod lspclient;
+mod lsp;
+mod messagehandler;
 mod networking;
 mod node;
 pub mod nodemanager;
@@ -78,6 +79,8 @@ pub struct MutinyWalletConfig {
     user_esplora_url: Option<String>,
     user_rgs_url: Option<String>,
     lsp_url: Option<String>,
+    lsp_connection_string: Option<String>,
+    lsp_token: Option<String>,
     auth_client: Option<Arc<MutinyAuthClient>>,
     subscription_url: Option<String>,
     scorer_url: Option<String>,
@@ -96,6 +99,8 @@ impl MutinyWalletConfig {
         user_esplora_url: Option<String>,
         user_rgs_url: Option<String>,
         lsp_url: Option<String>,
+        lsp_connection_string: Option<String>,
+        lsp_token: Option<String>,
         auth_client: Option<Arc<MutinyAuthClient>>,
         subscription_url: Option<String>,
         scorer_url: Option<String>,
@@ -111,6 +116,8 @@ impl MutinyWalletConfig {
             user_rgs_url,
             scorer_url,
             lsp_url,
+            lsp_connection_string,
+            lsp_token,
             auth_client,
             subscription_url,
             do_not_connect_peers: false,
@@ -668,6 +675,8 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
             false,
             true,
         );
@@ -693,6 +702,8 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             None,
             Network::Regtest,
+            None,
+            None,
             None,
             None,
             None,
@@ -730,6 +741,8 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             None,
             Network::Regtest,
+            None,
+            None,
             None,
             None,
             None,
@@ -774,6 +787,8 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
             false,
             true,
         );
@@ -794,6 +809,8 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             None,
             Network::Regtest,
+            None,
+            None,
             None,
             None,
             None,

--- a/mutiny-core/src/lsp/lsps.rs
+++ b/mutiny-core/src/lsp/lsps.rs
@@ -1,0 +1,502 @@
+use async_trait::async_trait;
+use bitcoin::hashes::{sha256, Hash};
+use bitcoin::secp256k1::{PublicKey, Secp256k1};
+use bitcoin::Network;
+use futures::channel::oneshot;
+use lightning::ln::channelmanager::MIN_FINAL_CLTV_EXPIRY_DELTA;
+use lightning::ln::PaymentHash;
+use lightning::routing::gossip::RoutingFees;
+use lightning::routing::router::{RouteHint, RouteHintHop};
+use lightning::util::logger::Logger;
+use lightning::{log_debug, log_error};
+use lightning_invoice::{Bolt11Invoice, InvoiceBuilder};
+use lightning_liquidity::events;
+use lightning_liquidity::lsps2::{LSPS2Event, OpeningFeeParams};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::{
+    error::MutinyError,
+    keymanager::PhantomKeysManager,
+    ldkstorage::PhantomChannelManager,
+    logging::MutinyLogger,
+    lsp::{FeeRequest, InvoiceRequest, Lsp, LspConfig},
+    node::{parse_peer_info, LiquidityManager},
+    storage::MutinyStorage,
+    utils,
+};
+
+use super::FeeResponse;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct LspsConfig {
+    pub connection_string: String,
+    pub token: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct JitChannelInfo {
+    pub channel_id: u128,
+    pub fee_params: OpeningFeeParams,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct GetInfoResponse {
+    pub jit_channel_id: u128,
+    pub opening_fee_params_menu: Vec<OpeningFeeParams>,
+}
+
+pub(crate) struct PendingPaymentInfo {
+    pub expected_fee_msat: Option<u64>,
+    pub fee_params: OpeningFeeParams,
+}
+
+type PendingFeeRequestSender = oneshot::Sender<Result<GetInfoResponse, MutinyError>>;
+type PendingBuyRequestSender = oneshot::Sender<Result<Bolt11Invoice, MutinyError>>;
+
+#[derive(Clone)]
+pub struct LspsClient<S: MutinyStorage> {
+    pub pubkey: PublicKey,
+    pub connection_string: String,
+    pub token: Option<String>,
+    liquidity_manager: Arc<LiquidityManager<S>>,
+    channel_manager: Arc<PhantomChannelManager<S>>,
+    keys_manager: Arc<PhantomKeysManager<S>>,
+    network: Network,
+    logger: Arc<MutinyLogger>,
+    pending_fee_requests: Arc<Mutex<HashMap<u128, PendingFeeRequestSender>>>,
+    pending_buy_requests: Arc<Mutex<HashMap<u128, PendingBuyRequestSender>>>,
+    pending_channel_info: Arc<Mutex<HashMap<u128, JitChannelInfo>>>,
+    pending_payments: Arc<Mutex<HashMap<PaymentHash, PendingPaymentInfo>>>,
+    stop: Arc<AtomicBool>,
+}
+
+impl<S: MutinyStorage> LspsClient<S> {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        lsp_connection_string: String,
+        token: Option<String>,
+        liquidity_manager: Arc<LiquidityManager<S>>,
+        channel_manager: Arc<PhantomChannelManager<S>>,
+        keys_manager: Arc<PhantomKeysManager<S>>,
+        network: Network,
+        logger: Arc<MutinyLogger>,
+        stop: Arc<AtomicBool>,
+    ) -> Result<Self, MutinyError> {
+        let (lsp_pubkey, _) = parse_peer_info(&lsp_connection_string)?;
+
+        let client = LspsClient {
+            pubkey: lsp_pubkey,
+            connection_string: lsp_connection_string,
+            token,
+            liquidity_manager,
+            channel_manager,
+            keys_manager,
+            network,
+            logger,
+            pending_fee_requests: Arc::new(Mutex::new(HashMap::new())),
+            pending_buy_requests: Arc::new(Mutex::new(HashMap::new())),
+            pending_channel_info: Arc::new(Mutex::new(HashMap::new())),
+            pending_payments: Arc::new(Mutex::new(HashMap::new())),
+            stop,
+        };
+
+        let events_client = client.clone();
+        utils::spawn(async move {
+            events_client.handle_events().await;
+        });
+
+        Ok(client)
+    }
+
+    pub(crate) async fn handle_event(&self, event: events::Event) {
+        match event {
+            events::Event::LSPS2(LSPS2Event::GetInfoResponse {
+                jit_channel_id,
+                opening_fee_params_menu,
+                user_channel_id,
+                ..
+            }) => {
+                log_debug!(
+                    self.logger,
+                    "received GetInfoResponse for jit_channel_id {}, user_channel_id {}",
+                    jit_channel_id,
+                    user_channel_id
+                );
+
+                let mut pending_fee_requests = self.pending_fee_requests.lock().unwrap();
+
+                if let Some(fee_response_sender) = pending_fee_requests.remove(&user_channel_id) {
+                    if fee_response_sender
+                        .send(Ok(GetInfoResponse {
+                            jit_channel_id,
+                            opening_fee_params_menu,
+                        }))
+                        .is_err()
+                    {
+                        log_error!(self.logger, "error sending fee response, receiver dropped?");
+                    }
+                }
+            }
+            events::Event::LSPS2(LSPS2Event::InvoiceGenerationReady {
+                scid,
+                cltv_expiry_delta,
+                user_channel_id,
+                counterparty_node_id,
+                payment_size_msat,
+                ..
+            }) => {
+                log_debug!(self.logger, "received InvoiceGenerationReady with scid {}, cltv_expiry_delta {}, user_channel_id {}, counterparty_node_id {}, payment_size_msat {:?}", scid, cltv_expiry_delta, user_channel_id, counterparty_node_id, payment_size_msat);
+
+                let mut pending_buy_requests = self.pending_buy_requests.lock().unwrap();
+
+                if let Some(buy_response_sender) = pending_buy_requests.remove(&user_channel_id) {
+                    let invoice_expiry_delta_secs = 3600;
+                    let (payment_hash, payment_secret) = match self
+                        .channel_manager
+                        .create_inbound_payment(None, invoice_expiry_delta_secs, None)
+                    {
+                        Ok((payment_hash, payment_secret)) => (payment_hash, payment_secret),
+                        Err(_) => {
+                            log_error!(self.logger, "error creating inbound payment");
+                            if buy_response_sender
+                                .send(Err(MutinyError::InvoiceCreationFailed))
+                                .is_err()
+                            {
+                                log_error!(
+                                    self.logger,
+                                    "error sending buy response, receiver dropped?"
+                                );
+                            }
+                            return;
+                        }
+                    };
+
+                    let cltv_expiry_delta: u16 = match cltv_expiry_delta.try_into() {
+                        Ok(cltv_expiry_delta) => cltv_expiry_delta,
+                        Err(e) => {
+                            log_error!(
+                                self.logger,
+                                "error converting cltv_expiry_delta to u16: {:?}",
+                                e
+                            );
+                            if buy_response_sender
+                                .send(Err(MutinyError::InvoiceCreationFailed))
+                                .is_err()
+                            {
+                                log_error!(
+                                    self.logger,
+                                    "error sending buy response, receiver dropped?"
+                                );
+                            }
+                            return;
+                        }
+                    };
+
+                    let lsp_route_hint = RouteHint(vec![RouteHintHop {
+                        src_node_id: counterparty_node_id,
+                        short_channel_id: scid,
+                        fees: RoutingFees {
+                            base_msat: 0,
+                            proportional_millionths: 0,
+                        },
+                        cltv_expiry_delta,
+                        htlc_minimum_msat: None,
+                        htlc_maximum_msat: None,
+                    }]);
+
+                    let payment_hash = match sha256::Hash::from_slice(&payment_hash.0) {
+                        Ok(payment_hash) => payment_hash,
+                        Err(e) => {
+                            log_error!(
+                                self.logger,
+                                "error converting payment_hash to sha256::Hash: {:?}",
+                                e
+                            );
+                            if buy_response_sender
+                                .send(Err(MutinyError::InvoiceCreationFailed))
+                                .is_err()
+                            {
+                                log_error!(
+                                    self.logger,
+                                    "error sending buy response, receiver dropped?"
+                                );
+                            }
+                            return;
+                        }
+                    };
+
+                    let mut invoice = InvoiceBuilder::new(self.network.into())
+                        .description("".into())
+                        .payment_hash(payment_hash)
+                        .payment_secret(payment_secret)
+                        .duration_since_epoch(utils::now())
+                        .min_final_cltv_expiry_delta(MIN_FINAL_CLTV_EXPIRY_DELTA.into())
+                        .private_route(lsp_route_hint);
+
+                    let payment_size_msat = match payment_size_msat {
+                        Some(payment_size_msat) => payment_size_msat,
+                        None => {
+                            log_error!(self.logger, "payment_size_msat was not specified but is required to create an invoice");
+                            if buy_response_sender
+                                .send(Err(MutinyError::InvoiceCreationFailed))
+                                .is_err()
+                            {
+                                log_error!(
+                                    self.logger,
+                                    "error sending buy response, receiver dropped?"
+                                );
+                            }
+                            return;
+                        }
+                    };
+
+                    invoice = invoice.amount_milli_satoshis(payment_size_msat);
+
+                    let invoice = match invoice.build_signed(|hash| {
+                        Secp256k1::new()
+                            .sign_ecdsa_recoverable(hash, &self.keys_manager.get_node_secret_key())
+                    }) {
+                        Ok(invoice) => invoice,
+                        Err(e) => {
+                            log_error!(self.logger, "error building signed invoice: {:?}", e);
+                            if buy_response_sender
+                                .send(Err(MutinyError::InvoiceCreationFailed))
+                                .is_err()
+                            {
+                                log_error!(
+                                    self.logger,
+                                    "error sending buy response, receiver dropped?"
+                                );
+                            }
+                            return;
+                        }
+                    };
+
+                    if buy_response_sender.send(Ok(invoice)).is_err() {
+                        log_error!(self.logger, "error sending buy response, receiver dropped?");
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) async fn handle_events(&self) {
+        loop {
+            for event in self.liquidity_manager.get_and_clear_pending_events() {
+                self.handle_event(event).await;
+            }
+
+            if self.stop.load(Ordering::Relaxed) {
+                break;
+            }
+
+            utils::sleep(1000).await;
+        }
+    }
+}
+
+/// TODO: import from lightning-liquidity once it's exposed
+/// Computes the opening fee given a payment size and the fee parameters.
+///
+/// Returns [`Option::None`] when the computation overflows.
+///
+/// See the [`specification`](https://github.com/BitcoinAndLightningLayerSpecs/lsp/tree/main/LSPS2#computing-the-opening_fee) for more details.
+pub fn compute_opening_fee(
+    payment_size_msat: u64,
+    opening_fee_min_fee_msat: u64,
+    opening_fee_proportional: u64,
+) -> Option<u64> {
+    payment_size_msat
+        .checked_mul(opening_fee_proportional)
+        .and_then(|f| f.checked_add(999999))
+        .and_then(|f| f.checked_div(1000000))
+        .map(|f| std::cmp::max(f, opening_fee_min_fee_msat))
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<S: MutinyStorage> Lsp for LspsClient<S> {
+    async fn get_lsp_fee_msat(&self, fee_request: FeeRequest) -> Result<FeeResponse, MutinyError> {
+        let user_channel_id = fee_request
+            .user_channel_id
+            .ok_or(MutinyError::LspGenericError)?;
+
+        let inbound_capacity_msat: u64 = self
+            .channel_manager
+            .list_channels_with_counterparty(&self.get_lsp_pubkey())
+            .iter()
+            .map(|c| c.inbound_capacity_msat)
+            .sum();
+
+        // if there's enough capacity then the LSP won't charge an opening fee to route a normal payment
+        // this is only here to keep both voltage + lsps logic symmetric
+        if inbound_capacity_msat >= fee_request.amount_msat {
+            return Ok(FeeResponse {
+                id: None,
+                fee_amount_msat: 0,
+            });
+        }
+
+        let (pending_fee_request_sender, pending_fee_request_receiver) =
+            oneshot::channel::<Result<GetInfoResponse, MutinyError>>();
+
+        {
+            let mut pending_fee_requests = self.pending_fee_requests.lock().unwrap();
+            pending_fee_requests.insert(user_channel_id, pending_fee_request_sender);
+        }
+
+        log_debug!(
+            self.logger,
+            "initiating inbound flow for {}msats with token {:?}",
+            fee_request.amount_msat,
+            &self.token
+        );
+
+        self.liquidity_manager
+            .lsps2_create_invoice(
+                self.pubkey,
+                Some(fee_request.amount_msat),
+                self.token.clone(),
+                user_channel_id,
+            )
+            .map_err(|e| {
+                log_debug!(self.logger, "error creating lsps2 invoice: {:?}", e);
+                MutinyError::LspGenericError
+            })?;
+
+        let get_info_response = pending_fee_request_receiver.await.map_err(|e| {
+            log_debug!(self.logger, "error receiving get info response: {:?}", e);
+            MutinyError::LspGenericError
+        })??;
+
+        let fee_params = get_info_response.opening_fee_params_menu[0].clone();
+
+        let min_fee_msat = fee_params.min_fee_msat;
+        let proportional_fee = fee_params.proportional;
+
+        log_debug!(
+            self.logger,
+            "received fee information. min_fee_msat {} and proportional fee {}",
+            min_fee_msat,
+            proportional_fee
+        );
+
+        {
+            let mut pending_channel_info = self.pending_channel_info.lock().unwrap();
+            pending_channel_info.insert(
+                user_channel_id,
+                JitChannelInfo {
+                    channel_id: get_info_response.jit_channel_id,
+                    fee_params,
+                },
+            );
+        }
+
+        let fee_amount_msat = compute_opening_fee(
+            fee_request.amount_msat,
+            min_fee_msat,
+            proportional_fee.into(),
+        )
+        .ok_or(MutinyError::LspGenericError)?;
+
+        Ok(FeeResponse {
+            id: None,
+            fee_amount_msat,
+        })
+    }
+
+    async fn get_lsp_invoice(
+        &self,
+        invoice_request: InvoiceRequest,
+    ) -> Result<String, MutinyError> {
+        let user_channel_id = invoice_request
+            .user_channel_id
+            .ok_or(MutinyError::LspGenericError)?;
+
+        let (pending_buy_request_sender, pending_buy_request_receiver) =
+            oneshot::channel::<Result<Bolt11Invoice, MutinyError>>();
+
+        {
+            let mut pending_buy_requests = self.pending_buy_requests.lock().unwrap();
+            pending_buy_requests.insert(user_channel_id, pending_buy_request_sender);
+        }
+
+        let (channel_id, fee_params) = {
+            let channel_info = self.pending_channel_info.lock().unwrap();
+            let channel_info = channel_info
+                .get(&user_channel_id)
+                .ok_or(MutinyError::LspGenericError)?;
+
+            (channel_info.channel_id, channel_info.fee_params.clone())
+        };
+
+        self.liquidity_manager
+            .opening_fee_params_selected(self.pubkey, channel_id, fee_params.clone())
+            .map_err(|_| MutinyError::LspGenericError)?;
+
+        let invoice = pending_buy_request_receiver
+            .await
+            .map_err(|_| MutinyError::LspGenericError)??;
+
+        let payment_hash = PaymentHash((*invoice.payment_hash()).into_inner());
+        let payment_amount = invoice.amount_milli_satoshis();
+
+        let expected_fee_msat = payment_amount.and_then(|payment_amount| {
+            compute_opening_fee(
+                payment_amount,
+                fee_params.min_fee_msat,
+                fee_params.proportional.into(),
+            )
+        });
+        {
+            let mut pending_payments = self.pending_payments.lock().unwrap();
+            pending_payments.insert(
+                payment_hash,
+                PendingPaymentInfo {
+                    expected_fee_msat,
+                    fee_params,
+                },
+            );
+        }
+
+        Ok(invoice.to_string())
+    }
+
+    fn get_lsp_pubkey(&self) -> PublicKey {
+        self.pubkey
+    }
+
+    fn get_lsp_connection_string(&self) -> String {
+        self.connection_string.clone()
+    }
+
+    fn get_config(&self) -> LspConfig {
+        LspConfig::Lsps(LspsConfig {
+            connection_string: self.get_lsp_connection_string(),
+            token: self.token.clone(),
+        })
+    }
+
+    fn get_expected_skimmed_fee_msat(&self, payment_hash: PaymentHash, payment_size: u64) -> u64 {
+        let mut pending_payments = self.pending_payments.lock().unwrap();
+
+        if let Some(pending_payment) = pending_payments.get_mut(&payment_hash) {
+            if let Some(expected_fee_msat) = pending_payment.expected_fee_msat {
+                return expected_fee_msat;
+            }
+
+            compute_opening_fee(
+                payment_size,
+                pending_payment.fee_params.min_fee_msat,
+                pending_payment.fee_params.proportional.into(),
+            )
+            .unwrap_or(0)
+        } else {
+            0
+        }
+    }
+}

--- a/mutiny-core/src/lsp/mod.rs
+++ b/mutiny-core/src/lsp/mod.rs
@@ -1,0 +1,181 @@
+use crate::error::MutinyError;
+use crate::keymanager::PhantomKeysManager;
+use crate::ldkstorage::PhantomChannelManager;
+use crate::logging::MutinyLogger;
+use crate::node::LiquidityManager;
+use crate::storage::MutinyStorage;
+use async_trait::async_trait;
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::Network;
+use lightning::ln::PaymentHash;
+use lsps::{LspsClient, LspsConfig};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::{atomic::AtomicBool, Arc};
+use voltage::LspClient;
+
+pub mod lsps;
+pub mod voltage;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum LspConfig {
+    VoltageFlow(String),
+    Lsps(LspsConfig),
+}
+
+impl LspConfig {
+    pub fn new_voltage_flow(url: String) -> Self {
+        Self::VoltageFlow(url)
+    }
+
+    pub fn new_lsps(connection_string: String, token: Option<String>) -> Self {
+        Self::Lsps(LspsConfig {
+            connection_string,
+            token,
+        })
+    }
+}
+
+pub fn deserialize_lsp_config<'de, D>(deserializer: D) -> Result<Option<LspConfig>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v: Option<Value> = Option::deserialize(deserializer)?;
+    match v {
+        Some(Value::String(s)) => Ok(Some(LspConfig::VoltageFlow(s))),
+        Some(Value::Object(_)) => LspConfig::deserialize(v.unwrap())
+            .map(Some)
+            .map_err(|e| serde::de::Error::custom(format!("invalid lsp config: {e}"))),
+        Some(Value::Null) => Ok(None),
+        Some(x) => Err(serde::de::Error::custom(format!(
+            "invalid lsp config: {x:?}"
+        ))),
+        None => Ok(None),
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct InvoiceRequest {
+    // Used only for VoltageFlow
+    pub bolt11: Option<String>,
+    // Used only for VoltageFlow to map to previously fetched fee
+    pub fee_id: Option<String>,
+    // Used only for LSPS to track channel creation
+    pub user_channel_id: Option<u128>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct FeeRequest {
+    pub pubkey: String,
+    pub amount_msat: u64,
+    // Used only for LSPS to track channel creation
+    pub user_channel_id: Option<u128>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct FeeResponse {
+    // Used only for VoltageFlow to be used in subsequent InvoiceRequest
+    pub id: Option<String>,
+    pub fee_amount_msat: u64,
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub(crate) trait Lsp {
+    async fn get_lsp_fee_msat(&self, fee_request: FeeRequest) -> Result<FeeResponse, MutinyError>;
+    async fn get_lsp_invoice(&self, invoice_request: InvoiceRequest)
+        -> Result<String, MutinyError>;
+    fn get_lsp_pubkey(&self) -> PublicKey;
+    fn get_lsp_connection_string(&self) -> String;
+    fn get_expected_skimmed_fee_msat(&self, payment_hash: PaymentHash, payment_size: u64) -> u64;
+    fn get_config(&self) -> LspConfig;
+}
+
+#[derive(Clone)]
+pub enum AnyLsp<S: MutinyStorage> {
+    VoltageFlow(LspClient),
+    Lsps(LspsClient<S>),
+}
+
+impl<S: MutinyStorage> AnyLsp<S> {
+    pub async fn new_voltage_flow(url: &str) -> Result<Self, MutinyError> {
+        Ok(Self::VoltageFlow(LspClient::new(url).await?))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_lsps(
+        connection_string: String,
+        token: Option<String>,
+        liquidity_manager: Arc<LiquidityManager<S>>,
+        channel_manager: Arc<PhantomChannelManager<S>>,
+        keys_manager: Arc<PhantomKeysManager<S>>,
+        network: Network,
+        logger: Arc<MutinyLogger>,
+        stop: Arc<AtomicBool>,
+    ) -> Result<Self, MutinyError> {
+        let lsps_client = LspsClient::new(
+            connection_string,
+            token,
+            liquidity_manager,
+            channel_manager,
+            keys_manager,
+            network,
+            logger,
+            stop,
+        )?;
+        Ok(Self::Lsps(lsps_client))
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<S: MutinyStorage> Lsp for AnyLsp<S> {
+    async fn get_lsp_fee_msat(&self, fee_request: FeeRequest) -> Result<FeeResponse, MutinyError> {
+        match self {
+            AnyLsp::VoltageFlow(client) => client.get_lsp_fee_msat(fee_request).await,
+            AnyLsp::Lsps(client) => client.get_lsp_fee_msat(fee_request).await,
+        }
+    }
+
+    async fn get_lsp_invoice(
+        &self,
+        invoice_request: InvoiceRequest,
+    ) -> Result<String, MutinyError> {
+        match self {
+            AnyLsp::VoltageFlow(client) => client.get_lsp_invoice(invoice_request).await,
+            AnyLsp::Lsps(client) => client.get_lsp_invoice(invoice_request).await,
+        }
+    }
+
+    fn get_lsp_pubkey(&self) -> PublicKey {
+        match self {
+            AnyLsp::VoltageFlow(client) => client.get_lsp_pubkey(),
+            AnyLsp::Lsps(client) => client.get_lsp_pubkey(),
+        }
+    }
+
+    fn get_lsp_connection_string(&self) -> String {
+        match self {
+            AnyLsp::VoltageFlow(client) => client.get_lsp_connection_string(),
+            AnyLsp::Lsps(client) => client.get_lsp_connection_string(),
+        }
+    }
+
+    fn get_config(&self) -> LspConfig {
+        match self {
+            AnyLsp::VoltageFlow(client) => client.get_config(),
+            AnyLsp::Lsps(client) => client.get_config(),
+        }
+    }
+
+    fn get_expected_skimmed_fee_msat(&self, payment_hash: PaymentHash, payment_size: u64) -> u64 {
+        match self {
+            AnyLsp::VoltageFlow(client) => {
+                client.get_expected_skimmed_fee_msat(payment_hash, payment_size)
+            }
+            AnyLsp::Lsps(client) => {
+                client.get_expected_skimmed_fee_msat(payment_hash, payment_size)
+            }
+        }
+    }
+}

--- a/mutiny-core/src/messagehandler.rs
+++ b/mutiny-core/src/messagehandler.rs
@@ -1,0 +1,114 @@
+use std::sync::Arc;
+
+use bitcoin::secp256k1::PublicKey;
+use lightning::io::{Error, Read};
+use lightning::ln::features::{InitFeatures, NodeFeatures};
+use lightning::ln::msgs::{DecodeError, LightningError};
+use lightning::ln::peer_handler::CustomMessageHandler;
+use lightning::ln::wire::{CustomMessageReader, Type};
+use lightning::util::ser::{Writeable, Writer};
+
+use crate::node::LiquidityManager;
+use crate::storage::MutinyStorage;
+
+pub struct MutinyMessageHandler<S: MutinyStorage> {
+    pub liquidity: Option<Arc<LiquidityManager<S>>>,
+}
+
+pub enum MutinyMessage<S: MutinyStorage> {
+    Liquidity(<LiquidityManager<S> as CustomMessageReader>::CustomMessage),
+}
+
+impl<S: MutinyStorage> std::fmt::Debug for MutinyMessage<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Liquidity(arg0) => f.debug_tuple("Liquidity").field(arg0).finish(),
+        }
+    }
+}
+
+impl<S: MutinyStorage> CustomMessageHandler for MutinyMessageHandler<S> {
+    fn handle_custom_message(
+        &self,
+        msg: Self::CustomMessage,
+        sender_node_id: &PublicKey,
+    ) -> Result<(), LightningError> {
+        match msg {
+            MutinyMessage::Liquidity(message) => {
+                if let Some(liquidity) = &self.liquidity {
+                    return CustomMessageHandler::handle_custom_message(
+                        liquidity.as_ref(),
+                        message,
+                        sender_node_id,
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_and_clear_pending_msg(&self) -> Vec<(PublicKey, Self::CustomMessage)> {
+        if let Some(liquidity) = &self.liquidity {
+            liquidity
+                .get_and_clear_pending_msg()
+                .into_iter()
+                .map(|(pubkey, message)| (pubkey, MutinyMessage::Liquidity(message)))
+                .collect()
+        } else {
+            vec![]
+        }
+    }
+
+    fn provided_node_features(&self) -> NodeFeatures {
+        match &self.liquidity {
+            Some(liquidity) => liquidity.provided_node_features(),
+            None => NodeFeatures::empty(),
+        }
+    }
+
+    fn provided_init_features(&self, their_node_id: &PublicKey) -> InitFeatures {
+        match &self.liquidity {
+            Some(liquidity) => liquidity.provided_init_features(their_node_id),
+            None => InitFeatures::empty(),
+        }
+    }
+}
+
+impl<S: MutinyStorage> CustomMessageReader for MutinyMessageHandler<S> {
+    type CustomMessage = MutinyMessage<S>;
+    fn read<R: Read>(
+        &self,
+        message_type: u16,
+        buffer: &mut R,
+    ) -> Result<Option<Self::CustomMessage>, DecodeError> {
+        if let Some(liquidity) = &self.liquidity {
+            match <LiquidityManager<S> as CustomMessageReader>::read(
+                liquidity,
+                message_type,
+                buffer,
+            )? {
+                None => Ok(None),
+                Some(message) => Ok(Some(MutinyMessage::Liquidity(message))),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl<S: MutinyStorage> Type for MutinyMessage<S> {
+    fn type_id(&self) -> u16 {
+        match self {
+            MutinyMessage::Liquidity(message) => message.type_id(),
+        }
+    }
+}
+
+impl<S: MutinyStorage> Writeable for MutinyMessage<S> {
+    fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+        match self {
+            MutinyMessage::Liquidity(message) => message.write(writer),
+        }
+    }
+}

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1,7 +1,10 @@
 use crate::labels::LabelStorage;
 use crate::ldkstorage::{persist_monitor, ChannelOpenParams};
-use crate::nodemanager::{ChannelClosure, LspConfig};
+use crate::lsp::{InvoiceRequest, LspConfig};
+use crate::messagehandler::MutinyMessageHandler;
+use crate::nodemanager::ChannelClosure;
 use crate::peermanager::LspMessageRouter;
+use crate::storage::MutinyStorage;
 use crate::utils::get_monitor_version;
 use crate::{
     chain::MutinyChain,
@@ -12,7 +15,7 @@ use crate::{
     keymanager::{create_keys_manager, pubkey_from_keys_manager},
     ldkstorage::{MutinyNodePersister, PhantomChannelManager},
     logging::MutinyLogger,
-    lspclient::LspClient,
+    lsp::{AnyLsp, FeeRequest, Lsp},
     nodemanager::{MutinyInvoice, NodeIndex},
     onchain::OnChainWallet,
     peermanager::{GossipMessageHandler, PeerManagerImpl},
@@ -20,7 +23,6 @@ use crate::{
 };
 use crate::{fees::P2WSH_OUTPUT_SIZE, peermanager::connect_peer_if_necessary};
 use crate::{keymanager::PhantomKeysManager, scorer::HubPreferentialScorer};
-use crate::{lspclient::FeeRequest, storage::MutinyStorage};
 use anyhow::{anyhow, Context};
 use bdk::FeeRate;
 use bitcoin::hashes::{hex::ToHex, sha256::Hash as Sha256};
@@ -67,6 +69,10 @@ use lightning_invoice::{
     utils::{create_invoice_from_channelmanager_and_duration_since_epoch, create_phantom_invoice},
     Bolt11Invoice,
 };
+use lightning_liquidity::{
+    JITChannelsConfig, LiquidityManager as LDKLSPLiquidityManager, LiquidityProviderConfig,
+};
+
 #[cfg(test)]
 use mockall::{automock, predicate::*};
 use std::collections::HashMap;
@@ -103,11 +109,18 @@ pub(crate) type OnionMessenger<S: MutinyStorage> = LdkOnionMessenger<
     IgnoringMessageHandler,
 >;
 
+pub type LiquidityManager<S> = LDKLSPLiquidityManager<
+    Arc<PhantomKeysManager<S>>,
+    Arc<PhantomChannelManager<S>>,
+    Arc<PeerManagerImpl<S>>,
+    Arc<dyn Filter + Send + Sync>,
+>;
+
 pub(crate) type MessageHandler<S: MutinyStorage> = LdkMessageHandler<
     Arc<PhantomChannelManager<S>>,
     Arc<GossipMessageHandler<S>>,
     Arc<OnionMessenger<S>>,
-    IgnoringMessageHandler,
+    Arc<MutinyMessageHandler<S>>,
 >;
 
 pub(crate) type ChainMonitor<S: MutinyStorage> = chainmonitor::ChainMonitor<
@@ -169,7 +182,7 @@ pub(crate) struct Node<S: MutinyStorage> {
     pub persister: Arc<MutinyNodePersister<S>>,
     wallet: Arc<OnChainWallet<S>>,
     pub(crate) logger: Arc<MutinyLogger>,
-    pub(crate) lsp_client: Option<LspClient>,
+    pub(crate) lsp_client: Option<AnyLsp<S>>,
     pub(crate) sync_lock: Arc<Mutex<()>>,
     stop: Arc<AtomicBool>,
     pub skip_hodl_invoices: bool,
@@ -191,7 +204,7 @@ impl<S: MutinyStorage> Node<S> {
         wallet: Arc<OnChainWallet<S>>,
         network: Network,
         esplora: &AsyncClient,
-        lsp_clients: &[LspClient],
+        lsp_configs: &[LspConfig],
         logger: Arc<MutinyLogger>,
         do_not_connect_peers: bool,
         empty_state: bool,
@@ -321,27 +334,61 @@ impl<S: MutinyStorage> Node<S> {
         }
 
         log_info!(logger, "creating lsp client");
-        let lsp_client: Option<LspClient> = match node_index.lsp {
+        let lsp_config: Option<LspConfig> = match node_index.lsp {
             None => {
-                if lsp_clients.is_empty() {
+                if lsp_configs.is_empty() {
                     log_info!(logger, "no lsp saved and no lsp clients available");
                     None
                 } else {
                     log_info!(logger, "no lsp saved, picking random one");
                     // If we don't have an lsp saved we should pick a random
                     // one from our client list and save it for next time
-                    let rand = rand::random::<usize>() % lsp_clients.len();
-                    Some(lsp_clients[rand].clone())
+                    let rand = rand::random::<usize>() % lsp_configs.len();
+                    Some(lsp_configs[rand].clone())
                 }
             }
-            Some(ref lsp) => lsp_clients
-                .iter()
-                .find(|c| match lsp {
-                    LspConfig::VoltageFlow(ref url) => url == &c.url,
-                })
-                .cloned(),
+            Some(ref lsp) => lsp_configs.iter().find(|c| *c == lsp).cloned(),
         };
-        let lsp_client_pubkey = lsp_client.clone().map(|lsp| lsp.pubkey);
+
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let (lsp_client, liquidity) = match lsp_config {
+            Some(LspConfig::VoltageFlow(url)) => {
+                (Some(AnyLsp::new_voltage_flow(&url).await?), None)
+            }
+            Some(LspConfig::Lsps(lsps_config)) => {
+                let liquidity_manager = Arc::new(LiquidityManager::new(
+                    keys_manager.clone(),
+                    Some(LiquidityProviderConfig {
+                        lsps2_config: Some(JITChannelsConfig {
+                            promise_secret: [0; 32],
+                            min_payment_size_msat: 0,
+                            max_payment_size_msat: 9999999999,
+                        }),
+                    }),
+                    channel_manager.clone(),
+                    None,
+                    None,
+                ));
+
+                (
+                    Some(AnyLsp::new_lsps(
+                        lsps_config.connection_string.clone(),
+                        lsps_config.token.clone(),
+                        liquidity_manager.clone(),
+                        channel_manager.clone(),
+                        keys_manager.clone(),
+                        network,
+                        logger.clone(),
+                        stop.clone(),
+                    )?),
+                    Some(liquidity_manager),
+                )
+            }
+            None => (None, None),
+        };
+
+        let lsp_client_pubkey = lsp_client.clone().map(|lsp| lsp.get_lsp_pubkey());
         let message_router = Arc::new(LspMessageRouter::new(lsp_client_pubkey));
         let onion_message_handler = Arc::new(OnionMessenger::new(
             keys_manager.clone(),
@@ -363,7 +410,7 @@ impl<S: MutinyStorage> Node<S> {
             chan_handler: channel_manager.clone(),
             route_handler,
             onion_message_handler,
-            custom_message_handler: IgnoringMessageHandler {},
+            custom_message_handler: Arc::new(MutinyMessageHandler { liquidity }),
         };
 
         let bump_tx_event_handler = Arc::new(BumpTransactionEventHandler::new(
@@ -381,7 +428,7 @@ impl<S: MutinyStorage> Node<S> {
             keys_manager.clone(),
             persister.clone(),
             bump_tx_event_handler,
-            lsp_client_pubkey,
+            lsp_client.clone(),
             logger.clone(),
         );
 
@@ -475,8 +522,6 @@ impl<S: MutinyStorage> Node<S> {
                 }
             }
         }
-
-        let stop = Arc::new(AtomicBool::new(false));
 
         let background_persister = persister.clone();
         let background_event_handler = event_handler.clone();
@@ -717,10 +762,7 @@ impl<S: MutinyStorage> Node<S> {
     pub fn node_index(&self) -> NodeIndex {
         NodeIndex {
             child_index: self.child_index,
-            lsp: self
-                .lsp_client
-                .clone()
-                .map(|l| LspConfig::VoltageFlow(l.url)),
+            lsp: self.lsp_client.as_ref().map(|l| l.get_config()),
             archived: Some(false),
         }
     }
@@ -801,92 +843,138 @@ impl<S: MutinyStorage> Node<S> {
         labels: Vec<String>,
         route_hints: Option<Vec<PhantomRouteHints>>,
     ) -> Result<Bolt11Invoice, MutinyError> {
-        // the amount to create for the invoice whether or not there is an lsp
-        let (amount_sat, lsp_fee) = if let Some(lsp) = self.lsp_client.as_ref() {
-            // LSP requires an amount:
-            let amount_sat = amount_sat.ok_or(MutinyError::BadAmountError)?;
-
-            // Needs any amount over 0 if channel exists
-            // Needs amount over minimum if no channel
-            let inbound_capacity_msat: u64 = self
-                .channel_manager
-                .list_channels_with_counterparty(&lsp.pubkey)
-                .iter()
-                .map(|c| c.inbound_capacity_msat)
-                .sum();
-            let min_amount_sat = if inbound_capacity_msat > amount_sat * 1_000 {
-                1
-            } else {
-                utils::min_lightning_amount(self.network)
-            };
-            if amount_sat < min_amount_sat {
-                return Err(MutinyError::BadAmountError);
-            }
-
-            // check the fee from the LSP
-            let lsp_fee = lsp
-                .get_lsp_fee_msat(FeeRequest {
-                    pubkey: self.pubkey.to_hex(),
-                    amount_msat: amount_sat * 1000,
-                })
-                .await?;
-
-            // Convert the fee from msat to sat for comparison and subtraction
-            let lsp_fee_sat = lsp_fee.fee_amount_msat / 1000;
-
-            // Ensure that the fee is less than the amount being requested.
-            // If it isn't, we don't subtract it.
-            // This prevents amount from being subtracted down to 0.
-            // This will mean that the LSP fee will be paid by the payer instead.
-            let amount_minus_fee = if lsp_fee_sat < amount_sat {
-                amount_sat
-                    .checked_sub(lsp_fee_sat)
-                    .ok_or(MutinyError::BadAmountError)?
-            } else {
-                amount_sat
-            };
-
-            (Some(amount_minus_fee), Some(lsp_fee))
-        } else {
-            (amount_sat, None)
-        };
-
-        let lsp_fee_msat = lsp_fee.as_ref().map(|l| l.fee_amount_msat);
-
-        let invoice = self
-            .create_internal_invoice(amount_sat, lsp_fee_msat, labels, route_hints)
-            .await?;
-
-        if let Some(lsp) = self.lsp_client.as_ref() {
-            self.connect_peer(PubkeyConnectionInfo::new(&lsp.connection_string)?, None)
-                .await?;
-            let lsp_invoice = match lsp
-                .get_lsp_invoice(
-                    invoice.to_string(),
-                    lsp_fee.expect("should have gotten a fee id").id,
+        match self.lsp_client.as_ref() {
+            Some(lsp) => {
+                self.connect_peer(
+                    PubkeyConnectionInfo::new(&lsp.get_lsp_connection_string())?,
+                    None,
                 )
-                .await
-            {
-                Ok(lsp_invoice_str) => Bolt11Invoice::from_str(&lsp_invoice_str)?,
-                Err(e) => {
-                    log_error!(self.logger, "Failed to get invoice from LSP: {e}");
-                    return Err(e);
+                .await?;
+
+                // LSP requires an amount:
+                let amount_sat = amount_sat.ok_or(MutinyError::BadAmountError)?;
+
+                // Needs any amount over 0 if channel exists
+                // Needs amount over minimum if no channel
+                let inbound_capacity_msat: u64 = self
+                    .channel_manager
+                    .list_channels_with_counterparty(&lsp.get_lsp_pubkey())
+                    .iter()
+                    .map(|c| c.inbound_capacity_msat)
+                    .sum();
+
+                let has_inbound_capacity = inbound_capacity_msat > amount_sat * 1_000;
+
+                let min_amount_sat = if has_inbound_capacity {
+                    1
+                } else {
+                    utils::min_lightning_amount(self.network)
+                };
+
+                if amount_sat < min_amount_sat {
+                    return Err(MutinyError::BadAmountError);
                 }
-            };
 
-            if invoice.network() != self.network {
-                return Err(MutinyError::IncorrectNetwork(invoice.network()));
+                let user_channel_id = match lsp {
+                    AnyLsp::VoltageFlow(_) => None,
+                    AnyLsp::Lsps(_) => Some(utils::now().as_secs().into()),
+                };
+
+                // check the fee from the LSP
+                let lsp_fee = lsp
+                    .get_lsp_fee_msat(FeeRequest {
+                        pubkey: self.pubkey.to_hex(),
+                        amount_msat: amount_sat * 1000,
+                        user_channel_id,
+                    })
+                    .await?;
+
+                // Convert the fee from msat to sat for comparison and subtraction
+                let lsp_fee_sat = lsp_fee.fee_amount_msat / 1000;
+
+                // Ensure that the fee is less than the amount being requested.
+                // If it isn't, we don't subtract it.
+                // This prevents amount from being subtracted down to 0.
+                // This will mean that the LSP fee will be paid by the payer instead.
+                let amount_minus_fee = if lsp_fee_sat < amount_sat {
+                    amount_sat
+                        .checked_sub(lsp_fee_sat)
+                        .ok_or(MutinyError::BadAmountError)?
+                } else {
+                    amount_sat
+                };
+
+                match lsp {
+                    AnyLsp::VoltageFlow(client) => {
+                        let invoice = self
+                            .create_internal_invoice(
+                                Some(amount_minus_fee),
+                                Some(lsp_fee.fee_amount_msat),
+                                labels,
+                                route_hints,
+                            )
+                            .await?;
+
+                        let lsp_invoice = match client
+                            .get_lsp_invoice(InvoiceRequest {
+                                bolt11: Some(invoice.to_string()),
+                                user_channel_id,
+                                fee_id: lsp_fee.id,
+                            })
+                            .await
+                        {
+                            Ok(lsp_invoice_str) => Bolt11Invoice::from_str(&lsp_invoice_str)?,
+                            Err(e) => {
+                                log_error!(self.logger, "Failed to get invoice from LSP: {e}");
+                                return Err(e);
+                            }
+                        };
+
+                        if invoice.network() != self.network {
+                            return Err(MutinyError::IncorrectNetwork(invoice.network()));
+                        }
+
+                        if lsp_invoice.payment_hash() != invoice.payment_hash()
+                            || lsp_invoice.recover_payee_pub_key() != client.get_lsp_pubkey()
+                        {
+                            return Err(MutinyError::InvoiceCreationFailed);
+                        }
+
+                        Ok(lsp_invoice)
+                    }
+                    AnyLsp::Lsps(client) => {
+                        if has_inbound_capacity {
+                            Ok(self
+                                .create_internal_invoice(
+                                    Some(amount_sat),
+                                    None,
+                                    labels,
+                                    route_hints,
+                                )
+                                .await?)
+                        } else {
+                            let lsp_invoice = match client
+                                .get_lsp_invoice(InvoiceRequest {
+                                    bolt11: None,
+                                    user_channel_id,
+                                    fee_id: lsp_fee.id,
+                                })
+                                .await
+                            {
+                                Ok(lsp_invoice_str) => Bolt11Invoice::from_str(&lsp_invoice_str)?,
+                                Err(e) => {
+                                    log_error!(self.logger, "Failed to get invoice from LSP: {e}");
+                                    return Err(e);
+                                }
+                            };
+                            Ok(lsp_invoice)
+                        }
+                    }
+                }
             }
-
-            if lsp_invoice.payment_hash() != invoice.payment_hash()
-                || lsp_invoice.recover_payee_pub_key() != lsp.pubkey
-            {
-                return Err(MutinyError::InvoiceCreationFailed);
-            }
-
-            Ok(lsp_invoice)
-        } else {
-            Ok(invoice)
+            None => Ok(self
+                .create_internal_invoice(amount_sat, None, labels, route_hints)
+                .await?),
         }
     }
 
@@ -1480,7 +1568,7 @@ impl<S: MutinyStorage> Node<S> {
         // if we are opening channel to LSP, turn off SCID alias until CLN is updated
         // LSP protects all invoice information anyways, so no UTXO leakage
         if let Some(lsp) = self.lsp_client.clone() {
-            if pubkey == lsp.pubkey {
+            if pubkey == lsp.get_lsp_pubkey() {
                 config.channel_handshake_config.negotiate_scid_privacy = false;
             }
         }
@@ -1583,7 +1671,7 @@ impl<S: MutinyStorage> Node<S> {
         // if we are opening channel to LSP, turn off SCID alias until CLN is updated
         // LSP protects all invoice information anyways, so no UTXO leakage
         if let Some(lsp) = self.lsp_client.clone() {
-            if pubkey == lsp.pubkey {
+            if pubkey == lsp.get_lsp_pubkey() {
                 config.channel_handshake_config.negotiate_scid_privacy = false;
             }
         }
@@ -1714,7 +1802,7 @@ async fn start_reconnection_handling<S: MutinyStorage>(
     fee_estimator: Arc<MutinyFeeEstimator<S>>,
     logger: &Arc<MutinyLogger>,
     uuid: String,
-    lsp_client: Option<&LspClient>,
+    lsp_client: Option<&AnyLsp<S>>,
     stop: Arc<AtomicBool>,
     stopped_components: Arc<RwLock<Vec<bool>>>,
     skip_fee_estimates: bool,
@@ -1752,12 +1840,12 @@ async fn start_reconnection_handling<S: MutinyStorage>(
     utils::spawn(async move {
         // Now try to connect to the client's LSP
         if let Some(lsp) = lsp_client_copy {
-            let node_id = NodeId::from_pubkey(&lsp.pubkey);
+            let node_id = NodeId::from_pubkey(&lsp.get_lsp_pubkey());
 
             let connect_res = connect_peer_if_necessary(
                 #[cfg(target_arch = "wasm32")]
                 &websocket_proxy_addr_copy_proxy,
-                &PubkeyConnectionInfo::new(lsp.connection_string.as_str()).unwrap(),
+                &PubkeyConnectionInfo::new(lsp.get_lsp_connection_string().as_str()).unwrap(),
                 &storage_copy,
                 proxy_logger.clone(),
                 peer_man_proxy.clone(),
@@ -1778,7 +1866,7 @@ async fn start_reconnection_handling<S: MutinyStorage>(
                 &storage_copy,
                 &uuid_copy,
                 &node_id,
-                &lsp.connection_string,
+                &lsp.get_lsp_connection_string(),
                 None,
             ) {
                 log_error!(proxy_logger, "could not save connection to lsp: {e}");
@@ -1965,6 +2053,7 @@ pub(crate) fn default_user_config() -> UserConfig {
             max_dust_htlc_exposure: MaxDustHTLCExposure::FixedLimitMsat(
                 21_000_000 * 100_000_000 * 1_000,
             ),
+            accept_underpaying_htlcs: true,
             ..Default::default()
         },
         ..Default::default()

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -630,19 +630,13 @@ impl<S: MutinyStorage> NodeManager<S> {
                         None
                     }
                 }
-                (Some(lsp_url), Some(lsp_connection_string)) => {
-                    // if both are set, for now default to voltage
-                    if !c.safe_mode {
-                        if !lsp_url.is_empty() {
-                            Some(LspConfig::new_voltage_flow(lsp_url))
-                        } else if !lsp_connection_string.is_empty() {
-                            Some(LspConfig::new_lsps(lsp_connection_string, c.lsp_token))
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
+                (Some(_), Some(_)) => {
+                    // both shouldn't be set, surface error
+                    log_error!(
+                        logger,
+                        "Both lsp_url and lsp_connection_string should not be set."
+                    );
+                    return Err(MutinyError::InvalidArgumentsError);
                 }
                 (None, None) => None,
             };

--- a/mutiny-core/src/peermanager.rs
+++ b/mutiny-core/src/peermanager.rs
@@ -1,3 +1,4 @@
+use crate::messagehandler::MutinyMessageHandler;
 use crate::networking::socket::{schedule_descriptor_read, MutinySocketDescriptor};
 use crate::node::{NetworkGraph, OnionMessenger};
 use crate::storage::MutinyStorage;
@@ -10,8 +11,8 @@ use lightning::events::{MessageSendEvent, MessageSendEventsProvider};
 use lightning::ln::features::{InitFeatures, NodeFeatures};
 use lightning::ln::msgs;
 use lightning::ln::msgs::{LightningError, RoutingMessageHandler};
+use lightning::ln::peer_handler::PeerHandleError;
 use lightning::ln::peer_handler::PeerManager as LdkPeerManager;
-use lightning::ln::peer_handler::{IgnoringMessageHandler, PeerHandleError};
 use lightning::log_warn;
 use lightning::onion_message::{Destination, MessageRouter, OnionMessagePath};
 use lightning::routing::gossip::NodeId;
@@ -92,7 +93,7 @@ pub(crate) type PeerManagerImpl<S: MutinyStorage> = LdkPeerManager<
     Arc<GossipMessageHandler<S>>,
     Arc<OnionMessenger<S>>,
     Arc<MutinyLogger>,
-    IgnoringMessageHandler,
+    Arc<MutinyMessageHandler<S>>,
     Arc<PhantomKeysManager<S>>,
 >;
 

--- a/mutiny-core/src/redshift.rs
+++ b/mutiny-core/src/redshift.rs
@@ -1,4 +1,5 @@
 use crate::error::MutinyError;
+use crate::lsp::Lsp;
 use crate::nodemanager::NodeManager;
 use crate::storage::MutinyStorage;
 use crate::utils::sleep;
@@ -198,7 +199,7 @@ impl<S: MutinyStorage> RedshiftManager for NodeManager<S> {
                 // TODO this would be better if it was a random node
                 let node = self.get_node(&node.pubkey).await?;
                 match &node.lsp_client {
-                    Some(lsp) => lsp.pubkey,
+                    Some(lsp) => lsp.get_lsp_pubkey(),
                     None => return Err(MutinyError::LspGenericError),
                 }
             }

--- a/mutiny-core/src/test_utils.rs
+++ b/mutiny-core/src/test_utils.rs
@@ -111,7 +111,7 @@ pub(crate) async fn create_node<S: MutinyStorage>(storage: S) -> Node<S> {
         wallet,
         network,
         &esplora,
-        &[],
+        None,
         logger,
         false,
         false,

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -62,6 +62,9 @@ pub enum MutinyJsError {
     /// LSP indicated it was not connected to the client node.
     #[error("Failed to have a connection to the LSP node.")]
     LspConnectionError,
+    /// LSP required an invoice and none was provided.
+    #[error("Failed to provide an invoice to the LSP.")]
+    LspInvoiceRequired,
     /// Subscription Client Not Configured
     #[error("Subscription Client Not Configured")]
     SubscriptionClientNotConfigured,
@@ -174,6 +177,7 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::LspGenericError => MutinyJsError::LspGenericError,
             MutinyError::LspFundingError => MutinyJsError::LspFundingError,
             MutinyError::LspConnectionError => MutinyJsError::LspConnectionError,
+            MutinyError::LspInvoiceRequired => MutinyJsError::LspInvoiceRequired,
             MutinyError::RoutingFailed => MutinyJsError::RoutingFailed,
             MutinyError::PeerInfoParseFailed => MutinyJsError::PeerInfoParseFailed,
             MutinyError::ChannelCreationFailed => MutinyJsError::ChannelCreationFailed,

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -87,6 +87,8 @@ impl MutinyWallet {
         user_esplora_url: Option<String>,
         user_rgs_url: Option<String>,
         lsp_url: Option<String>,
+        lsp_connection_string: Option<String>,
+        lsp_token: Option<String>,
         auth_url: Option<String>,
         subscription_url: Option<String>,
         storage_url: Option<String>,
@@ -112,6 +114,8 @@ impl MutinyWallet {
             user_esplora_url,
             user_rgs_url,
             lsp_url,
+            lsp_connection_string,
+            lsp_token,
             auth_url,
             subscription_url,
             storage_url,
@@ -141,6 +145,8 @@ impl MutinyWallet {
         user_esplora_url: Option<String>,
         user_rgs_url: Option<String>,
         lsp_url: Option<String>,
+        lsp_connection_string: Option<String>,
+        lsp_token: Option<String>,
         auth_url: Option<String>,
         subscription_url: Option<String>,
         storage_url: Option<String>,
@@ -221,6 +227,8 @@ impl MutinyWallet {
             user_esplora_url,
             user_rgs_url,
             lsp_url,
+            lsp_connection_string,
+            lsp_token,
             auth_client,
             subscription_url,
             scorer_url,
@@ -1688,6 +1696,8 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
         )
         .await
         .expect("mutiny wallet should initialize");
@@ -1718,6 +1728,8 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
         )
         .await
         .expect("mutiny wallet should initialize");
@@ -1731,6 +1743,8 @@ mod tests {
             Some(seed.to_string()),
             None,
             Some("regtest".to_owned()),
+            None,
+            None,
             None,
             None,
             None,
@@ -1779,6 +1793,8 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
         )
         .await
         .expect("mutiny wallet should initialize");
@@ -1791,6 +1807,8 @@ mod tests {
             None,
             None,
             Some("regtest".to_owned()),
+            None,
+            None,
             None,
             None,
             None,
@@ -1846,6 +1864,8 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -1888,6 +1908,8 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -1906,6 +1928,8 @@ mod tests {
             Some(seed.to_string()),
             None,
             Some("regtest".to_owned()),
+            None,
+            None,
             None,
             None,
             None,
@@ -1939,6 +1963,8 @@ mod tests {
             None,
             None,
             Some("regtest".to_owned()),
+            None,
+            None,
             None,
             None,
             None,
@@ -2013,6 +2039,8 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
         )
         .await
         .expect("mutiny wallet should initialize");
@@ -2054,6 +2082,8 @@ mod tests {
             None,
             None,
             Some("regtest".to_owned()),
+            None,
+            None,
             None,
             None,
             None,


### PR DESCRIPTION
Adds support for both Voltage and LSPS style LSP's.

If lsp_url configuration option is set, it adds voltage style lsp's as it does today.

If lsp_connection_string option is set, it adds lsps style lsp's. If the lsps lsp requires a token then lsp_token must be set and the index of the token must match the index of the corresponding lsp_connection_string. It's a little janky. One idea could be to incorporate the token into the connection_string... something like pubkey:token@ip:port and let it be optional when parsing. This isn't standardized anywhere but might be a nice way to do it? Though it does go against the typical connection string someone might copy and paste from other software for their LSP (amboss/mempool.space/etc). though maybe if someone's willing to go add a custom LSP they can handle this whereas most users will just use one of the predefined one's you guys populate in a list somewhere. I'll let you guys make final call on how to handle this.

The compute_opening_fee fn should be exported from the lightning-liquidity crate soon enough so we can remove the copy-pasted version here.

An alpha release of the crate is also expected to land shortly, not sure if we want to wait for that before merging something like this or if you guys are fine with keeping a dependency on a specific git commit for now.