### PR TITLE
Fixes for LSPS

### DIFF
--- a/mutiny-core/src/lsp/lsps.rs
+++ b/mutiny-core/src/lsp/lsps.rs
@@ -8,7 +8,7 @@ use lightning::ln::PaymentHash;
 use lightning::routing::gossip::RoutingFees;
 use lightning::routing::router::{RouteHint, RouteHintHop};
 use lightning::util::logger::Logger;
-use lightning::{log_debug, log_error};
+use lightning::{log_debug, log_error, log_info};
 use lightning_invoice::{Bolt11Invoice, InvoiceBuilder};
 use lightning_liquidity::events;
 use lightning_liquidity::lsps2::{LSPS2Event, OpeningFeeParams};
@@ -279,6 +279,8 @@ impl<S: MutinyStorage> LspsClient<S> {
                     if buy_response_sender.send(Ok(invoice)).is_err() {
                         log_error!(self.logger, "error sending buy response, receiver dropped?");
                     }
+
+                    log_info!(self.logger, "LSPS invoice created successfully");
                 }
             }
             _ => {}

--- a/mutiny-core/src/lsp/mod.rs
+++ b/mutiny-core/src/lsp/mod.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::Network;
 use lightning::ln::PaymentHash;
+use lightning_invoice::Bolt11Invoice;
 use lsps::{LspsClient, LspsConfig};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -83,8 +84,10 @@ pub struct FeeResponse {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub(crate) trait Lsp {
     async fn get_lsp_fee_msat(&self, fee_request: FeeRequest) -> Result<FeeResponse, MutinyError>;
-    async fn get_lsp_invoice(&self, invoice_request: InvoiceRequest)
-        -> Result<String, MutinyError>;
+    async fn get_lsp_invoice(
+        &self,
+        invoice_request: InvoiceRequest,
+    ) -> Result<Bolt11Invoice, MutinyError>;
     fn get_lsp_pubkey(&self) -> PublicKey;
     fn get_lsp_connection_string(&self) -> String;
     fn get_expected_skimmed_fee_msat(&self, payment_hash: PaymentHash, payment_size: u64) -> u64;
@@ -140,7 +143,7 @@ impl<S: MutinyStorage> Lsp for AnyLsp<S> {
     async fn get_lsp_invoice(
         &self,
         invoice_request: InvoiceRequest,
-    ) -> Result<String, MutinyError> {
+    ) -> Result<Bolt11Invoice, MutinyError> {
         match self {
             AnyLsp::VoltageFlow(client) => client.get_lsp_invoice(invoice_request).await,
             AnyLsp::Lsps(client) => client.get_lsp_invoice(invoice_request).await,

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1074,7 +1074,17 @@ impl<S: MutinyStorage> Node<S> {
                                 })
                                 .await
                             {
-                                Ok(invoice) => invoice,
+                                Ok(invoice) => {
+                                    self.save_invoice_payment_info(
+                                        invoice.clone(),
+                                        Some(amount_sat * 1_000),
+                                        Some(lsp_fee.fee_amount_msat),
+                                        labels.clone(),
+                                    )
+                                    .await?;
+
+                                    invoice
+                                }
                                 Err(e) => {
                                     log_error!(self.logger, "Failed to get invoice from LSP: {e}");
                                     return Err(e);
@@ -1150,7 +1160,22 @@ impl<S: MutinyStorage> Node<S> {
             MutinyError::InvoiceCreationFailed
         })?;
 
-        let last_update = crate::utils::now().as_secs();
+        self.save_invoice_payment_info(invoice.clone(), amount_msat, fee_amount_msat, labels)
+            .await?;
+
+        log_info!(self.logger, "SUCCESS: generated invoice: {invoice}");
+
+        Ok(invoice)
+    }
+
+    async fn save_invoice_payment_info(
+        &self,
+        invoice: Bolt11Invoice,
+        amount_msat: Option<u64>,
+        fee_amount_msat: Option<u64>,
+        labels: Vec<String>,
+    ) -> Result<(), MutinyError> {
+        let last_update = utils::now().as_secs();
         let payment_hash = PaymentHash(invoice.payment_hash().into_inner());
         let payment_info = PaymentInfo {
             preimage: None,
@@ -1169,13 +1194,9 @@ impl<S: MutinyStorage> Node<S> {
                 MutinyError::InvoiceCreationFailed
             })?;
 
-        self.persister
-            .storage
-            .set_invoice_labels(invoice.clone(), labels)?;
+        self.persister.storage.set_invoice_labels(invoice, labels)?;
 
-        log_info!(self.logger, "SUCCESS: generated invoice: {invoice}");
-
-        Ok(invoice)
+        Ok(())
     }
 
     pub fn get_invoice_by_hash(&self, payment_hash: &Sha256) -> Result<MutinyInvoice, MutinyError> {

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1035,20 +1035,13 @@ impl<S: MutinyStorage> Node<S> {
                             )
                             .await?;
 
-                        let lsp_invoice = match client
+                        let lsp_invoice = client
                             .get_lsp_invoice(InvoiceRequest {
                                 bolt11: Some(invoice.to_string()),
                                 user_channel_id,
                                 fee_id: lsp_fee.id,
                             })
-                            .await
-                        {
-                            Ok(lsp_invoice_str) => Bolt11Invoice::from_str(&lsp_invoice_str)?,
-                            Err(e) => {
-                                log_error!(self.logger, "Failed to get invoice from LSP: {e}");
-                                return Err(e);
-                            }
-                        };
+                            .await?;
 
                         if invoice.network() != self.network {
                             return Err(MutinyError::IncorrectNetwork(invoice.network()));
@@ -1081,7 +1074,7 @@ impl<S: MutinyStorage> Node<S> {
                                 })
                                 .await
                             {
-                                Ok(lsp_invoice_str) => Bolt11Invoice::from_str(&lsp_invoice_str)?,
+                                Ok(invoice) => invoice,
                                 Err(e) => {
                                     log_error!(self.logger, "Failed to get invoice from LSP: {e}");
                                     return Err(e);

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -556,10 +556,12 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
 
             log_info!(logger, "inserting updated nodes");
 
-            self.storage.insert_nodes(&NodeStorage {
-                nodes: updated_nodes,
-                version: node_storage.version + 1,
-            })?;
+            self.storage
+                .insert_nodes(&NodeStorage {
+                    nodes: updated_nodes,
+                    version: node_storage.version + 1,
+                })
+                .await?;
 
             log_info!(logger, "inserted updated nodes");
 
@@ -1415,7 +1417,7 @@ impl<S: MutinyStorage> NodeManager<S> {
         node_storage.version += 1; // update version for VSS
 
         // save updated lsp to storage
-        self.storage.insert_nodes(&node_storage)?;
+        self.storage.insert_nodes(&node_storage).await?;
 
         Ok(())
     }
@@ -2114,7 +2116,7 @@ pub(crate) async fn create_new_node_from_node_manager<S: MutinyStorage>(
         .nodes
         .insert(next_node_uuid.clone(), next_node.clone());
 
-    node_manager.storage.insert_nodes(&existing_nodes)?;
+    node_manager.storage.insert_nodes(&existing_nodes).await?;
     node_mutex.nodes = existing_nodes.nodes.clone();
 
     let mut node_builder = NodeBuilder::new(node_manager.xprivkey, node_manager.storage.clone())

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -349,9 +349,10 @@ pub trait MutinyStorage: Clone + Sized + Send + Sync + 'static {
     }
 
     /// Inserts the node indexes into storage
-    fn insert_nodes(&self, nodes: &NodeStorage) -> Result<(), MutinyError> {
+    async fn insert_nodes(&self, nodes: &NodeStorage) -> Result<(), MutinyError> {
         let version = Some(nodes.version);
-        self.set_data(NODES_KEY.to_string(), nodes, version)
+        self.set_data_async(NODES_KEY.to_string(), nodes, version)
+            .await
     }
 
     /// Gets the federation indexes from storage

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -668,8 +668,6 @@ impl MutinyWallet {
         let lsp_config = create_lsp_config(lsp_url, lsp_connection_string, lsp_token)?;
 
         self.inner.node_manager.change_lsp(lsp_config).await?;
-        // sleep 250ms to let storage take effect
-        sleep(250).await;
         Ok(())
     }
 


### PR DESCRIPTION
Fixes a couple issues.

1. Makes sure we await node storage being written, this way we are sure it is done when we change LSP and restart
2. Makes `get_lsp_invoice` so we aren't serializing and deserializing when we don't need to 
3. Fixes a bug where I put the wrong pubkey in the invoice
4. Fixes so we persist invoices created from LSPS so we can properly track it