### PR TITLE
Support new NWC commands

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -78,6 +78,7 @@ use ::nostr::nips::nip57;
 #[cfg(target_arch = "wasm32")]
 use ::nostr::prelude::rand::rngs::OsRng;
 use ::nostr::prelude::ZapRequestData;
+use ::nostr::nips::nip47::Method;
 use ::nostr::{EventBuilder, EventId, JsonUtil, Kind};
 #[cfg(target_arch = "wasm32")]
 use ::nostr::{Keys, Tag};
@@ -1653,6 +1654,7 @@ impl<S: MutinyStorage> MutinyWallet<S> {
                                 period: BudgetPeriod::Month,
                             }),
                             NwcProfileTag::Subscription,
+                            vec![Method::PayInvoice], // subscription only needs pay invoice
                         )
                         .await?
                         .nwc_uri
@@ -1662,6 +1664,7 @@ impl<S: MutinyStorage> MutinyWallet<S> {
                             ProfileType::Reserved(ReservedProfile::MutinySubscription),
                             SpendingConditions::RequireApproval,
                             NwcProfileTag::Subscription,
+                            vec![Method::PayInvoice], // subscription only needs pay invoice
                         )
                         .await?
                         .nwc_uri

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -74,11 +74,11 @@ use crate::{
     subscription::MutinySubscriptionClient,
 };
 use crate::{nostr::NostrManager, utils::sleep};
+use ::nostr::nips::nip47::Method;
 use ::nostr::nips::nip57;
 #[cfg(target_arch = "wasm32")]
 use ::nostr::prelude::rand::rngs::OsRng;
 use ::nostr::prelude::ZapRequestData;
-use ::nostr::nips::nip47::Method;
 use ::nostr::{EventBuilder, EventId, JsonUtil, Kind};
 #[cfg(target_arch = "wasm32")]
 use ::nostr::{Keys, Tag};

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -516,6 +516,7 @@ impl<S: MutinyStorage> NostrManager<S> {
         profile_type: ProfileType,
         spending_conditions: SpendingConditions,
         tag: NwcProfileTag,
+        commands: Vec<Method>,
     ) -> Result<NwcProfile, MutinyError> {
         let mut profiles = self.nwc.try_write()?;
 
@@ -532,7 +533,7 @@ impl<S: MutinyStorage> NostrManager<S> {
             tag,
             client_key: None,
             label: None,
-            commands: Some(vec![Method::PayInvoice]),
+            commands: Some(commands),
         };
         let nwc = NostrWalletConnect::new(&Secp256k1::new(), self.xprivkey, profile)?;
 
@@ -559,9 +560,10 @@ impl<S: MutinyStorage> NostrManager<S> {
         profile_type: ProfileType,
         spending_conditions: SpendingConditions,
         tag: NwcProfileTag,
+        commands: Vec<Method>,
     ) -> Result<NwcProfile, MutinyError> {
         let profile =
-            self.create_new_nwc_profile_internal(profile_type, spending_conditions, tag)?;
+            self.create_new_nwc_profile_internal(profile_type, spending_conditions, tag, commands)?;
         // add relay if needed
         let needs_connect = self.client.add_relay(profile.relay.as_str()).await?;
         if needs_connect {
@@ -599,8 +601,13 @@ impl<S: MutinyStorage> NostrManager<S> {
             amount_sats,
             payment_hash: None,
         });
-        self.create_new_nwc_profile(profile, spending_conditions, NwcProfileTag::Gift)
-            .await
+        self.create_new_nwc_profile(
+            profile,
+            spending_conditions,
+            NwcProfileTag::Gift,
+            vec![Method::PayInvoice], // gifting only needs pay invoice
+        )
+        .await
     }
 
     /// Approves a nostr wallet auth request.
@@ -1473,6 +1480,7 @@ mod test {
                 ProfileType::Normal { name: name.clone() },
                 SpendingConditions::default(),
                 Default::default(),
+                vec![Method::PayInvoice],
             )
             .unwrap();
 
@@ -1516,6 +1524,7 @@ mod test {
                 ProfileType::Reserved(ReservedProfile::MutinySubscription),
                 SpendingConditions::default(),
                 Default::default(),
+                vec![Method::PayInvoice],
             )
             .unwrap();
 
@@ -1549,6 +1558,7 @@ mod test {
                 ProfileType::Normal { name: name.clone() },
                 SpendingConditions::default(),
                 Default::default(),
+                vec![Method::PayInvoice],
             )
             .unwrap();
 
@@ -1566,6 +1576,7 @@ mod test {
             archived: None,
             child_key_index: None,
             spending_conditions: Default::default(),
+            commands: None,
             tag: Default::default(),
             label: None,
         };
@@ -1632,6 +1643,7 @@ mod test {
                 uri.clone(),
                 None,
                 Default::default(),
+                vec![Method::PayInvoice],
             )
             .unwrap();
 
@@ -1681,6 +1693,7 @@ mod test {
                 ProfileType::Normal { name: name.clone() },
                 SpendingConditions::default(),
                 Default::default(),
+                vec![Method::PayInvoice],
             )
             .unwrap();
 
@@ -1722,6 +1735,7 @@ mod test {
                 ProfileType::Normal { name: name.clone() },
                 SpendingConditions::default(),
                 Default::default(),
+                vec![Method::PayInvoice],
             )
             .unwrap();
 
@@ -1754,6 +1768,7 @@ mod test {
                 ProfileType::Normal { name },
                 SpendingConditions::default(),
                 Default::default(),
+                vec![Method::PayInvoice],
             )
             .unwrap();
 

--- a/mutiny-core/src/nostr/nwc.rs
+++ b/mutiny-core/src/nostr/nwc.rs
@@ -12,6 +12,7 @@ use bitcoin::secp256k1::{Secp256k1, Signing, ThirtyTwoByteHash};
 use chrono::{DateTime, Datelike, Duration, NaiveDateTime, Utc};
 use core::fmt;
 use hex_conservative::DisplayHex;
+use itertools::Itertools;
 use lightning::util::logger::Logger;
 use lightning::{log_error, log_warn};
 use lightning_invoice::Bolt11Invoice;
@@ -281,8 +282,14 @@ impl NostrWalletConnect {
 
     /// Create Nostr Wallet Connect Info event
     pub fn create_nwc_info_event(&self) -> anyhow::Result<Event> {
-        let info = EventBuilder::new(Kind::WalletConnectInfo, "pay_invoice".to_string(), [])
-            .to_event(&self.server_key)?;
+        let commands = self
+            .profile
+            .available_commands()
+            .iter()
+            .map(|c| c.to_string())
+            .join(" ");
+        let info =
+            EventBuilder::new(Kind::WalletConnectInfo, commands, []).to_event(&self.server_key)?;
         Ok(info)
     }
 
@@ -1290,6 +1297,7 @@ mod wasm_test {
                 },
                 SpendingConditions::RequireApproval,
                 NwcProfileTag::General,
+                vec![Method::PayInvoice],
             )
             .unwrap();
 
@@ -1348,6 +1356,7 @@ mod wasm_test {
                 },
                 SpendingConditions::RequireApproval,
                 NwcProfileTag::General,
+                vec![Method::PayInvoice],
             )
             .unwrap();
 
@@ -1605,6 +1614,7 @@ mod wasm_test {
                     period: BudgetPeriod::Seconds(10),
                 }),
                 NwcProfileTag::General,
+                vec![Method::PayInvoice],
             )
             .unwrap();
 
@@ -1693,6 +1703,7 @@ mod wasm_test {
                     period: BudgetPeriod::Seconds(10),
                 }),
                 NwcProfileTag::General,
+                vec![Method::PayInvoice],
             )
             .unwrap();
 

--- a/mutiny-core/src/test_utils.rs
+++ b/mutiny-core/src/test_utils.rs
@@ -47,6 +47,10 @@ pub fn create_nwc_request(nwc: &NostrWalletConnectURI, invoice: String) -> Event
         }),
     };
 
+    sign_nwc_request(nwc, req)
+}
+
+pub fn sign_nwc_request(nwc: &NostrWalletConnectURI, req: Request) -> Event {
     let encrypted = encrypt(&nwc.secret, &nwc.public_key, req.as_json()).unwrap();
     let p_tag = Tag::PublicKey {
         public_key: nwc.public_key,

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -1406,7 +1406,13 @@ impl MutinyWallet {
         commands: Option<Vec<String>>,
     ) -> Result<models::NwcProfile, MutinyJsError> {
         let commands = match commands {
-            None => vec![Method::PayInvoice],
+            None => vec![
+                Method::PayInvoice,
+                Method::GetInfo,
+                Method::GetBalance,
+                Method::LookupInvoice,
+                Method::MakeInvoice,
+            ],
             Some(strs) => strs
                 .into_iter()
                 .map(|s| Method::from_str(&s))
@@ -1437,7 +1443,13 @@ impl MutinyWallet {
         commands: Option<Vec<String>>,
     ) -> Result<models::NwcProfile, MutinyJsError> {
         let commands = match commands {
-            None => vec![Method::PayInvoice],
+            None => vec![
+                Method::PayInvoice,
+                Method::GetInfo,
+                Method::GetBalance,
+                Method::LookupInvoice,
+                Method::MakeInvoice,
+            ],
             Some(strs) => strs
                 .into_iter()
                 .map(|s| Method::from_str(&s))

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -49,6 +49,7 @@ use mutiny_core::{
     nodemanager::{create_lsp_config, NodeManager},
 };
 use mutiny_core::{logging::MutinyLogger, nostr::ProfileType};
+use nostr::prelude::Method;
 use nostr::{Keys, ToBech32};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -1402,7 +1403,16 @@ impl MutinyWallet {
     pub async fn create_nwc_profile(
         &self,
         name: String,
+        commands: Option<Vec<String>>,
     ) -> Result<models::NwcProfile, MutinyJsError> {
+        let commands = match commands {
+            None => vec![Method::PayInvoice],
+            Some(strs) => strs
+                .into_iter()
+                .map(|s| Method::from_str(&s))
+                .collect::<Result<_, _>>()
+                .map_err(|_| MutinyJsError::InvalidArgumentsError)?,
+        };
         Ok(self
             .inner
             .nostr
@@ -1410,6 +1420,7 @@ impl MutinyWallet {
                 ProfileType::Normal { name },
                 SpendingConditions::default(),
                 NwcProfileTag::General,
+                commands,
             )
             .await?
             .into())
@@ -1423,7 +1434,16 @@ impl MutinyWallet {
         budget: u64,
         period: BudgetPeriod,
         single_max: Option<u64>,
+        commands: Option<Vec<String>>,
     ) -> Result<models::NwcProfile, MutinyJsError> {
+        let commands = match commands {
+            None => vec![Method::PayInvoice],
+            Some(strs) => strs
+                .into_iter()
+                .map(|s| Method::from_str(&s))
+                .collect::<Result<_, _>>()
+                .map_err(|_| MutinyJsError::InvalidArgumentsError)?,
+        };
         let budget = BudgetedSpendingConditions {
             budget,
             period: period.into(),
@@ -1435,7 +1455,12 @@ impl MutinyWallet {
         Ok(self
             .inner
             .nostr
-            .create_new_nwc_profile(ProfileType::Normal { name }, sp, NwcProfileTag::General)
+            .create_new_nwc_profile(
+                ProfileType::Normal { name },
+                sp,
+                NwcProfileTag::General,
+                commands,
+            )
             .await?
             .into())
     }


### PR DESCRIPTION
This adds support for `get_balance`, `get_info`, `make_invoice`, and `lookup_invoice`.

Currently missing the multi commands as they'd require a larger refactor that I'd rather do as a follow up. Also left out keysends because that'd require a refactor for budgeting and `list_transactions` because I am not sure how we'd want to implement that while preserving privacy.

Closes #895