### PR TITLE
Switch to builder methodology

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -227,6 +227,131 @@ impl Ord for ActivityItem {
     }
 }
 
+pub struct MutinyWalletConfigBuilder {
+    xprivkey: ExtendedPrivKey,
+    #[cfg(target_arch = "wasm32")]
+    websocket_proxy_addr: Option<String>,
+    network: Option<Network>,
+    user_esplora_url: Option<String>,
+    user_rgs_url: Option<String>,
+    lsp_url: Option<String>,
+    lsp_connection_string: Option<String>,
+    lsp_token: Option<String>,
+    auth_client: Option<Arc<MutinyAuthClient>>,
+    subscription_url: Option<String>,
+    scorer_url: Option<String>,
+    do_not_connect_peers: bool,
+    skip_device_lock: bool,
+    pub safe_mode: bool,
+    skip_hodl_invoices: bool,
+}
+
+impl MutinyWalletConfigBuilder {
+    pub fn new(xprivkey: ExtendedPrivKey) -> MutinyWalletConfigBuilder {
+        MutinyWalletConfigBuilder {
+            xprivkey,
+            #[cfg(target_arch = "wasm32")]
+            websocket_proxy_addr: None,
+            network: None,
+            user_esplora_url: None,
+            user_rgs_url: None,
+            lsp_url: None,
+            lsp_connection_string: None,
+            lsp_token: None,
+            auth_client: None,
+            subscription_url: None,
+            scorer_url: None,
+            do_not_connect_peers: false,
+            skip_device_lock: false,
+            safe_mode: false,
+            skip_hodl_invoices: true,
+        }
+    }
+
+    /// Required
+    pub fn with_network(mut self, network: Network) -> MutinyWalletConfigBuilder {
+        self.network = Some(network);
+        self
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn with_websocket_proxy_addr(&mut self, websocket_proxy_addr: String) {
+        self.websocket_proxy_addr = Some(websocket_proxy_addr);
+    }
+
+    pub fn with_user_esplora_url(&mut self, user_esplora_url: String) {
+        self.user_esplora_url = Some(user_esplora_url);
+    }
+
+    pub fn with_user_rgs_url(&mut self, user_rgs_url: String) {
+        self.user_rgs_url = Some(user_rgs_url);
+    }
+
+    pub fn with_lsp_url(&mut self, lsp_url: String) {
+        self.lsp_url = Some(lsp_url);
+    }
+
+    pub fn with_lsp_connection_string(&mut self, lsp_connection_string: String) {
+        self.lsp_connection_string = Some(lsp_connection_string);
+    }
+
+    pub fn with_lsp_token(&mut self, lsp_token: String) {
+        self.lsp_token = Some(lsp_token);
+    }
+
+    pub fn with_auth_client(&mut self, auth_client: Arc<MutinyAuthClient>) {
+        self.auth_client = Some(auth_client);
+    }
+
+    pub fn with_subscription_url(&mut self, subscription_url: String) {
+        self.subscription_url = Some(subscription_url);
+    }
+
+    pub fn with_scorer_url(&mut self, scorer_url: String) {
+        self.scorer_url = Some(scorer_url);
+    }
+
+    pub fn do_not_connect_peers(&mut self) {
+        self.do_not_connect_peers = true;
+    }
+
+    pub fn with_skip_device_lock(&mut self) {
+        self.skip_device_lock = true;
+    }
+
+    pub fn with_safe_mode(&mut self) {
+        self.safe_mode = true;
+        self.skip_device_lock = true;
+    }
+
+    pub fn do_not_skip_hodl_invoices(&mut self) {
+        self.skip_hodl_invoices = false;
+    }
+
+    pub fn build(self) -> MutinyWalletConfig {
+        let network = self.network.expect("network is required");
+
+        MutinyWalletConfig {
+            xprivkey: self.xprivkey,
+            #[cfg(target_arch = "wasm32")]
+            websocket_proxy_addr: self.websocket_proxy_addr,
+            network,
+            user_esplora_url: self.user_esplora_url,
+            user_rgs_url: self.user_rgs_url,
+            lsp_url: self.lsp_url,
+            lsp_connection_string: self.lsp_connection_string,
+            lsp_token: self.lsp_token,
+            auth_client: self.auth_client,
+            subscription_url: self.subscription_url,
+            scorer_url: self.scorer_url,
+            do_not_connect_peers: self.do_not_connect_peers,
+            skip_device_lock: self.skip_device_lock,
+            safe_mode: self.safe_mode,
+            skip_hodl_invoices: self.skip_hodl_invoices,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct MutinyWalletConfig {
     xprivkey: ExtendedPrivKey,
@@ -245,54 +370,6 @@ pub struct MutinyWalletConfig {
     skip_device_lock: bool,
     pub safe_mode: bool,
     skip_hodl_invoices: bool,
-}
-
-impl MutinyWalletConfig {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        xprivkey: ExtendedPrivKey,
-        #[cfg(target_arch = "wasm32")] websocket_proxy_addr: Option<String>,
-        network: Network,
-        user_esplora_url: Option<String>,
-        user_rgs_url: Option<String>,
-        lsp_url: Option<String>,
-        lsp_connection_string: Option<String>,
-        lsp_token: Option<String>,
-        auth_client: Option<Arc<MutinyAuthClient>>,
-        subscription_url: Option<String>,
-        scorer_url: Option<String>,
-        skip_device_lock: bool,
-        skip_hodl_invoices: bool,
-    ) -> Self {
-        Self {
-            xprivkey,
-            #[cfg(target_arch = "wasm32")]
-            websocket_proxy_addr,
-            network,
-            user_esplora_url,
-            user_rgs_url,
-            scorer_url,
-            lsp_url,
-            lsp_connection_string,
-            lsp_token,
-            auth_client,
-            subscription_url,
-            do_not_connect_peers: false,
-            skip_device_lock,
-            safe_mode: false,
-            skip_hodl_invoices,
-        }
-    }
-
-    pub fn with_do_not_connect_peers(mut self) -> Self {
-        self.do_not_connect_peers = true;
-        self
-    }
-
-    pub fn with_safe_mode(mut self) -> Self {
-        self.safe_mode = true;
-        self.with_do_not_connect_peers()
-    }
 }
 
 #[derive(Clone)]
@@ -1290,7 +1367,7 @@ mod tests {
 
     use crate::{
         encrypt::encryption_key_from_pass, generate_seed, logging::MutinyLogger,
-        nodemanager::NodeManager, sql::glue::GlueDB, MutinyWallet, MutinyWalletConfig,
+        nodemanager::NodeManager, sql::glue::GlueDB, MutinyWallet, MutinyWalletConfigBuilder,
     };
     use bitcoin::util::bip32::ExtendedPrivKey;
     use bitcoin::Network;
@@ -1308,28 +1385,16 @@ mod tests {
         log!("{}", test_name);
 
         let mnemonic = generate_seed(12).unwrap();
-        let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &mnemonic.to_seed("")).unwrap();
+        let network = Network::Regtest;
+        let xpriv = ExtendedPrivKey::new_master(network, &mnemonic.to_seed("")).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
         let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
-        let config = MutinyWalletConfig::new(
-            xpriv,
-            #[cfg(target_arch = "wasm32")]
-            None,
-            Network::Regtest,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-            true,
-        );
+        let config = MutinyWalletConfigBuilder::new(xpriv)
+            .with_network(network)
+            .build();
         let mw = MutinyWallet::new(storage.clone(), config, None)
             .await
             .expect("mutiny wallet should initialize");
@@ -1341,28 +1406,16 @@ mod tests {
     async fn restart_mutiny_wallet() {
         let test_name = "restart_mutiny_wallet";
         log!("{}", test_name);
-        let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &[0; 32]).unwrap();
+        let network = Network::Regtest;
+        let xpriv = ExtendedPrivKey::new_master(network, &[0; 32]).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
         let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
-        let config = MutinyWalletConfig::new(
-            xpriv,
-            #[cfg(target_arch = "wasm32")]
-            None,
-            Network::Regtest,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-            true,
-        );
+        let config = MutinyWalletConfigBuilder::new(xpriv)
+            .with_network(network)
+            .build();
         let mut mw = MutinyWallet::new(storage.clone(), config, None)
             .await
             .expect("mutiny wallet should initialize");
@@ -1379,29 +1432,17 @@ mod tests {
         let test_name = "restart_mutiny_wallet_with_nodes";
         log!("{}", test_name);
 
-        let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &[0; 32]).unwrap();
+        let network = Network::Regtest;
+        let xpriv = ExtendedPrivKey::new_master(network, &[0; 32]).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
         let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
 
         assert!(!NodeManager::has_node_manager(storage.clone()));
-        let config = MutinyWalletConfig::new(
-            xpriv,
-            #[cfg(target_arch = "wasm32")]
-            None,
-            Network::Regtest,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-            true,
-        );
+        let config = MutinyWalletConfigBuilder::new(xpriv)
+            .with_network(network)
+            .build();
         let mut mw = MutinyWallet::new(storage.clone(), config, None)
             .await
             .expect("mutiny wallet should initialize");
@@ -1420,28 +1461,16 @@ mod tests {
         let test_name = "restore_mutiny_mnemonic";
         log!("{}", test_name);
         let mnemonic = generate_seed(12).unwrap();
-        let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &mnemonic.to_seed("")).unwrap();
+        let network = Network::Regtest;
+        let xpriv = ExtendedPrivKey::new_master(network, &mnemonic.to_seed("")).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
         let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
-        let config = MutinyWalletConfig::new(
-            xpriv,
-            #[cfg(target_arch = "wasm32")]
-            None,
-            Network::Regtest,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-            true,
-        );
+        let config = MutinyWalletConfigBuilder::new(xpriv)
+            .with_network(network)
+            .build();
         let mw = MutinyWallet::new(storage.clone(), config, None)
             .await
             .expect("mutiny wallet should initialize");
@@ -1453,23 +1482,10 @@ mod tests {
         let cipher = encryption_key_from_pass(&pass).unwrap();
         let storage2 = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage2.clone()));
-        let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &[0; 32]).unwrap();
-        let mut config2 = MutinyWalletConfig::new(
-            xpriv,
-            #[cfg(target_arch = "wasm32")]
-            None,
-            Network::Regtest,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-            true,
-        );
+        let xpriv = ExtendedPrivKey::new_master(network, &[0; 32]).unwrap();
+        let config2 = MutinyWalletConfigBuilder::new(xpriv)
+            .with_network(network)
+            .build();
         let mw2 = MutinyWallet::new(storage2.clone(), config2.clone(), None)
             .await
             .expect("mutiny wallet should initialize");
@@ -1496,11 +1512,12 @@ mod tests {
             .await
             .expect("mutiny wallet should restore");
 
-        config2.xprivkey = {
-            let seed = storage3.get_mnemonic().unwrap().unwrap();
-            ExtendedPrivKey::new_master(Network::Regtest, &seed.to_seed("")).unwrap()
-        };
-        let mw2 = MutinyWallet::new(storage3, config2, None)
+        let new_mnemonic = storage3.get_mnemonic().unwrap().unwrap();
+        let new_xpriv = ExtendedPrivKey::new_master(network, &new_mnemonic.to_seed("")).unwrap();
+        let config3 = MutinyWalletConfigBuilder::new(new_xpriv)
+            .with_network(network)
+            .build();
+        let mw2 = MutinyWallet::new(storage3, config3, None)
             .await
             .expect("mutiny wallet should initialize");
         let restored_seed = mw2.node_manager.xprivkey;
@@ -1513,29 +1530,16 @@ mod tests {
         log!("{}", test_name);
 
         let mnemonic = generate_seed(12).unwrap();
-        let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &mnemonic.to_seed("")).unwrap();
+        let network = Network::Regtest;
+        let xpriv = ExtendedPrivKey::new_master(network, &mnemonic.to_seed("")).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
         let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         assert!(!NodeManager::has_node_manager(storage.clone()));
-        let config = MutinyWalletConfig::new(
-            xpriv,
-            #[cfg(target_arch = "wasm32")]
-            None,
-            Network::Regtest,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-            true,
-        )
-        .with_safe_mode();
+        let mut config_builder = MutinyWalletConfigBuilder::new(xpriv).with_network(network);
+        config_builder.with_safe_mode();
+        let config = config_builder.build();
         let mw = MutinyWallet::new(storage.clone(), config, None)
             .await
             .expect("mutiny wallet should initialize");

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2379,14 +2379,15 @@ pub fn create_lsp_config(
 
 #[cfg(test)]
 mod tests {
+    use crate::keymanager::generate_seed;
     use crate::{
         encrypt::encryption_key_from_pass,
         logging::MutinyLogger,
         nodemanager::{
             ActivityItem, ChannelClosure, MutinyInvoice, NodeManager, TransactionDetails,
         },
+        MutinyWalletConfigBuilder,
     };
-    use crate::{keymanager::generate_seed, MutinyWalletConfig};
     use bdk::chain::ConfirmationTime;
     use bitcoin::hashes::hex::{FromHex, ToHex};
     use bitcoin::hashes::{sha256, Hash};
@@ -2417,29 +2418,17 @@ mod tests {
         let test_name = "create_node_manager";
         log!("{}", test_name);
         let seed = generate_seed(12).unwrap();
-        let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &seed.to_seed("")).unwrap();
+        let network = Network::Regtest;
+        let xpriv = ExtendedPrivKey::new_master(network, &seed.to_seed("")).unwrap();
 
         let pass = uuid::Uuid::new_v4().to_string();
         let cipher = encryption_key_from_pass(&pass).unwrap();
         let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
 
         assert!(!NodeManager::has_node_manager(storage.clone()));
-        let c = MutinyWalletConfig::new(
-            xpriv,
-            #[cfg(target_arch = "wasm32")]
-            None,
-            Network::Regtest,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-            true,
-        );
+        let c = MutinyWalletConfigBuilder::new(xpriv)
+            .with_network(network)
+            .build();
         NodeManager::new(
             c,
             storage.clone(),
@@ -2461,23 +2450,11 @@ mod tests {
         let cipher = encryption_key_from_pass(&pass).unwrap();
         let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         let seed = generate_seed(12).expect("Failed to gen seed");
-        let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &seed.to_seed("")).unwrap();
-        let c = MutinyWalletConfig::new(
-            xpriv,
-            #[cfg(target_arch = "wasm32")]
-            None,
-            Network::Regtest,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-            true,
-        );
+        let network = Network::Regtest;
+        let xpriv = ExtendedPrivKey::new_master(network, &seed.to_seed("")).unwrap();
+        let c = MutinyWalletConfigBuilder::new(xpriv)
+            .with_network(network)
+            .build();
         let nm = NodeManager::new(
             c,
             storage,
@@ -2520,23 +2497,11 @@ mod tests {
         let cipher = encryption_key_from_pass(&pass).unwrap();
         let storage = MemoryStorage::new(Some(pass), Some(cipher), None);
         let seed = generate_seed(12).expect("Failed to gen seed");
-        let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &seed.to_seed("")).unwrap();
-        let c = MutinyWalletConfig::new(
-            xpriv,
-            #[cfg(target_arch = "wasm32")]
-            None,
-            Network::Signet,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-            true,
-        );
+        let network = Network::Regtest;
+        let xpriv = ExtendedPrivKey::new_master(network, &seed.to_seed("")).unwrap();
+        let c = MutinyWalletConfigBuilder::new(xpriv)
+            .with_network(network)
+            .build();
         let nm = NodeManager::new(
             c,
             storage,

--- a/mutiny-core/src/nostr/nwc.rs
+++ b/mutiny-core/src/nostr/nwc.rs
@@ -1215,7 +1215,7 @@ mod wasm_test {
     async fn test_allowed_hodl_invoice() {
         let storage = MemoryStorage::default();
         let mut mw = create_mutiny_wallet(storage.clone()).await;
-        mw.config.skip_hodl_invoices = false; // allow hodl invoices
+        mw.skip_hodl_invoices = false; // allow hodl invoices
 
         let xprivkey = ExtendedPrivKey::new_master(Network::Regtest, &[0; 64]).unwrap();
         let stop = Arc::new(AtomicBool::new(false));

--- a/mutiny-core/src/test_utils.rs
+++ b/mutiny-core/src/test_utils.rs
@@ -56,25 +56,11 @@ pub fn create_nwc_request(nwc: &NostrWalletConnectURI, invoice: String) -> Event
 }
 
 pub(crate) async fn create_mutiny_wallet<S: MutinyStorage>(storage: S) -> MutinyWallet<S> {
-    let xpriv = ExtendedPrivKey::new_master(Network::Regtest, &[0; 32]).unwrap();
-
-    let config = MutinyWalletConfig::new(
-        xpriv,
-        #[cfg(target_arch = "wasm32")]
-        None,
-        Network::Regtest,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        false,
-        true,
-    );
-
+    let network = Network::Regtest;
+    let xpriv = ExtendedPrivKey::new_master(network, &[0; 32]).unwrap();
+    let config = MutinyWalletConfigBuilder::new(xpriv)
+        .with_network(network)
+        .build();
     MutinyWallet::new(storage.clone(), config, None)
         .await
         .expect("mutiny wallet should initialize")
@@ -215,7 +201,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::fees::MutinyFeeEstimator;
+use crate::chain::MutinyChain;
 use crate::logging::MutinyLogger;
 use crate::node::{NetworkGraph, Node, RapidGossipSync};
 use crate::nodemanager::NodeIndex;
@@ -225,7 +211,7 @@ use crate::storage::MutinyStorage;
 use crate::utils::{now, Mutex};
 use crate::vss::MutinyVssClient;
 use crate::{auth::MutinyAuthClient, MutinyWallet};
-use crate::{chain::MutinyChain, MutinyWalletConfig};
+use crate::{fees::MutinyFeeEstimator, MutinyWalletConfigBuilder};
 use crate::{generate_seed, lnurlauth::AuthManager};
 
 pub const MANAGER_BYTES: [u8; 256] = [

--- a/mutiny-core/src/test_utils.rs
+++ b/mutiny-core/src/test_utils.rs
@@ -61,7 +61,9 @@ pub(crate) async fn create_mutiny_wallet<S: MutinyStorage>(storage: S) -> Mutiny
     let config = MutinyWalletConfigBuilder::new(xpriv)
         .with_network(network)
         .build();
-    MutinyWallet::new(storage.clone(), config, None)
+    let mw_builder = MutinyWalletBuilder::new(xpriv, storage.clone()).with_config(config);
+    mw_builder
+        .build()
         .await
         .expect("mutiny wallet should initialize")
 }
@@ -201,7 +203,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::chain::MutinyChain;
 use crate::logging::MutinyLogger;
 use crate::node::{NetworkGraph, Node, RapidGossipSync};
 use crate::nodemanager::NodeIndex;
@@ -211,6 +212,7 @@ use crate::storage::MutinyStorage;
 use crate::utils::{now, Mutex};
 use crate::vss::MutinyVssClient;
 use crate::{auth::MutinyAuthClient, MutinyWallet};
+use crate::{chain::MutinyChain, MutinyWalletBuilder};
 use crate::{fees::MutinyFeeEstimator, MutinyWalletConfigBuilder};
 use crate::{generate_seed, lnurlauth::AuthManager};
 

--- a/mutiny-core/src/test_utils.rs
+++ b/mutiny-core/src/test_utils.rs
@@ -116,27 +116,22 @@ pub(crate) async fn create_node<S: MutinyStorage>(storage: S) -> Node<S> {
 
     let chain = Arc::new(MutinyChain::new(tx_sync, wallet.clone(), logger.clone()));
 
-    Node::new(
-        Uuid::new_v4().to_string(),
-        &NodeIndex::default(),
-        xprivkey,
-        storage,
-        gossip_sync,
-        scorer,
-        chain,
-        fee_estimator,
-        wallet,
-        network,
-        &esplora,
-        None,
-        logger,
-        false,
-        false,
-        #[cfg(target_arch = "wasm32")]
-        String::from("wss://p.mutinywallet.com"),
-    )
-    .await
-    .unwrap()
+    let mut node_builder = NodeBuilder::new(xprivkey, storage)
+        .with_uuid(Uuid::new_v4().to_string())
+        .with_node_index(NodeIndex::default())
+        .with_gossip_sync(gossip_sync)
+        .with_scorer(scorer)
+        .with_chain(chain)
+        .with_fee_estimator(fee_estimator)
+        .with_wallet(wallet)
+        .with_esplora(esplora)
+        .with_network(network);
+    node_builder.with_logger(logger.clone());
+
+    #[cfg(target_arch = "wasm32")]
+    node_builder.with_websocket_proxy_addr(String::from("wss://p.mutinywallet.com"));
+
+    node_builder.build().await.unwrap()
 }
 
 pub fn create_dummy_invoice(
@@ -203,7 +198,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::logging::MutinyLogger;
 use crate::node::{NetworkGraph, Node, RapidGossipSync};
 use crate::nodemanager::NodeIndex;
 use crate::onchain::{get_esplora_url, OnChainWallet};
@@ -215,6 +209,7 @@ use crate::{auth::MutinyAuthClient, MutinyWallet};
 use crate::{chain::MutinyChain, MutinyWalletBuilder};
 use crate::{fees::MutinyFeeEstimator, MutinyWalletConfigBuilder};
 use crate::{generate_seed, lnurlauth::AuthManager};
+use crate::{logging::MutinyLogger, node::NodeBuilder};
 
 pub const MANAGER_BYTES: [u8; 256] = [
     1, 1, 246, 30, 238, 59, 99, 163, 128, 164, 119, 160, 99, 175, 50, 178, 187, 201, 124, 159, 249,

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -29,7 +29,6 @@ use lightning::{log_error, routing::gossip::NodeId, util::logger::Logger};
 use lightning_invoice::Bolt11Invoice;
 use lnurl::lightning_address::LightningAddress;
 use lnurl::lnurl::LnUrl;
-use mutiny_core::labels::Contact;
 use mutiny_core::lnurlauth::AuthManager;
 use mutiny_core::nostr::nip49::NIP49URI;
 use mutiny_core::nostr::nwc::{BudgetedSpendingConditions, NwcProfileTag, SpendingConditions};
@@ -38,6 +37,7 @@ use mutiny_core::utils::{now, sleep};
 use mutiny_core::vss::MutinyVssClient;
 use mutiny_core::{auth::MutinyAuthClient, sql::glue::GlueDB};
 use mutiny_core::{encrypt::encryption_key_from_pass, MutinyWalletConfigBuilder};
+use mutiny_core::{labels::Contact, MutinyWalletBuilder};
 use mutiny_core::{
     labels::LabelStorage,
     nodemanager::{create_lsp_config, NodeManager},
@@ -266,14 +266,14 @@ impl MutinyWallet {
         }
         let config = config_builder.build();
 
-        let inner =
-            mutiny_core::MutinyWallet::new(storage, config, Some(logger.session_id.clone()))
-                .await?;
+        let mut mw_builder = MutinyWalletBuilder::new(xprivkey, storage).with_config(config);
+        mw_builder.with_session_id(logger.session_id.clone());
+        let inner = mw_builder.build().await?;
         Ok(MutinyWallet { mnemonic, inner })
     }
 
     pub fn is_safe_mode(&self) -> bool {
-        self.inner.config.safe_mode
+        self.inner.is_safe_mode()
     }
 
     /// Returns if there is a saved wallet in storage.

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -29,7 +29,6 @@ use lightning::{log_error, routing::gossip::NodeId, util::logger::Logger};
 use lightning_invoice::Bolt11Invoice;
 use lnurl::lightning_address::LightningAddress;
 use lnurl::lnurl::LnUrl;
-use mutiny_core::encrypt::encryption_key_from_pass;
 use mutiny_core::labels::Contact;
 use mutiny_core::lnurlauth::AuthManager;
 use mutiny_core::nostr::nip49::NIP49URI;
@@ -38,6 +37,7 @@ use mutiny_core::storage::{DeviceLock, MutinyStorage, DEVICE_LOCK_KEY};
 use mutiny_core::utils::{now, sleep};
 use mutiny_core::vss::MutinyVssClient;
 use mutiny_core::{auth::MutinyAuthClient, sql::glue::GlueDB};
+use mutiny_core::{encrypt::encryption_key_from_pass, MutinyWalletConfigBuilder};
 use mutiny_core::{
     labels::LabelStorage,
     nodemanager::{create_lsp_config, NodeManager},
@@ -224,29 +224,47 @@ impl MutinyWallet {
 
         let storage = IndexedDbStorage::new(password, cipher, vss_client, logger.clone()).await?;
 
-        let mut config = mutiny_core::MutinyWalletConfig::new(
-            xprivkey,
-            websocket_proxy_addr,
-            network,
-            user_esplora_url,
-            user_rgs_url,
-            lsp_url,
-            lsp_connection_string,
-            lsp_token,
-            auth_client,
-            subscription_url,
-            scorer_url,
-            skip_device_lock.unwrap_or(false),
-            skip_hodl_invoices.unwrap_or(true),
-        );
-
+        let mut config_builder = MutinyWalletConfigBuilder::new(xprivkey).with_network(network);
+        if let Some(w) = websocket_proxy_addr {
+            config_builder.with_websocket_proxy_addr(w);
+        }
+        if let Some(url) = user_esplora_url {
+            config_builder.with_user_esplora_url(url);
+        }
+        if let Some(url) = user_rgs_url {
+            config_builder.with_user_rgs_url(url);
+        }
+        if let Some(url) = lsp_url {
+            config_builder.with_lsp_url(url);
+        }
+        if let Some(url) = lsp_connection_string {
+            config_builder.with_lsp_connection_string(url);
+        }
+        if let Some(url) = lsp_token {
+            config_builder.with_lsp_token(url);
+        }
+        if let Some(a) = auth_client {
+            config_builder.with_auth_client(a);
+        }
+        if let Some(url) = subscription_url {
+            config_builder.with_subscription_url(url);
+        }
+        if let Some(url) = scorer_url {
+            config_builder.with_scorer_url(url);
+        }
+        if let Some(true) = skip_device_lock {
+            config_builder.with_skip_device_lock();
+        }
+        if let Some(false) = skip_hodl_invoices {
+            config_builder.do_not_skip_hodl_invoices();
+        }
         if let Some(true) = do_not_connect_peers {
-            config = config.with_do_not_connect_peers();
+            config_builder.do_not_connect_peers();
         }
-
         if safe_mode {
-            config = config.with_safe_mode();
+            config_builder.with_safe_mode();
         }
+        let config = config_builder.build();
 
         let inner =
             mutiny_core::MutinyWallet::new(storage, config, Some(logger.session_id.clone()))


### PR DESCRIPTION
TODO: 
- [x] MutinyWalletConfig
- [x] MutinyWallet
- [x] NodeManager
- [x] Node

Will probably get rid of MutinyWalletConfigBuilder once I make my way through it all and just use MutinyWalletBuilder instead. But baby steps.

This will make it a lot easier to do specific things with `MutinyWallet` but not init the whole thing. 