### PR TITLE
Set swap label before paying invoice

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -1215,10 +1215,9 @@ impl<S: MutinyStorage> MutinyWallet<S> {
                 .await?;
 
             let bolt_11 = inv.bolt11.expect("create inv had one job");
-            let pay_res = fedimint_client
-                .pay_invoice(bolt_11.clone(), labels.clone())
-                .await?;
-            self.storage.set_invoice_labels(bolt_11, labels)?;
+            self.storage
+                .set_invoice_labels(bolt_11.clone(), labels.clone())?;
+            let pay_res = fedimint_client.pay_invoice(bolt_11, labels).await?;
             let total_fees_paid = pay_res.fees_paid.unwrap_or(0) + fee;
 
             return Ok(FedimintSweepResult {
@@ -1267,10 +1266,9 @@ impl<S: MutinyStorage> MutinyWallet<S> {
 
         log_debug!(self.logger, "attempting payment from fedimint client");
         let bolt_11 = inv_to_pay.bolt11.expect("create inv had one job");
-        let first_invoice_res = fedimint_client
-            .pay_invoice(bolt_11.clone(), labels.clone())
-            .await?;
-        self.storage.set_invoice_labels(bolt_11, labels)?;
+        self.storage
+            .set_invoice_labels(bolt_11.clone(), labels.clone())?;
+        let first_invoice_res = fedimint_client.pay_invoice(bolt_11, labels).await?;
 
         let remaining_balance = fedimint_client.get_balance().await?;
         if remaining_balance > 0 {


### PR DESCRIPTION
If the payment would timeout / take over 30 seconds it'd never get the label. This makes sure we set it first so we always get the proper label