### PR TITLE
Don't save federation to storage until after init

### DIFF
--- a/mutiny-core/src/federation.rs
+++ b/mutiny-core/src/federation.rs
@@ -254,6 +254,12 @@ impl<S: MutinyStorage> FederationClient<S> {
                 "Fedimint on different network {}, expected: {network}",
                 wallet_client.get_network()
             );
+
+            // try to delete the storage for this federation
+            if let Err(e) = fedimint_storage.delete_store().await {
+                log_error!(logger, "Could not delete fedimint storage: {e}");
+            }
+
             return Err(MutinyError::NetworkMismatch);
         }
 

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -2442,12 +2442,6 @@ pub(crate) async fn create_new_federation<S: MutinyStorage>(
         federation_code: federation_code.clone(),
     };
 
-    federation_mutex
-        .federations
-        .insert(next_federation_uuid.clone(), next_federation.clone());
-    federation_mutex.version += 1;
-    storage.insert_federations(federation_mutex.clone()).await?;
-
     // now create the federation process and init it
     let new_federation = FederationClient::new(
         next_federation_uuid.clone(),
@@ -2458,6 +2452,12 @@ pub(crate) async fn create_new_federation<S: MutinyStorage>(
         logger.clone(),
     )
     .await?;
+
+    federation_mutex
+        .federations
+        .insert(next_federation_uuid.clone(), next_federation.clone());
+    federation_mutex.version += 1;
+    storage.insert_federations(federation_mutex.clone()).await?;
 
     let federation_id = new_federation.fedimint_client.federation_id();
     let federation_name = new_federation.fedimint_client.get_meta("federation_name");


### PR DESCRIPTION
before we'd save the federation to storage before we created the client and checked the network, so if the federation was on the wrong network it'd still get persisted and we'd attempt to join on the next startup. This fixes so we don't persist the federation until after we've made the client