### PR TITLE
Save Voltage pubkey and connection string to storage

### DIFF
--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -408,10 +408,10 @@ impl<S: MutinyStorage> EventHandler<S> {
                     Err(e) => log_debug!(self.logger, "EVENT: OpenChannelRequest error: {e:?}"),
                 };
 
-                let lsp_pubkey = self
-                    .lsp_client
-                    .as_ref()
-                    .map(|client| client.get_lsp_pubkey());
+                let lsp_pubkey = match self.lsp_client {
+                    Some(ref lsp) => Some(lsp.get_lsp_pubkey().await),
+                    None => None,
+                };
 
                 if lsp_pubkey.as_ref() != Some(&counterparty_node_id) {
                     // did not match the lsp pubkey, normal open

--- a/mutiny-core/src/lsp/lsps.rs
+++ b/mutiny-core/src/lsp/lsps.rs
@@ -342,7 +342,7 @@ impl<S: MutinyStorage> Lsp for LspsClient<S> {
 
         let inbound_capacity_msat: u64 = self
             .channel_manager
-            .list_channels_with_counterparty(&self.get_lsp_pubkey())
+            .list_channels_with_counterparty(&self.pubkey)
             .iter()
             .map(|c| c.inbound_capacity_msat)
             .sum();
@@ -486,17 +486,17 @@ impl<S: MutinyStorage> Lsp for LspsClient<S> {
         Ok(invoice)
     }
 
-    fn get_lsp_pubkey(&self) -> PublicKey {
+    async fn get_lsp_pubkey(&self) -> PublicKey {
         self.pubkey
     }
 
-    fn get_lsp_connection_string(&self) -> String {
+    async fn get_lsp_connection_string(&self) -> String {
         self.connection_string.clone()
     }
 
-    fn get_config(&self) -> LspConfig {
+    async fn get_config(&self) -> LspConfig {
         LspConfig::Lsps(LspsConfig {
-            connection_string: self.get_lsp_connection_string(),
+            connection_string: self.connection_string.clone(),
             token: self.token.clone(),
         })
     }

--- a/mutiny-core/src/lsp/mod.rs
+++ b/mutiny-core/src/lsp/mod.rs
@@ -115,10 +115,10 @@ pub(crate) trait Lsp {
         &self,
         invoice_request: InvoiceRequest,
     ) -> Result<Bolt11Invoice, MutinyError>;
-    fn get_lsp_pubkey(&self) -> PublicKey;
-    fn get_lsp_connection_string(&self) -> String;
+    async fn get_lsp_pubkey(&self) -> PublicKey;
+    async fn get_lsp_connection_string(&self) -> String;
     fn get_expected_skimmed_fee_msat(&self, payment_hash: PaymentHash, payment_size: u64) -> u64;
-    fn get_config(&self) -> LspConfig;
+    async fn get_config(&self) -> LspConfig;
 }
 
 #[derive(Clone)]
@@ -192,33 +192,33 @@ impl<S: MutinyStorage> Lsp for AnyLsp<S> {
         }
     }
 
-    fn get_lsp_pubkey(&self) -> PublicKey {
+    async fn get_lsp_pubkey(&self) -> PublicKey {
         match self {
             AnyLsp::VoltageFlow(lock) => {
-                let client = lock.try_read().unwrap();
-                client.get_lsp_pubkey()
+                let client = lock.read().await;
+                client.get_lsp_pubkey().await
             }
-            AnyLsp::Lsps(client) => client.get_lsp_pubkey(),
+            AnyLsp::Lsps(client) => client.get_lsp_pubkey().await,
         }
     }
 
-    fn get_lsp_connection_string(&self) -> String {
+    async fn get_lsp_connection_string(&self) -> String {
         match self {
             AnyLsp::VoltageFlow(lock) => {
-                let client = lock.try_read().unwrap();
-                client.get_lsp_connection_string()
+                let client = lock.read().await;
+                client.get_lsp_connection_string().await
             }
-            AnyLsp::Lsps(client) => client.get_lsp_connection_string(),
+            AnyLsp::Lsps(client) => client.get_lsp_connection_string().await,
         }
     }
 
-    fn get_config(&self) -> LspConfig {
+    async fn get_config(&self) -> LspConfig {
         match self {
             AnyLsp::VoltageFlow(lock) => {
-                let client = lock.try_read().unwrap();
-                client.get_config()
+                let client = lock.read().await;
+                client.get_config().await
             }
-            AnyLsp::Lsps(client) => client.get_config(),
+            AnyLsp::Lsps(client) => client.get_config().await,
         }
     }
 

--- a/mutiny-core/src/lsp/voltage.rs
+++ b/mutiny-core/src/lsp/voltage.rs
@@ -271,15 +271,15 @@ impl Lsp for LspClient {
         Ok(fee_response)
     }
 
-    fn get_lsp_pubkey(&self) -> PublicKey {
+    async fn get_lsp_pubkey(&self) -> PublicKey {
         self.pubkey
     }
 
-    fn get_lsp_connection_string(&self) -> String {
+    async fn get_lsp_connection_string(&self) -> String {
         self.connection_string.clone()
     }
 
-    fn get_config(&self) -> LspConfig {
+    async fn get_config(&self) -> LspConfig {
         LspConfig::VoltageFlow(VoltageConfig {
             url: self.url.clone(),
             pubkey: Some(self.pubkey),

--- a/mutiny-core/src/lsp/voltage.rs
+++ b/mutiny-core/src/lsp/voltage.rs
@@ -180,6 +180,16 @@ impl LspClient {
 
         Ok((get_info_response.pubkey, connection_string))
     }
+
+    /// Get the pubkey and connection string from the LSP from the /info endpoint
+    /// and set them on the LSP client
+    pub(crate) async fn set_connection_info(&mut self) -> Result<(), MutinyError> {
+        let (pubkey, connection_string) =
+            Self::fetch_connection_info(&self.http_client, &self.url).await?;
+        self.pubkey = pubkey;
+        self.connection_string = connection_string;
+        Ok(())
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -394,7 +394,7 @@ impl<S: MutinyStorage> NodeBuilder<S> {
                 self.lsp_config
             }
             Some(ref lsp) => {
-                if self.lsp_config.as_ref() == Some(lsp) {
+                if self.lsp_config.as_ref().is_some_and(|l| l.matches(lsp)) {
                     log_info!(logger, "lsp config matches saved lsp config");
                     self.lsp_config
                 } else {
@@ -429,8 +429,8 @@ impl<S: MutinyStorage> NodeBuilder<S> {
         let stop = Arc::new(AtomicBool::new(false));
 
         let (lsp_client, liquidity) = match lsp_config {
-            Some(LspConfig::VoltageFlow(url)) => {
-                (Some(AnyLsp::new_voltage_flow(&url).await?), None)
+            Some(LspConfig::VoltageFlow(config)) => {
+                (Some(AnyLsp::new_voltage_flow(config).await?), None)
             }
             Some(LspConfig::Lsps(lsps_config)) => {
                 let liquidity_manager = Arc::new(LiquidityManager::new(

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -2073,6 +2073,7 @@ mod tests {
     use crate::test_utils::*;
 
     use crate::event::{HTLCStatus, MillisatAmount, PaymentInfo};
+    use crate::lsp::voltage::VoltageConfig;
     use crate::nodemanager::{LspConfig, NodeIndex, NodeStorage};
     use crate::storage::{MemoryStorage, MutinyStorage};
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
@@ -2324,19 +2325,23 @@ mod tests {
 
     #[test]
     fn test_serialize_node_storage() {
-        let old: NodeStorage = serde_json::from_str("{\"nodes\":{\"93ca1ee3-d5f1-42ed-8bd9-042b298c70dc\":{\"archived\":false,\"child_index\":0,\"lsp\":\"https://signet-lsp.mutinywallet.com\"}},\"version\":11}").unwrap();
+        let old1: NodeStorage = serde_json::from_str("{\"nodes\":{\"93ca1ee3-d5f1-42ed-8bd9-042b298c70dc\":{\"archived\":false,\"child_index\":0,\"lsp\":\"https://signet-lsp.mutinywallet.com\"}},\"version\":11}").unwrap();
+        let old2: NodeStorage = serde_json::from_str("{\"nodes\":{\"93ca1ee3-d5f1-42ed-8bd9-042b298c70dc\":{\"archived\":false,\"child_index\":0,\"lsp\":{\"VoltageFlow\":\"https://signet-lsp.mutinywallet.com\"}}},\"version\":11}").unwrap();
         let node = NodeIndex {
             child_index: 0,
-            lsp: Some(LspConfig::VoltageFlow(
-                "https://signet-lsp.mutinywallet.com".to_string(),
-            )),
+            lsp: Some(LspConfig::VoltageFlow(VoltageConfig {
+                url: "https://signet-lsp.mutinywallet.com".to_string(),
+                pubkey: None,
+                connection_string: None,
+            })),
             archived: Some(false),
         };
         let mut nodes = HashMap::new();
         nodes.insert("93ca1ee3-d5f1-42ed-8bd9-042b298c70dc".to_string(), node);
         let expected = NodeStorage { nodes, version: 11 };
 
-        assert_eq!(old, expected);
+        assert_eq!(old1, expected);
+        assert_eq!(old2, expected);
 
         let serialized = serde_json::to_string(&expected).unwrap();
         let deserialized: NodeStorage = serde_json::from_str(&serialized).unwrap();


### PR DESCRIPTION
Makes it so we don't need to call the `info` api on every startup and can instead just cache this in storage.

2nd commit handles if it has changed and refetch it.

3rd commit is optional but get rids of the unwraps and awaits the RwLock to be safer

#1016 