### PR TITLE
Make node manager locks RwLocks

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -1067,7 +1067,7 @@ impl<S: MutinyStorage> MutinyWallet<S> {
         if self
             .node_manager
             .nodes
-            .lock()
+            .read()
             .await
             .iter()
             .flat_map(|(_, n)| n.channel_manager.list_channels())


### PR DESCRIPTION
Closes #925

Pulled out from #1002 

This was breaking tests in the above PR because the syncing background thread would block us from making other calls (ie get balance). This fixes by putting it in a `RwLock` instead of in a generic `Mutex` as well as making us drop the lock after reading the nodes we are gonna sync instead of holding it during the entire sync duration