### PR TITLE
Only auto-label lnurls if no labels were given

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -1505,9 +1505,9 @@ impl<S: MutinyStorage> MutinyWallet<S> {
                     .amount_milli_satoshis()
                     .is_some_and(|amt| msats == amt)
                 {
-                    // If we have a contact for this lnurl, add it to the labels as the first
-                    if let Some(label) = self.storage.get_contact_for_lnurl(lnurl)? {
-                        if !labels.contains(&label) {
+                    // If we don't have any labels, see if this matches a contact
+                    if labels.is_empty() {
+                        if let Some(label) = self.storage.get_contact_for_lnurl(lnurl)? {
                             labels.insert(0, label)
                         }
                     }


### PR DESCRIPTION
This was causing some confusion where if multiple contacts had the same lnurl then when paying one the other would get tagged. This will fix where we'll only try to label it if no tags were given