### PR TITLE
Add firefox only on non-darwin systems' flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         pkgs = import nixpkgs { inherit system overlays; };
         rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         inputs = [
-	  rust
+          rust
           pkgs.rust-analyzer
           pkgs.openssl
           pkgs.zlib
@@ -27,7 +27,7 @@
           pkgs.wasm-pack
           pkgs.wasm-bindgen-cli
           pkgs.binaryen
-	  pkgs.clang
+          pkgs.clang
           pkgs.corepack_20
           pkgs.nodejs_20
         ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
@@ -50,14 +50,14 @@
 
 
         devShell = pkgs.mkShell {
-	  packages = inputs;
+          packages = inputs;
           shellHook = ''
-	    export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
+            export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
             export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
             export CC_wasm32_unknown_unknown=${pkgs.llvmPackages_14.clang-unwrapped}/bin/clang-14
             export CFLAGS_wasm32_unknown_unknown="-I ${pkgs.llvmPackages_14.libclang.lib}/lib/clang/14.0.6/include/"
           '';
-	};
+        };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -30,9 +30,12 @@
 	  pkgs.clang
           pkgs.corepack_20
           pkgs.nodejs_20
+        ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
+          # Add firefox deps only on non-darwin.
+          # darwin is listed in badPlatforms in pkgs.firefox's meta.
           pkgs.firefox
           pkgs.geckodriver
-	];
+        ];
       in
       {
         defaultPackage = pkgs.rustPlatform.buildRustPackage {


### PR DESCRIPTION
pkgs.firefox's metadata list darwin in badPlatforms.
See: https://github.com/NixOS/nixpkgs/blob/d89f18a17e51532ed5f4d45297b0ddf11e46b9c8/pkgs/applications/networking/browsers/firefox/packages.nix#L21

This applies to firefox-119 and may change

Without this change, using the flake produces the following. I don't think the readme should say darwin has first-class nix support, but this is a nice change to have.

```
direnv: loading ~/f/dev/mutiny-node/.envrc                                                                                                         
direnv: using flake
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/35dcag44a0ymww0vy0s4jjgxwpv9g62d-source/pkgs/stdenv/generic/make-derivation.nix:300:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'nix-shell'

         at /nix/store/35dcag44a0ymww0vy0s4jjgxwpv9g62d-source/pkgs/stdenv/generic/make-derivation.nix:344:7:

          343|       depsBuildBuild              = lib.elemAt (lib.elemAt dependencies 0) 0;
          344|       nativeBuildInputs           = lib.elemAt (lib.elemAt dependencies 0) 1;
             |       ^
          345|       depsBuildTarget             = lib.elemAt (lib.elemAt dependencies 0) 2;

       error: Package ‘firefox-119.0’ in /nix/store/35dcag44a0ymww0vy0s4jjgxwpv9g62d-source/pkgs/applications/networking/browsers/firefox/wrapper.nix:421 is not available on the requested hostPlatform:
         hostPlatform.config = "aarch64-apple-darwin"
         package.meta.platforms = [
           "i686-cygwin"
           "x86_64-cygwin"
           "x86_64-darwin"
           "i686-darwin"
           "aarch64-darwin"
           "armv7a-darwin"
           "i686-freebsd13"
           "x86_64-freebsd13"
           "x86_64-solaris"
           "aarch64-linux"
           "armv5tel-linux"
           "armv6l-linux"
           "armv7a-linux"
           "armv7l-linux"
           "i686-linux"
           "loongarch64-linux"
           "m68k-linux"
           "microblaze-linux"
           "microblazeel-linux"
           "mips-linux"
           "mips64-linux"
           "mips64el-linux"
           "mipsel-linux"
           "powerpc64-linux"
           "powerpc64le-linux"
           "riscv32-linux"
           "riscv64-linux"
           "s390-linux"
           "s390x-linux"
           "x86_64-linux"
           "aarch64-netbsd"
           "armv6l-netbsd"
           "armv7a-netbsd"
           "armv7l-netbsd"
           "i686-netbsd"
           "m68k-netbsd"
           "mipsel-netbsd"
           "powerpc-netbsd"
           "riscv32-netbsd"
           "riscv64-netbsd"
           "x86_64-netbsd"
           "i686-openbsd"
           "x86_64-openbsd"
           "x86_64-redox"
         ]
         package.meta.badPlatforms = [
           "x86_64-darwin"
           "i686-darwin"
           "aarch64-darwin"
           "armv7a-darwin"
         ]
       , refusing to evaluate.

       a) To temporarily allow packages that are unsupported for this system, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1

        Note: For `nix shell`, `nix build`, `nix develop` or any other Nix 2.4+
        (Flake) command, `--impure` must be passed in order to read this
        environment variable.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowUnsupportedSystem = true; }
       in configuration.nix to override this.

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowUnsupportedSystem = true; }
       to ~/.config/nixpkgs/config.nix.
```