### PR TITLE
Some optimizations to fedimint startup

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -2233,12 +2233,11 @@ async fn create_federations<S: MutinyStorage>(
     storage: &S,
     logger: &Arc<MutinyLogger>,
 ) -> Result<Arc<RwLock<HashMap<FederationId, Arc<FederationClient<S>>>>>, MutinyError> {
-    let federations = federation_storage.federations.into_iter();
-    let mut federation_map = HashMap::new();
-    for federation_item in federations {
+    let mut federation_map = HashMap::with_capacity(federation_storage.federations.len());
+    for (uuid, federation_index) in federation_storage.federations {
         let federation = FederationClient::new(
-            federation_item.0,
-            federation_item.1.federation_code.clone(),
+            uuid,
+            federation_index.federation_code,
             c.xprivkey,
             storage,
             c.network,


### PR DESCRIPTION
Fedimint seems to be the worst offender of startup time in my tests. This fixes one of the issues where we would block on setting the preferred guardian, this is now done in the background. The biggest offender is still `FederationInfo::from_invite_code` which takes ~6 seconds for me. Apparently fedimint-cli saves this to storage so we should be able to do the same and get it rid of the download as well.

This also does some minor touch ups like initializing `federation_id` instead of doing `federation_info.federation_id()` since this would do a hash everytime.

#1016