### PR TITLE
Timestamp NWC filters

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -953,7 +953,7 @@ impl<S: MutinyStorage> MutinyWallet<S> {
                         _ = filter_check_fut => {
                             // Check if the filters have changed
                             if let Ok(current_filters) = nostr.get_filters() {
-                                if current_filters != last_filters {
+                                if !utils::compare_filters_vec(&current_filters, &last_filters) {
                                     log_debug!(logger, "subscribing to new nwc filters");
                                     client.subscribe(current_filters.clone()).await;
                                     last_filters = current_filters;

--- a/mutiny-core/src/nostr/nwc.rs
+++ b/mutiny-core/src/nostr/nwc.rs
@@ -17,7 +17,7 @@ use lightning_invoice::Bolt11Invoice;
 use nostr::key::XOnlyPublicKey;
 use nostr::nips::nip47::*;
 use nostr::prelude::{decrypt, encrypt};
-use nostr::{Event, EventBuilder, EventId, Filter, JsonUtil, Keys, Kind, Tag};
+use nostr::{Event, EventBuilder, EventId, Filter, JsonUtil, Keys, Kind, Tag, Timestamp};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::str::FromStr;
@@ -266,11 +266,12 @@ impl NostrWalletConnect {
         self.server_key.public_key()
     }
 
-    pub fn create_nwc_filter(&self) -> Filter {
+    pub fn create_nwc_filter(&self, timestamp: Timestamp) -> Filter {
         Filter::new()
             .kinds(vec![Kind::WalletConnectRequest])
             .author(self.client_pubkey())
             .pubkey(self.server_pubkey())
+            .since(timestamp)
     }
 
     /// Create Nostr Wallet Connect Info event

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -33,6 +33,7 @@ pub const FEDERATIONS_KEY: &str = "federations";
 const FEE_ESTIMATES_KEY: &str = "fee_estimates";
 pub const BITCOIN_PRICE_CACHE_KEY: &str = "bitcoin_price_cache";
 const FIRST_SYNC_KEY: &str = "first_sync";
+pub const LAST_NWC_SYNC_TIME_KEY: &str = "last_nwc_sync_time";
 pub(crate) const DEVICE_ID_KEY: &str = "device_id";
 pub const DEVICE_LOCK_KEY: &str = "device_lock";
 pub(crate) const EXPECTED_NETWORK_KEY: &str = "network";
@@ -419,6 +420,20 @@ pub trait MutinyStorage: Clone + Sized + Send + Sync + 'static {
         let current = self.get_dm_sync_time()?.unwrap_or_default();
         if current < time {
             self.set_data(LAST_DM_SYNC_TIME_KEY.to_string(), time, None)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn get_nwc_sync_time(&self) -> Result<Option<u64>, MutinyError> {
+        self.get_data(LAST_NWC_SYNC_TIME_KEY)
+    }
+
+    fn set_nwc_sync_time(&self, time: u64) -> Result<(), MutinyError> {
+        // only update if the time is newer
+        let current = self.get_nwc_sync_time()?.unwrap_or_default();
+        if current < time {
+            self.set_data(LAST_NWC_SYNC_TIME_KEY.to_string(), time, None)
         } else {
             Ok(())
         }


### PR DESCRIPTION
This is needed to do NWC on relays that aren't on blastr. Otherwise we may pull down events multiple times and keep reprocessing them