### PR TITLE
update to latest liquidity lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,7 +2339,7 @@ dependencies = [
 [[package]]
 name = "lightning-liquidity"
 version = "0.1.0"
-source = "git+https://github.com/lightningdevkit/lightning-liquidity.git?rev=e00d917a8bb17e29493497538c7a4dda00bef151#e00d917a8bb17e29493497538c7a4dda00bef151"
+source = "git+https://github.com/johncantrell97/ldk-lsp-client.git?rev=9e01757d20c04aa31c28de8c4ffab5442d547edc#9e01757d20c04aa31c28de8c4ffab5442d547edc"
 dependencies = [
  "bitcoin 0.29.2",
  "chrono",

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -32,7 +32,7 @@ lightning-invoice = { version = "0.26.0", features = ["serde"] }
 lightning-rapid-gossip-sync = { version = "0.0.118" }
 lightning-background-processor = { version = "0.0.118", features = ["futures"] }
 lightning-transaction-sync = { version = "0.0.118", features = ["esplora-async-https"] }
-lightning-liquidity = { git = "https://github.com/lightningdevkit/lightning-liquidity.git", rev = "e00d917a8bb17e29493497538c7a4dda00bef151" }
+lightning-liquidity = { git = "https://github.com/johncantrell97/ldk-lsp-client.git", rev = "9e01757d20c04aa31c28de8c4ffab5442d547edc" }
 chrono = "0.4.22"
 futures-util = { version = "0.3", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -68,9 +68,8 @@ use lightning_invoice::{
     utils::{create_invoice_from_channelmanager_and_duration_since_epoch, create_phantom_invoice},
     Bolt11Invoice,
 };
-use lightning_liquidity::{
-    JITChannelsConfig, LiquidityManager as LDKLSPLiquidityManager, LiquidityProviderConfig,
-};
+use lightning_liquidity::lsps2::client::LSPS2ClientConfig;
+use lightning_liquidity::{LiquidityClientConfig, LiquidityManager as LDKLSPLiquidityManager};
 
 #[cfg(test)]
 use mockall::predicate::*;
@@ -110,7 +109,6 @@ pub(crate) type OnionMessenger<S: MutinyStorage> = LdkOnionMessenger<
 pub type LiquidityManager<S> = LDKLSPLiquidityManager<
     Arc<PhantomKeysManager<S>>,
     Arc<PhantomChannelManager<S>>,
-    Arc<PeerManagerImpl<S>>,
     Arc<dyn Filter + Send + Sync>,
 >;
 
@@ -433,16 +431,13 @@ impl<S: MutinyStorage> NodeBuilder<S> {
             Some(LspConfig::Lsps(lsps_config)) => {
                 let liquidity_manager = Arc::new(LiquidityManager::new(
                     keys_manager.clone(),
-                    Some(LiquidityProviderConfig {
-                        lsps2_config: Some(JITChannelsConfig {
-                            promise_secret: [0; 32],
-                            min_payment_size_msat: 0,
-                            max_payment_size_msat: 9999999999,
-                        }),
-                    }),
                     channel_manager.clone(),
                     None,
                     None,
+                    None,
+                    Some(LiquidityClientConfig {
+                        lsps2_client_config: Some(LSPS2ClientConfig {}),
+                    }),
                 ));
 
                 (
@@ -484,7 +479,9 @@ impl<S: MutinyStorage> NodeBuilder<S> {
             chan_handler: channel_manager.clone(),
             route_handler,
             onion_message_handler,
-            custom_message_handler: Arc::new(MutinyMessageHandler { liquidity }),
+            custom_message_handler: Arc::new(MutinyMessageHandler {
+                liquidity: liquidity.clone(),
+            }),
         };
 
         let bump_tx_event_handler = Arc::new(BumpTransactionEventHandler::new(
@@ -511,6 +508,13 @@ impl<S: MutinyStorage> NodeBuilder<S> {
             ln_msg_handler,
             logger.clone(),
         ));
+
+        if let Some(liquidity) = liquidity {
+            let process_msgs_pm = peer_man.clone();
+            liquidity.set_process_msgs_callback(move || {
+                process_msgs_pm.process_events();
+            });
+        }
 
         // sync to chain tip
         if read_channel_manager.is_restarting {


### PR DESCRIPTION
- updates to latest lib
- needs to use fork to patch ldk back to 118 (same as c=)
- fixes a bug where we weren't calling peer manager process events, causing delays in message sending