### PR TITLE
Use AddressIndex::LastUnused when sweeping spendable outputs

### DIFF
--- a/mutiny-core/src/keymanager.rs
+++ b/mutiny-core/src/keymanager.rs
@@ -68,7 +68,11 @@ impl<S: MutinyStorage> PhantomKeysManager<S> {
     ) -> Result<Transaction, ()> {
         let address = {
             let mut wallet = self.wallet.wallet.try_write().map_err(|_| ())?;
-            wallet.get_internal_address(AddressIndex::New).address
+            // These often fail because we continually retry these. Use LastUnused so we don't generate a ton of new
+            // addresses for no reason.
+            wallet
+                .get_internal_address(AddressIndex::LastUnused)
+                .address
         };
 
         let result = self.inner.spend_spendable_outputs(

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -800,12 +800,10 @@ impl<S: MutinyStorage> NodeManager<S> {
     }
 
     /// Gets a new bitcoin address from the wallet.
-    /// Will generate a new address on every call.
-    ///
-    /// It is recommended to create a new address for every transaction.
+    /// Will generate the last unused address in our bdk wallet.
     pub fn get_new_address(&self, labels: Vec<String>) -> Result<Address, MutinyError> {
         if let Ok(mut wallet) = self.wallet.wallet.try_write() {
-            let address = wallet.get_address(AddressIndex::New).address;
+            let address = wallet.get_address(AddressIndex::LastUnused).address;
             self.set_address_labels(address.clone(), labels)?;
             return Ok(address);
         }

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -695,7 +695,9 @@ impl<S: MutinyStorage> WalletSource for OnChainWallet<S> {
 
     fn get_change_script(&self) -> Result<Script, ()> {
         let mut wallet = self.wallet.try_write().map_err(|_| ())?;
-        let addr = wallet.get_internal_address(AddressIndex::New).address;
+        let addr = wallet
+            .get_internal_address(AddressIndex::LastUnused)
+            .address;
         Ok(addr.script_pubkey())
     }
 


### PR DESCRIPTION
We had to bump the stop gap for the on-chain wallet because people had large gaps, I suspect this is one of the causes. This should help reduce the number of on-chain addresses we generate that don't end up ever being used.