### PR TITLE
Only log to console the info logs

### DIFF
--- a/mutiny-wasm/src/utils.rs
+++ b/mutiny-wasm/src/utils.rs
@@ -14,7 +14,7 @@ pub fn set_panic_hook() {
 
 #[wasm_bindgen(start)]
 pub async fn main_js() -> Result<(), JsValue> {
-    wasm_logger::init(wasm_logger::Config::new(Level::Debug).message_on_new_line());
+    wasm_logger::init(wasm_logger::Config::new(Level::Info).message_on_new_line());
     debug!("Main function begins and ends");
     Ok(())
 }


### PR DESCRIPTION
Still shows debug/trace when you download logs. We use gluesql now which uses sqlparser which spams `debug` in console which is annoying. 