### PR TITLE
Start up optimizations grab bag

### DIFF
--- a/mutiny-core/src/federation.rs
+++ b/mutiny-core/src/federation.rs
@@ -1,3 +1,4 @@
+use crate::utils::spawn;
 use crate::{
     error::{MutinyError, MutinyStorageError},
     event::PaymentInfo,
@@ -55,11 +56,15 @@ use fedimint_wallet_client::{WalletClientInit, WalletClientModule};
 use futures::future::{self};
 use futures_util::{pin_mut, StreamExt};
 use hex::FromHex;
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
 use lightning::{
     ln::PaymentHash, log_debug, log_error, log_info, log_trace, log_warn, util::logger::Logger,
 };
 use lightning_invoice::{Bolt11Invoice, RoutingFees};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 use std::{
     str::FromStr,
@@ -192,18 +197,7 @@ impl<S: MutinyStorage> FederationClient<S> {
     ) -> Result<Self, MutinyError> {
         log_info!(logger, "initializing a new federation client: {uuid}");
 
-        let federation_info = FederationInfo::from_invite_code(federation_code.clone())
-            .await
-            .map_err(|e| {
-                log_error!(logger, "Could not parse invite code: {}", e);
-                e
-            })?;
-
-        log_debug!(
-            logger,
-            "parsed federation invite code: {:?}",
-            federation_info.invite_code()
-        );
+        let federation_id = federation_code.federation_id();
 
         let mut client_builder = fedimint_client::Client::builder();
         client_builder.with_module(WalletClientInit(None));
@@ -211,16 +205,31 @@ impl<S: MutinyStorage> FederationClient<S> {
         client_builder.with_module(LightningClientInit);
 
         log_trace!(logger, "Building fedimint client db");
-        let fedimint_storage = FedimintStorage::new(
-            storage.clone(),
-            federation_info.federation_id().to_string(),
-            logger.clone(),
-        )
-        .await?;
+        let fedimint_storage =
+            FedimintStorage::new(storage.clone(), federation_id.to_string(), logger.clone())
+                .await?;
         let db = fedimint_storage.clone().into();
 
         if get_config_from_db(&db).await.is_none() {
-            client_builder.with_federation_info(federation_info.clone());
+            let download = Instant::now();
+            let federation_info = FederationInfo::from_invite_code(federation_code)
+                .await
+                .map_err(|e| {
+                    log_error!(logger, "Could not parse invite code: {}", e);
+                    e
+                })?;
+            log_trace!(
+                logger,
+                "Downloaded federation info in: {}ms",
+                download.elapsed().as_millis()
+            );
+
+            log_debug!(
+                logger,
+                "parsed federation invite code: {:?}",
+                federation_info.invite_code()
+            );
+            client_builder.with_federation_info(federation_info);
         }
 
         client_builder.with_database(db);
@@ -230,10 +239,7 @@ impl<S: MutinyStorage> FederationClient<S> {
         let secret = create_federation_secret(xprivkey, network)?;
 
         let fedimint_client = client_builder
-            .build(get_default_client_secret(
-                &secret,
-                &federation_info.federation_id(),
-            ))
+            .build(get_default_client_secret(&secret, &federation_id))
             .await?;
 
         log_trace!(logger, "Retrieving fedimint wallet client module");
@@ -249,36 +255,43 @@ impl<S: MutinyStorage> FederationClient<S> {
             return Err(MutinyError::NetworkMismatch);
         }
 
-        // Set active gateway preference
-        let lightning_module = fedimint_client.get_first_module::<LightningClientModule>();
-        let gateways = lightning_module
-            .fetch_registered_gateways()
-            .await
-            .map_err(|e| {
-                log_warn!(
-                    logger,
-                    "Could not fetch gateways from federation {}: {e}",
-                    federation_info.federation_id()
-                )
-            });
-
-        if let Ok(gateways) = gateways {
-            if let Some(a) = get_gateway_preference(gateways, fedimint_client.federation_id()) {
-                log_info!(
-                    logger,
-                    "Setting active gateway for federation {}: {:?}",
-                    federation_info.federation_id(),
-                    a
-                );
-                let _ = lightning_module.set_active_gateway(&a).await.map_err(|e| {
+        // Set active gateway preference in background
+        let client_clone = fedimint_client.clone();
+        let logger_clone = logger.clone();
+        spawn(async move {
+            let start = Instant::now();
+            let lightning_module = client_clone.get_first_module::<LightningClientModule>();
+            let gateways = lightning_module
+                .fetch_registered_gateways()
+                .await
+                .map_err(|e| {
                     log_warn!(
-                        logger,
-                        "Could not set gateway for federation {}: {e}",
-                        federation_info.federation_id()
+                        logger_clone,
+                        "Could not fetch gateways from federation {federation_id}: {e}",
                     )
                 });
+
+            if let Ok(gateways) = gateways {
+                if let Some(a) = get_gateway_preference(gateways, federation_id) {
+                    log_info!(
+                        logger_clone,
+                        "Setting active gateway for federation {federation_id}: {a}"
+                    );
+                    let _ = lightning_module.set_active_gateway(&a).await.map_err(|e| {
+                        log_warn!(
+                            logger_clone,
+                            "Could not set gateway for federation {federation_id}: {e}",
+                        )
+                    });
+                }
             }
-        }
+
+            log_trace!(
+                logger_clone,
+                "Setting active gateway took: {}ms",
+                start.elapsed().as_millis()
+            );
+        });
 
         log_debug!(logger, "Built fedimint client");
         Ok(FederationClient {

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -2542,7 +2542,7 @@ mod tests {
     use crate::labels::{Contact, LabelStorage};
     use crate::nostr::NostrKeySource;
     use crate::storage::{MemoryStorage, MutinyStorage};
-    use crate::utils::parse_npub;
+    use crate::utils::{parse_npub, sleep};
     use nostr::key::FromSkStr;
     use nostr::Keys;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
@@ -2623,8 +2623,15 @@ mod tests {
             .await
             .expect("mutiny wallet should initialize");
 
+        // let storage persist
+        sleep(1000).await;
+
         assert_eq!(mw.node_manager.list_nodes().await.unwrap().len(), 1);
+
         assert!(mw.node_manager.new_node().await.is_ok());
+        // let storage persist
+        sleep(1000).await;
+
         assert_eq!(mw.node_manager.list_nodes().await.unwrap().len(), 2);
 
         assert!(mw.stop().await.is_ok());

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -86,15 +86,19 @@ use bitcoin::util::bip32::ExtendedPrivKey;
 use bitcoin::Network;
 use fedimint_core::{api::InviteCode, config::FederationId};
 use futures::{pin_mut, select, FutureExt};
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
 use lightning::ln::PaymentHash;
-use lightning::{log_debug, util::logger::Logger};
-use lightning::{log_error, log_info, log_warn};
+use lightning::util::logger::Logger;
+use lightning::{log_debug, log_error, log_info, log_trace, log_warn};
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription};
 use lnurl::{lnurl::LnUrl, AsyncClient as LnUrlClient, LnUrlResponse, Response};
 use nostr_sdk::{Client, RelayPoolNotification};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 use std::{collections::HashMap, sync::atomic::AtomicBool};
 use std::{str::FromStr, sync::atomic::Ordering};
 use uuid::Uuid;
@@ -714,12 +718,21 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
             self.session_id,
         ));
 
+        let start = Instant::now();
+
         let mut nm_builder = NodeManagerBuilder::new(self.xprivkey, self.storage.clone())
             .with_config(config.clone());
         nm_builder.with_stop(stop.clone());
         nm_builder.with_logger(logger.clone());
         let node_manager = Arc::new(nm_builder.build().await?);
 
+        log_trace!(
+            logger,
+            "NodeManager started, took: {}ms",
+            start.elapsed().as_millis()
+        );
+
+        // start syncing node manager
         NodeManager::start_sync(node_manager.clone());
 
         // create nostr manager
@@ -738,7 +751,17 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
         // create federation module if any exist
         let federation_storage = self.storage.get_federations()?;
         let federations = if !federation_storage.federations.is_empty() {
-            create_federations(federation_storage.clone(), &config, &self.storage, &logger).await?
+            let start = Instant::now();
+            log_trace!(logger, "Building Federations");
+            let result =
+                create_federations(federation_storage.clone(), &config, &self.storage, &logger)
+                    .await?;
+            log_debug!(
+                logger,
+                "Federations started, took: {}ms",
+                start.elapsed().as_millis()
+            );
+            result
         } else {
             Arc::new(RwLock::new(HashMap::new()))
         };
@@ -749,6 +772,8 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
                 "Starting with HODL invoices enabled. This is not recommended!"
             );
         }
+
+        let start = Instant::now();
 
         let lnurl_client = Arc::new(
             lnurl::Builder::default()
@@ -795,11 +820,18 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
         {
             // if we need a full sync from a restore
             if mw.storage.get(NEED_FULL_SYNC_KEY)?.unwrap_or_default() {
+                let start = Instant::now();
+                log_info!(mw.logger, "Full sync needed from restore");
                 mw.node_manager
                     .wallet
                     .full_sync(crate::onchain::RESTORE_SYNC_STOP_GAP)
                     .await?;
                 mw.storage.delete(&[NEED_FULL_SYNC_KEY])?;
+                log_info!(
+                    mw.logger,
+                    "Full sync complete, took: {}ms",
+                    start.elapsed().as_millis()
+                );
             }
         }
 
@@ -810,11 +842,14 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
         }
 
         // if we don't have any nodes, create one
-        match mw.node_manager.list_nodes().await?.pop() {
-            Some(_) => (),
-            None => {
-                mw.node_manager.new_node().await?;
-            }
+        if mw.node_manager.list_nodes().await?.is_empty() {
+            let nm = mw.node_manager.clone();
+            // spawn in background, this can take a while and we don't want to block
+            utils::spawn(async move {
+                if let Err(e) = nm.new_node().await {
+                    log_error!(nm.logger, "Failed to create first node: {e}");
+                }
+            })
         };
 
         // start the nostr background process
@@ -822,6 +857,12 @@ impl<S: MutinyStorage> MutinyWalletBuilder<S> {
 
         // start the federation background processor
         mw.start_fedimint_background_checker().await;
+
+        log_info!(
+            mw.logger,
+            "Final setup took {}ms",
+            start.elapsed().as_millis()
+        );
 
         Ok(mw)
     }

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -2272,12 +2272,11 @@ async fn create_federations<S: MutinyStorage>(
     storage: &S,
     logger: &Arc<MutinyLogger>,
 ) -> Result<Arc<RwLock<HashMap<FederationId, Arc<FederationClient<S>>>>>, MutinyError> {
-    let federations = federation_storage.federations.into_iter();
-    let mut federation_map = HashMap::new();
-    for federation_item in federations {
+    let mut federation_map = HashMap::with_capacity(federation_storage.federations.len());
+    for (uuid, federation_index) in federation_storage.federations {
         let federation = FederationClient::new(
-            federation_item.0,
-            federation_item.1.federation_code.clone(),
+            uuid,
+            federation_index.federation_code,
             c.xprivkey,
             storage,
             c.network,

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1,3 +1,4 @@
+use crate::auth::MutinyAuthClient;
 use crate::event::HTLCStatus;
 use crate::labels::LabelStorage;
 use crate::logging::LOGGING_KEY;
@@ -381,14 +382,8 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
 
         let chain = Arc::new(MutinyChain::new(tx_sync, wallet.clone(), logger.clone()));
 
-        let (gossip_sync, scorer) = get_gossip_sync(
-            &self.storage,
-            c.scorer_url,
-            c.auth_client.clone(),
-            c.network,
-            logger.clone(),
-        )
-        .await?;
+        let (gossip_sync, scorer) =
+            get_gossip_sync(&self.storage, c.network, logger.clone()).await?;
 
         let scorer = Arc::new(utils::Mutex::new(scorer));
 
@@ -521,6 +516,8 @@ impl<S: MutinyStorage> NodeManagerBuilder<S> {
             #[cfg(target_arch = "wasm32")]
             websocket_proxy_addr,
             user_rgs_url: c.user_rgs_url,
+            scorer_url: c.scorer_url,
+            auth_client: c.auth_client,
             esplora,
             lsp_config,
             logger,
@@ -547,6 +544,8 @@ pub struct NodeManager<S: MutinyStorage> {
     #[cfg(target_arch = "wasm32")]
     websocket_proxy_addr: String,
     user_rgs_url: Option<String>,
+    scorer_url: Option<String>,
+    auth_client: Option<Arc<MutinyAuthClient>>,
     esplora: Arc<AsyncClient>,
     pub(crate) wallet: Arc<OnChainWallet<S>>,
     gossip_sync: Arc<RapidGossipSync>,
@@ -620,11 +619,6 @@ impl<S: MutinyStorage> NodeManager<S> {
     /// Creates a background process that will sync the wallet with the blockchain.
     /// This will also update the fee estimates every 10 minutes.
     pub fn start_sync(nm: Arc<NodeManager<S>>) {
-        // If we are stopped, don't sync
-        if nm.stop.load(Ordering::Relaxed) {
-            return;
-        }
-
         utils::spawn(async move {
             let mut synced = false;
             loop {
@@ -638,6 +632,12 @@ impl<S: MutinyStorage> NodeManager<S> {
                         log_error!(nm.logger, "Failed to sync RGS: {e}");
                     } else {
                         log_info!(nm.logger, "RGS Synced!");
+                    }
+
+                    if let Err(e) = nm.sync_scorer().await {
+                        log_error!(nm.logger, "Failed to sync scorer: {e}");
+                    } else {
+                        log_info!(nm.logger, "Scorer Synced!");
                     }
                 }
 
@@ -1202,6 +1202,39 @@ impl<S: MutinyStorage> NodeManager<S> {
                 )
                 .await?;
             }
+        }
+
+        Ok(())
+    }
+
+    /// Downloads the latest score data from the server and replaces the current scorer.
+    /// Will be skipped if in safe mode.
+    async fn sync_scorer(&self) -> Result<(), MutinyError> {
+        // Skip syncing scorer if we are in safe mode.
+        if self.safe_mode {
+            log_info!(self.logger, "Skipping scorer sync in safe mode");
+            return Ok(());
+        }
+
+        if let (Some(auth), Some(url)) = (self.auth_client.as_ref(), self.scorer_url.as_deref()) {
+            let scorer = get_remote_scorer(
+                auth,
+                url,
+                self.gossip_sync.network_graph().clone(),
+                self.logger.clone(),
+            )
+            .await
+            .map_err(|e| {
+                log_error!(self.logger, "Failed to sync scorer: {e}");
+                e
+            })?;
+
+            // Replace the current scorer with the new one
+            let mut lock = self
+                .scorer
+                .try_lock()
+                .map_err(|_| MutinyError::WalletSyncError)?;
+            *lock = scorer;
         }
 
         Ok(())

--- a/mutiny-core/src/test_utils.rs
+++ b/mutiny-core/src/test_utils.rs
@@ -23,7 +23,7 @@ pub async fn create_vss_client() -> MutinyVssClient {
 
     // Test authenticate method
     match auth_client.authenticate().await {
-        Ok(_) => assert!(auth_client.is_authenticated().is_some()),
+        Ok(_) => assert!(auth_client.is_authenticated().await.is_some()),
         Err(e) => panic!("Authentication failed with error: {:?}", e),
     };
 

--- a/mutiny-core/src/utils.rs
+++ b/mutiny-core/src/utils.rs
@@ -135,6 +135,13 @@ impl<T> Mutex<T> {
             lock: self.inner.borrow_mut(),
         })
     }
+
+    #[allow(clippy::result_unit_err)]
+    pub fn try_lock(&self) -> LockResult<MutexGuard<'_, T>> {
+        Ok(MutexGuard {
+            lock: self.inner.try_borrow_mut().map_err(|_| ())?,
+        })
+    }
 }
 
 impl<'a, T: 'a + ScoreLookUp + ScoreUpdate> LockableScore<'a> for Mutex<T> {

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -25,7 +25,7 @@ use bitcoin::{Address, Network, OutPoint, Transaction, Txid};
 use fedimint_core::{api::InviteCode, config::FederationId};
 use futures::lock::Mutex;
 use gloo_utils::format::JsValueSerdeExt;
-use lightning::{log_error, routing::gossip::NodeId, util::logger::Logger};
+use lightning::{log_error, log_info, routing::gossip::NodeId, util::logger::Logger};
 use lightning_invoice::Bolt11Invoice;
 use lnurl::lightning_address::LightningAddress;
 use lnurl::lnurl::LnUrl;
@@ -105,6 +105,7 @@ impl MutinyWallet {
         nip_07_key: Option<String>,
         primal_url: Option<String>,
     ) -> Result<MutinyWallet, MutinyJsError> {
+        let start = instant::Instant::now();
         // if both are set throw an error
         // todo default to nsec if both are for same key?
         if nsec_override.is_some() && nip_07_key.is_some() {
@@ -143,7 +144,14 @@ impl MutinyWallet {
         )
         .await
         {
-            Ok(m) => Ok(m),
+            Ok(m) => {
+                log_info!(
+                    m.inner.logger,
+                    "Wallet startup took {}ms",
+                    start.elapsed().as_millis()
+                );
+                Ok(m)
+            }
             Err(e) => {
                 // mark uninitialized because we failed to startup
                 *init = false;

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -25,7 +25,7 @@ use bitcoin::{Address, Network, OutPoint, Transaction, Txid};
 use fedimint_core::{api::InviteCode, config::FederationId};
 use futures::lock::Mutex;
 use gloo_utils::format::JsValueSerdeExt;
-use lightning::{log_error, log_info, routing::gossip::NodeId, util::logger::Logger};
+use lightning::{log_error, log_info, log_warn, routing::gossip::NodeId, util::logger::Logger};
 use lightning_invoice::Bolt11Invoice;
 use lnurl::lightning_address::LightningAddress;
 use lnurl::lnurl::LnUrl;
@@ -35,7 +35,7 @@ use mutiny_core::nostr::nip49::NIP49URI;
 use mutiny_core::nostr::nwc::{BudgetedSpendingConditions, NwcProfileTag, SpendingConditions};
 use mutiny_core::nostr::NostrKeySource;
 use mutiny_core::storage::{DeviceLock, MutinyStorage, DEVICE_LOCK_KEY};
-use mutiny_core::utils::{now, parse_npub, parse_npub_or_nip05, sleep};
+use mutiny_core::utils::{now, parse_npub, parse_npub_or_nip05, sleep, spawn};
 use mutiny_core::vss::MutinyVssClient;
 use mutiny_core::{encrypt::encryption_key_from_pass, InvoiceHandler, MutinyWalletConfigBuilder};
 use mutiny_core::{labels::Contact, MutinyWalletBuilder};
@@ -222,6 +222,19 @@ impl MutinyWallet {
                 logger.clone(),
                 auth_url,
             ));
+
+            // immediately start fetching JWT
+            let auth = auth_client.clone();
+            let logger_clone = logger.clone();
+            spawn(async move {
+                // if this errors, it's okay, we'll call it again when we fetch vss
+                if let Err(e) = auth.authenticate().await {
+                    log_warn!(
+                        logger_clone,
+                        "Failed to authenticate on startup, will retry on next call: {e}"
+                    );
+                }
+            });
 
             let vss = storage_url.map(|url| {
                 Arc::new(MutinyVssClient::new_authenticated(


### PR DESCRIPTION
#1016 

A bunch of startup optimizations, in my testing this brings down the startup time on a wallet with a lot of channels and a configured fedimint from 12 seconds to 6 seconds.

- 1st is mainly just adding the logs everywhere I have been using. Does an optimization for new wallets, where it'll now create the first node in the background instead of waiting for that to be initialized before returning
- 2nd backgrounds the saving of our node storage on startup, this was only done so we save any changes made to our LSP config while starting up (just migrations), these aren't the end of the world if they are missed, they'll persisted on the next startup 
- 3rd makes it so we don't block on retrying spendable outputs, these can happen async and there isn't a reason to wait
- 4th fixes two issues with fedimint startup. We would block on setting the preferred guardian, this is now done in the background. We also would download the federation info everytime but we only needed it if our db didn't have it (we were already only using the federation info if we didn't have it in our db), this fixes to only do the download if its not in our db. This also does some minor touch ups like initializing federation_id instead of doing federation_info.federation_id() since this would do a hash everytime.
- 5th changes to immediately start fetching the JWT for auth, before we would only fetch it once we got our first VSS request, this saves us about ~200ms because otherwise we wait until we have read all of indexed db until we make this call. Needed to modify the auth client to only allow one call to retrieve_new_jwt at a time, otherwise this would sometimes not complete by the time the first VSS call came in and we'd request multiple JWTs. Otherwise just adds some timing logs and tiny optimizations to indexed db
- 6th changes to sync scorer in the background rather than upfront, this made the startup ~500ms faster for me. This will still read the scorer on start up so we won't be without one until it is synced.
