### PR TITLE
Remove async-interface feature

### DIFF
--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -71,9 +71,7 @@ wasm-bindgen-test = "0.3.33"
 mockall = "0.11.2"
 
 [features]
-default = ["async-interface"]
-# needed to make async ldk esplora work
-async-interface = []
+default = []
 ignored_tests = []
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
We had to have this feature when we were copy-pasting the esplora syncing from ldk, now that we are able to use `lightning-transaction-sync`, we can remove this feature