### PR TITLE
Add public and private zaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-destructor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4653a42bf04120a1d4e92452e006b4e3af4ab4afff8fb4af0f1bbb98418adf3e"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,8 +446,8 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin-waila"
-version = "0.4.0"
-source = "git+https://github.com/mutinywallet/bitcoin-waila?rev=b8b6a4d709e438fbadeb16bdf0c577c59be4a7f2#b8b6a4d709e438fbadeb16bdf0c577c59be4a7f2"
+version = "0.4.1"
+source = "git+https://github.com/mutinywallet/bitcoin-waila?rev=311f8efcb5da9d351dd3445a4236f5f743605aa9#311f8efcb5da9d351dd3445a4236f5f743605aa9"
 dependencies = [
  "bech32",
  "bip21",
@@ -2608,9 +2617,9 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nostr"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62abb4201e9d6b8b25660bebcad7bc0eb0cf25ecf9fd139c8d8c36ac455d37da"
+checksum = "255485c2f41cf8f39d4e4a1901199549f54e32def81a71a8afe05f75809f441d"
 dependencies = [
  "aes",
  "base64 0.21.7",
@@ -2638,9 +2647,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-database"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b03cb406ff8efa194161b1cc1f6a81e46ad7ca4029acdf69d233775cc144bb2"
+checksum = "8e15ab55f96ea5e560af0c75f1d942b1064266d443d11b2afbe51ca9ad78a018"
 dependencies = [
  "async-trait",
  "lru",
@@ -2652,12 +2661,13 @@ dependencies = [
 
 [[package]]
 name = "nostr-relay-pool"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c5f1df666ffd52c274dbf1061a51e9cf363b525202d63ac08822a309b746cd"
+checksum = "83b39b3dc3f1fe912a0f530ad8bd2e71c55608679c8c427952f71c13f0a4c545"
 dependencies = [
  "async-utility",
  "async-wsocket",
+ "atomic-destructor",
  "nostr",
  "nostr-database",
  "thiserror",
@@ -2667,9 +2677,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-sdk"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531fbbb39aef79311b60488f2d4aacc5f8156d76a5fb1bb110486746b3cfe873"
+checksum = "81ed0ab9cbc3b20d3dba99337f2e0739f052ebe32133d690e212022a06a22044"
 dependencies = [
  "async-utility",
  "lnurl-pay",
@@ -2686,9 +2696,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-signer"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305c33e0ddde9c4288af000cc3fee665190a4ebef4841ce5bcb3eb4a2f473e62"
+checksum = "307bdc7c26887d7e65632e66872989a19892dfe9f2c6dbd9a1d3f959c5c524d5"
 dependencies = [
  "async-utility",
  "nostr",
@@ -2698,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-zapper"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523d787e19fbca8ad6ae4edf42db266a89d24aa3bfb1ce558ab87f3c5d10e2d5"
+checksum = "061d5eb00b430747a984ea9e41cd82c849832151b4263d8230c9c220dc2c62f8"
 dependencies = [
  "async-trait",
  "nostr",
@@ -2744,9 +2754,9 @@ dependencies = [
 
 [[package]]
 name = "nwc"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad79eb9f4819bfd6216c78bbab5310dcbe408fb1ec977b0e905e5815f57055a"
+checksum = "d1894ffe54a1e5adf8dbb22b5a290c0748ec4a88aa07fa69c4359010edea49ed"
 dependencies = [
  "async-utility",
  "nostr",

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -38,8 +38,8 @@ futures-util = { version = "0.3", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["multipart", "json"] }
 async-trait = "0.1.68"
 url = { version = "2.3.1", features = ["serde"] }
-nostr = { version = "0.28.1", default-features = false, features = ["nip04", "nip05", "nip47", "nip57"] }
-nostr-sdk = { version = "0.28.0", default-features = false, features = ["nip04", "nip05", "nip47", "nip57"] }
+nostr = { version = "0.29.0", default-features = false, features = ["nip04", "nip05", "nip47", "nip57"] }
+nostr-sdk = { version = "0.29.0", default-features = false, features = ["nip04", "nip05", "nip47", "nip57"] }
 cbc = { version = "0.1", features = ["alloc"] }
 aes = { version = "0.8" }
 jwt-compact = { version = "0.8.0-beta.1", features = ["es256k"] }
@@ -84,8 +84,8 @@ gloo-net = { version = "0.4.0" }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 getrandom = { version = "0.2", features = ["js"] }
 # add nip07 feature for wasm32
-nostr = { version = "0.28.1", default-features = false, features = ["nip04", "nip05", "nip07", "nip47", "nip57"] }
-nostr-sdk = { version = "0.28.0", default-features = false, features = ["nip04", "nip05", "nip07", "nip47", "nip57"] }
+nostr = { version = "0.29.0", default-features = false, features = ["nip04", "nip05", "nip07", "nip47", "nip57"] }
+nostr-sdk = { version = "0.29.0", default-features = false, features = ["nip04", "nip05", "nip07", "nip47", "nip57"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["rt"] }

--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -551,6 +551,12 @@ impl From<nostr::event::builder::Error> for MutinyError {
     }
 }
 
+impl From<nostr_sdk::signer::Error> for MutinyError {
+    fn from(_e: nostr_sdk::signer::Error) -> Self {
+        Self::NostrError
+    }
+}
+
 impl From<payjoin::send::CreateRequestError> for MutinyError {
     fn from(_e: payjoin::send::CreateRequestError) -> Self {
         Self::PayjoinCreateRequest

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -987,7 +987,7 @@ impl<S: MutinyStorage> MutinyWallet<S> {
                     .expect("Failed to add relays");
                 client.connect().await;
 
-                client.subscribe(last_filters.clone()).await;
+                client.subscribe(last_filters.clone(), None).await;
 
                 // handle NWC requests
                 let mut notifications = client.notifications();
@@ -1015,7 +1015,7 @@ impl<S: MutinyStorage> MutinyWallet<S> {
                                     if event.verify().is_ok() {
                                         match event.kind {
                                             Kind::WalletConnectRequest => {
-                                                match nostr.handle_nwc_request(event, &self_clone).await {
+                                                match nostr.handle_nwc_request(*event, &self_clone).await {
                                                     Ok(Some(event)) => {
                                                         if let Err(e) = client.send_event(event).await {
                                                             log_warn!(logger, "Error sending NWC event: {e}");
@@ -1028,7 +1028,7 @@ impl<S: MutinyStorage> MutinyWallet<S> {
                                                 }
                                             }
                                             Kind::EncryptedDirectMessage => {
-                                                if let Err(e) = nostr.handle_direct_message(event, &self_clone).await {
+                                                if let Err(e) = nostr.handle_direct_message(*event, &self_clone).await {
                                                         log_error!(logger, "Error handling dm: {e}");
                                                 }
                                             }
@@ -1053,7 +1053,7 @@ impl<S: MutinyStorage> MutinyWallet<S> {
                             if let Ok(current_filters) = nostr.get_filters() {
                                 if !utils::compare_filters_vec(&current_filters, &last_filters) {
                                     log_debug!(logger, "subscribing to new nwc filters");
-                                    client.subscribe(current_filters.clone()).await;
+                                    client.subscribe(current_filters.clone(), None).await;
                                     last_filters = current_filters;
                                 }
                             }

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -1052,7 +1052,7 @@ impl<S: MutinyStorage> NostrManager<S> {
             .pubkey(secret.public_key())
             .event(request_event.id);
 
-        client.subscribe(vec![filter]).await;
+        client.subscribe(vec![filter], None).await;
 
         client
             .send_event(request_event.clone())

--- a/mutiny-core/src/utils.rs
+++ b/mutiny-core/src/utils.rs
@@ -231,18 +231,28 @@ pub fn compare_filters_vec(a: &[Filter], b: &[Filter]) -> bool {
     }
 
     // compare that we have all the same kinds
-    let agg_kinds_a: HashSet<Kind> = a.iter().flat_map(|i| i.kinds.clone()).collect();
-    let agg_kinds_b: HashSet<Kind> = b.iter().flat_map(|i| i.kinds.clone()).collect();
+    let agg_kinds_a: HashSet<Kind> = a
+        .iter()
+        .flat_map(|i| i.kinds.clone().unwrap_or_default())
+        .collect();
+    let agg_kinds_b: HashSet<Kind> = b
+        .iter()
+        .flat_map(|i| i.kinds.clone().unwrap_or_default())
+        .collect();
 
     if agg_kinds_a != agg_kinds_b {
         return false;
     }
 
     // compare same authors
-    let agg_authors_a: HashSet<nostr::PublicKey> =
-        a.iter().flat_map(|i| i.authors.clone()).collect();
-    let agg_authors_b: HashSet<nostr::PublicKey> =
-        b.iter().flat_map(|i| i.authors.clone()).collect();
+    let agg_authors_a: HashSet<nostr::PublicKey> = a
+        .iter()
+        .flat_map(|i| i.authors.clone().unwrap_or_default())
+        .collect();
+    let agg_authors_b: HashSet<nostr::PublicKey> = b
+        .iter()
+        .flat_map(|i| i.authors.clone().unwrap_or_default())
+        .collect();
 
     if agg_authors_a != agg_authors_b {
         return false;

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -31,7 +31,7 @@ lightning-invoice = { version = "0.29.0" }
 thiserror = "1.0"
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 lnurl-rs = { version = "0.4.1", default-features = false }
-nostr = { version = "0.28.1", default-features = false, features = ["nip04", "nip05", "nip07", "nip47", "nip57"] }
+nostr = { version = "0.29.0", default-features = false, features = ["nip04", "nip05", "nip07", "nip47", "nip57"] }
 wasm-logger = "0.2.0"
 log = "0.4.17"
 rexie = "0.5.0"
@@ -47,7 +47,7 @@ payjoin = { version = "0.13.0", features = ["send", "base64"] }
 fedimint-core = { git = "https://github.com/fedimint/fedimint", rev = "5ade2536015a12a7e003a42b159ccc4a431e1a32" }
 moksha-core = { git = "https://github.com/ngutech21/moksha", rev = "18d99977965662d46ccec29fecdb0ce493745917" }
 
-bitcoin-waila = { git = "https://github.com/mutinywallet/bitcoin-waila", rev = "b8b6a4d709e438fbadeb16bdf0c577c59be4a7f2" }
+bitcoin-waila = { git = "https://github.com/mutinywallet/bitcoin-waila", rev = "311f8efcb5da9d351dd3445a4236f5f743605aa9" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -40,7 +40,9 @@ use mutiny_core::nostr::NostrKeySource;
 use mutiny_core::storage::{DeviceLock, MutinyStorage, DEVICE_LOCK_KEY};
 use mutiny_core::utils::{now, parse_npub, parse_npub_or_nip05, sleep, spawn};
 use mutiny_core::vss::MutinyVssClient;
-use mutiny_core::{encrypt::encryption_key_from_pass, InvoiceHandler, MutinyWalletConfigBuilder};
+use mutiny_core::{
+    encrypt::encryption_key_from_pass, InvoiceHandler, MutinyWalletConfigBuilder, PrivacyLevel,
+};
 use mutiny_core::{labels::Contact, MutinyWalletBuilder};
 use mutiny_core::{
     labels::LabelStorage,
@@ -868,6 +870,7 @@ impl MutinyWallet {
         zap_npub: Option<String>,
         labels: Vec<String>,
         comment: Option<String>,
+        privacy_level: Option<String>,
     ) -> Result<MutinyInvoice, MutinyJsError> {
         let lnurl = LnUrl::from_str(&lnurl)?;
 
@@ -876,9 +879,22 @@ impl MutinyWallet {
             None => None,
         };
 
+        let privacy_level = privacy_level
+            .as_deref()
+            .map(PrivacyLevel::from_str)
+            .transpose()?
+            .unwrap_or_default(); // default to NotAvailable
+
         Ok(self
             .inner
-            .lnurl_pay(&lnurl, amount_sats, zap_npub, labels, comment)
+            .lnurl_pay(
+                &lnurl,
+                amount_sats,
+                zap_npub,
+                labels,
+                comment,
+                privacy_level,
+            )
             .await?
             .into())
     }


### PR DESCRIPTION
This was _almost_ very simple, but sadly doing private zaps with a NIP-07 extension isn't very well supported. The way clients generate the random npub is deterministic from the user's nsec, but since we don't have the user's nsec, we cannot do this. Private zaps will still work, we can just randomly generate the key, the problem is if we see the event in the future, we won't be able to decrypt it ourselves.