### PR TITLE
Move channel config load after watch_channel

### DIFF
--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -197,6 +197,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
     pub(crate) async fn read_channel_manager(
         &self,
         network: Network,
+        accept_underpaying_htlcs: bool,
         chain_monitor: Arc<ChainMonitor<S>>,
         mutiny_chain: Arc<MutinyChain<S>>,
         fee_estimator: Arc<MutinyFeeEstimator<S>>,
@@ -215,6 +216,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
                 let bytes = FromHex::from_hex(&hex)?;
                 let res = Self::parse_channel_manager(
                     bytes,
+                    accept_underpaying_htlcs,
                     chain_monitor,
                     mutiny_chain,
                     fee_estimator,
@@ -234,6 +236,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
 
                 Self::create_new_channel_manager(
                     network,
+                    accept_underpaying_htlcs,
                     chain_monitor,
                     mutiny_chain,
                     fee_estimator,
@@ -250,6 +253,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
                 let bytes = self.read_value(CHANNEL_MANAGER_KEY)?;
                 Self::parse_channel_manager(
                     bytes,
+                    accept_underpaying_htlcs,
                     chain_monitor,
                     mutiny_chain,
                     fee_estimator,
@@ -265,6 +269,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
     #[allow(clippy::too_many_arguments)]
     fn parse_channel_manager(
         bytes: Vec<u8>,
+        accept_underpaying_htlcs: bool,
         chain_monitor: Arc<ChainMonitor<S>>,
         mutiny_chain: Arc<MutinyChain<S>>,
         fee_estimator: Arc<MutinyFeeEstimator<S>>,
@@ -286,7 +291,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
             mutiny_chain,
             router,
             mutiny_logger,
-            default_user_config(),
+            default_user_config(accept_underpaying_htlcs),
             channel_monitor_mut_references,
         );
         let mut readable_kv_value = Cursor::new(bytes);
@@ -307,6 +312,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn create_new_channel_manager(
         network: Network,
+        accept_underpaying_htlcs: bool,
         chain_monitor: Arc<ChainMonitor<S>>,
         mutiny_chain: Arc<MutinyChain<S>>,
         fee_estimator: Arc<MutinyFeeEstimator<S>>,
@@ -344,7 +350,7 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
             keys_manager.clone(),
             keys_manager.clone(),
             keys_manager,
-            default_user_config(),
+            default_user_config(accept_underpaying_htlcs),
             chain_params,
             utils::now().as_secs() as u32,
         );
@@ -978,6 +984,7 @@ mod test {
         let read = persister
             .read_channel_manager(
                 network,
+                false,
                 chain_monitor.clone(),
                 chain.clone(),
                 fees.clone(),
@@ -1001,6 +1008,7 @@ mod test {
         let read = persister
             .read_channel_manager(
                 network,
+                false,
                 chain_monitor,
                 chain.clone(),
                 fees.clone(),

--- a/mutiny-core/src/lsp/mod.rs
+++ b/mutiny-core/src/lsp/mod.rs
@@ -35,6 +35,13 @@ impl LspConfig {
             token,
         })
     }
+
+    pub fn accept_underpaying_htlcs(&self) -> bool {
+        match self {
+            LspConfig::VoltageFlow(_) => false,
+            LspConfig::Lsps(_) => true,
+        }
+    }
 }
 
 pub fn deserialize_lsp_config<'de, D>(deserializer: D) -> Result<Option<LspConfig>, D::Error>
@@ -127,6 +134,13 @@ impl<S: MutinyStorage> AnyLsp<S> {
             stop,
         )?;
         Ok(Self::Lsps(lsps_client))
+    }
+
+    pub fn accept_underpaying_htlcs(&self) -> bool {
+        match self {
+            AnyLsp::VoltageFlow(_) => false,
+            AnyLsp::Lsps(_) => true,
+        }
     }
 }
 

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -403,36 +403,6 @@ impl<S: MutinyStorage> NodeBuilder<S> {
         let channel_manager: Arc<PhantomChannelManager<S>> =
             Arc::new(read_channel_manager.channel_manager);
 
-        // Check all existing channels against default configs.
-        // If we have default config changes, those should apply
-        // to all existing and new channels.
-        let default_config = default_user_config().channel_config;
-        for channel in channel_manager.list_channels() {
-            // unwrap is safe after LDK.0.0.109
-            if channel.config.unwrap() != default_config {
-                match channel_manager.update_channel_config(
-                    &channel.counterparty.node_id,
-                    &[channel.channel_id],
-                    &default_config,
-                ) {
-                    Ok(_) => {
-                        log_debug!(
-                            logger,
-                            "changed default config for channel: {}",
-                            channel.channel_id.to_hex()
-                        )
-                    }
-                    Err(e) => {
-                        log_error!(
-                            logger,
-                            "error changing default config for channel: {} - {e:?}",
-                            channel.channel_id.to_hex()
-                        )
-                    }
-                };
-            }
-        }
-
         log_info!(logger, "creating lsp client");
         let lsp_config: Option<LspConfig> = match node_index.lsp {
             None => {
@@ -618,6 +588,36 @@ impl<S: MutinyStorage> NodeBuilder<S> {
                         persister.set_failed_spendable_outputs(failed)?;
                     };
                 }
+            }
+        }
+
+        // Check all existing channels against default configs.
+        // If we have default config changes, those should apply
+        // to all existing and new channels.
+        let default_config = default_user_config().channel_config;
+        for channel in channel_manager.list_channels() {
+            // unwrap is safe after LDK.0.0.109
+            if channel.config.unwrap() != default_config {
+                match channel_manager.update_channel_config(
+                    &channel.counterparty.node_id,
+                    &[channel.channel_id],
+                    &default_config,
+                ) {
+                    Ok(_) => {
+                        log_debug!(
+                            logger,
+                            "changed default config for channel: {}",
+                            channel.channel_id.to_hex()
+                        )
+                    }
+                    Err(e) => {
+                        log_error!(
+                            logger,
+                            "error changing default config for channel: {} - {e:?}",
+                            channel.channel_id.to_hex()
+                        )
+                    }
+                };
             }
         }
 

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -385,24 +385,6 @@ impl<S: MutinyStorage> NodeBuilder<S> {
             scoring_params(),
         ));
 
-        // init channel manager
-        let mut read_channel_manager = persister
-            .read_channel_manager(
-                network,
-                chain_monitor.clone(),
-                chain.clone(),
-                fee_estimator.clone(),
-                logger.clone(),
-                keys_manager.clone(),
-                router.clone(),
-                channel_monitors,
-                &esplora,
-            )
-            .await?;
-
-        let channel_manager: Arc<PhantomChannelManager<S>> =
-            Arc::new(read_channel_manager.channel_manager);
-
         log_info!(logger, "creating lsp client");
         let lsp_config: Option<LspConfig> = match node_index.lsp {
             None => {
@@ -419,6 +401,28 @@ impl<S: MutinyStorage> NodeBuilder<S> {
                 }
             }
         };
+
+        // init channel manager
+        let accept_underpaying_htlcs = lsp_config
+            .as_ref()
+            .is_some_and(|l| l.accept_underpaying_htlcs());
+        let mut read_channel_manager = persister
+            .read_channel_manager(
+                network,
+                accept_underpaying_htlcs,
+                chain_monitor.clone(),
+                chain.clone(),
+                fee_estimator.clone(),
+                logger.clone(),
+                keys_manager.clone(),
+                router.clone(),
+                channel_monitors,
+                &esplora,
+            )
+            .await?;
+
+        let channel_manager: Arc<PhantomChannelManager<S>> =
+            Arc::new(read_channel_manager.channel_manager);
 
         let stop = Arc::new(AtomicBool::new(false));
 
@@ -594,7 +598,7 @@ impl<S: MutinyStorage> NodeBuilder<S> {
         // Check all existing channels against default configs.
         // If we have default config changes, those should apply
         // to all existing and new channels.
-        let default_config = default_user_config().channel_config;
+        let default_config = default_user_config(accept_underpaying_htlcs).channel_config;
         for channel in channel_manager.list_channels() {
             // unwrap is safe after LDK.0.0.109
             if channel.config.unwrap() != default_config {
@@ -1693,7 +1697,11 @@ impl<S: MutinyStorage> Node<S> {
         fee_rate: Option<f32>,
         user_channel_id: Option<u128>,
     ) -> Result<u128, MutinyError> {
-        let mut config = default_user_config();
+        let accept_underpaying_htlcs = self
+            .lsp_client
+            .as_ref()
+            .is_some_and(|l| l.accept_underpaying_htlcs());
+        let mut config = default_user_config(accept_underpaying_htlcs);
 
         // if we are opening channel to LSP, turn off SCID alias until CLN is updated
         // LSP protects all invoice information anyways, so no UTXO leakage
@@ -1797,7 +1805,11 @@ impl<S: MutinyStorage> Node<S> {
         // channel size is the total value of the utxos minus the fee
         let channel_value_satoshis = utxo_value - expected_fee;
 
-        let mut config = default_user_config();
+        let accept_underpaying_htlcs = self
+            .lsp_client
+            .as_ref()
+            .is_some_and(|l| l.accept_underpaying_htlcs());
+        let mut config = default_user_config(accept_underpaying_htlcs);
         // if we are opening channel to LSP, turn off SCID alias until CLN is updated
         // LSP protects all invoice information anyways, so no UTXO leakage
         if let Some(lsp) = self.lsp_client.clone() {
@@ -2158,7 +2170,7 @@ pub(crate) fn split_peer_connection_string(
     Ok((pubkey, peer_addr_str.to_string()))
 }
 
-pub(crate) fn default_user_config() -> UserConfig {
+pub(crate) fn default_user_config(accept_underpaying_htlcs: bool) -> UserConfig {
     UserConfig {
         channel_handshake_limits: ChannelHandshakeLimits {
             // lnd's max to_self_delay is 2016, so we want to be compatible.
@@ -2183,7 +2195,7 @@ pub(crate) fn default_user_config() -> UserConfig {
             max_dust_htlc_exposure: MaxDustHTLCExposure::FixedLimitMsat(
                 21_000_000 * 100_000_000 * 1_000,
             ),
-            accept_underpaying_htlcs: true,
+            accept_underpaying_htlcs,
             ..Default::default()
         },
         ..Default::default()


### PR DESCRIPTION
We weren't following the docs for the channel manager where we shouldn't change the channel config until after we've called `watch_channel`. This should fix the `unreachable` @futurepaul was running into

https://docs.rs/lightning/latest/lightning/ln/channelmanager/struct.ChannelManagerReadArgs.html