### PR TITLE
Cache subscription timestamp

### DIFF
--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -26,6 +26,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use uuid::Uuid;
 
+pub const SUBSCRIPTION_TIMESTAMP: &str = "subscription_timestamp";
 pub const KEYCHAIN_STORE_KEY: &str = "bdk_keychain";
 pub const MNEMONIC_KEY: &str = "mnemonic";
 pub(crate) const NEED_FULL_SYNC_KEY: &str = "needs_full_sync";


### PR DESCRIPTION
This should speed up the startup time if you are a mutiny+ user. Sadly we can't do the same speed up for non mutiny+ users because then we'd lose the ability to restore subscriptions across devices.

@futurepaul made this happen in the background for the front end so it shouldn't effect load times as much but it is still a good optimization 