### PR TITLE
Reuse reqwest client across codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,9 +2087,9 @@ checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "lnurl-rs"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa42d2e0488393c00b96d0ea170eb6f9acbda7f965690fcd40ce6447517db7"
+checksum = "3912d662eeb78043d92de3c36e3839ec831e4b224be194864a5f4057e34854e2"
 dependencies = [
  "aes",
  "anyhow",

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://mutinywallet.com"
 repository = "https://github.com/mutinywallet/mutiny-node"
 
 [dependencies]
-lnurl-rs = { version = "0.3.1", default-features = false, features = ["async", "async-https"] }
+lnurl-rs = { version = "0.3.2", default-features = false, features = ["async", "async-https"] }
 
 cfg-if = "1.0.0"
 bip39 = { version = "2.0.0" }

--- a/mutiny-core/src/auth.rs
+++ b/mutiny-core/src/auth.rs
@@ -24,7 +24,7 @@ struct CustomClaims {
 
 pub struct MutinyAuthClient {
     pub auth: AuthManager,
-    lnurl_client: Arc<LnUrlClient>,
+    pub lnurl_client: Arc<LnUrlClient>,
     url: String,
     http_client: Client,
     jwt: RwLock<Option<String>>,
@@ -38,7 +38,7 @@ impl MutinyAuthClient {
         logger: Arc<MutinyLogger>,
         url: String,
     ) -> Self {
-        let http_client = Client::new();
+        let http_client = lnurl_client.client.clone();
         Self {
             auth,
             lnurl_client,

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -29,7 +29,7 @@ lightning = { version = "0.0.118", default-features = false, features = ["std"] 
 lightning-invoice = { version = "0.26.0" }
 thiserror = "1.0"
 instant = { version = "0.1", features = ["wasm-bindgen"] }
-lnurl-rs = { version = "0.3.1", default-features = false }
+lnurl-rs = { version = "0.3.2", default-features = false }
 nostr = { version = "0.27.0", default-features = false, features = ["nip04", "nip05", "nip07", "nip47", "nip57"] }
 wasm-logger = "0.2.0"
 log = "0.4.17"

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -1288,7 +1288,7 @@ impl MutinyWallet {
     /// Gets the current bitcoin price in chosen Fiat.
     #[wasm_bindgen]
     pub async fn get_bitcoin_price(&self, fiat: Option<String>) -> Result<f32, MutinyJsError> {
-        Ok(self.inner.node_manager.get_bitcoin_price(fiat).await?)
+        Ok(self.inner.get_bitcoin_price(fiat).await?)
     }
 
     /// Exports the current state of the node manager to a json object.


### PR DESCRIPTION
Closes #973

If we create new reqwest clients everywhere we need to create new connections and redo TLS verification for every new client. This makes it so we reuse one across the codebase for pretty much everywhere. Should make things more efficient .

As part of this, moved the bitcoin price code to mutiny wallet instead of the node manager, made more sense here and made the refactor easier.