### PR TITLE
Sync scorer data in the background

### DIFF
--- a/mutiny-core/src/utils.rs
+++ b/mutiny-core/src/utils.rs
@@ -135,6 +135,13 @@ impl<T> Mutex<T> {
             lock: self.inner.borrow_mut(),
         })
     }
+
+    #[allow(clippy::result_unit_err)]
+    pub fn try_lock(&self) -> LockResult<MutexGuard<'_, T>> {
+        Ok(MutexGuard {
+            lock: self.inner.try_borrow_mut().map_err(|_| ())?,
+        })
+    }
 }
 
 impl<'a, T: 'a + ScoreLookUp + ScoreUpdate> LockableScore<'a> for Mutex<T> {


### PR DESCRIPTION
Changes to sync scorer in the background rather than upfront, this made the startup ~500ms faster for me. This will still read the scorer on start up so we will still have a scorer up until it is synced.

#1016