### PR TITLE
Start fetching auth JWT immediately

### DIFF
--- a/mutiny-core/src/test_utils.rs
+++ b/mutiny-core/src/test_utils.rs
@@ -23,7 +23,7 @@ pub async fn create_vss_client() -> MutinyVssClient {
 
     // Test authenticate method
     match auth_client.authenticate().await {
-        Ok(_) => assert!(auth_client.is_authenticated().is_some()),
+        Ok(_) => assert!(auth_client.is_authenticated().await.is_some()),
         Err(e) => panic!("Authentication failed with error: {:?}", e),
     };
 


### PR DESCRIPTION
The main change for this in `mutiny-wasm/lib.rs`. The idea is to immediately start fetching the JWT for auth, before we would only fetch it once we got our first VSS request, this saves us about ~200ms because otherwise we wait until we have read all of indexed db until we make this call.

Needed to modify the auth client to only allow one call to `retrieve_new_jwt` at a time, otherwise this would sometimes not complete by the time the first VSS call came in and we'd request multiple JWTs.

Otherwise just adds some timing logs and tiny optimizations to indexed db

#1016