### PR TITLE
Don't save already paid invoices to pending list

### DIFF
--- a/mutiny-core/src/nostr/nwc.rs
+++ b/mutiny-core/src/nostr/nwc.rs
@@ -738,6 +738,20 @@ impl NostrWalletConnect {
                                                 "Payment timeout, not removing payment from budget"
                                             );
                                         }
+                                        MutinyError::NonUniquePaymentHash => {
+                                            log_warn!(
+                                                nostr_manager.logger,
+                                                "Already paid invoice, removing payment from budget"
+                                            );
+                                            budget.remove_payment(&invoice);
+                                            self.profile.spending_conditions =
+                                                SpendingConditions::Budget(budget);
+
+                                            nostr_manager.save_nwc_profile(self.clone())?;
+
+                                            // don't save to pending list, we already paid it
+                                            return Ok(None);
+                                        }
                                         _ => {
                                             log_warn!(
                                                 nostr_manager.logger,


### PR DESCRIPTION
Previously if we got this error we'd save it to our pending nwc list. If we've already paid the invoice there is no reason to add it to our pending list as it would just fail there too. This should better handle this case.