### PR TITLE
Remove empty claimable balances check

### DIFF
--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -177,10 +177,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
                         (keys_manager.as_ref(), keys_manager.as_ref()),
                     ) {
                         Ok((blockhash, channel_monitor)) => {
-                            // if there are no claimable balances, we don't need to watch the channel
-                            if !channel_monitor.get_claimable_balances().is_empty() {
-                                accum.push((blockhash, channel_monitor));
-                            }
+                            accum.push((blockhash, channel_monitor));
                             Ok(accum)
                         }
                         Err(e) => Err(io::Error::new(


### PR DESCRIPTION
I think this isn't behaving how we expect and seems like it will be empty for channels when it is still viable. I don't think this optimization did much either way.