### PR TITLE
upgrade lightning liquidity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-liquidity"
-version = "0.1.0-alpha"
+version = "0.1.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d38a4e9f5ecce43c46f7d362781e4dbde8816dd161950056ea1182a40ba61d"
+checksum = "9482742371d445c4ac0884eb263e60bccc06558db21e3ad5c03c16d73f1932f6"
 dependencies = [
  "bitcoin 0.30.2",
  "chrono",

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -32,7 +32,7 @@ lightning-invoice = { version = "0.29.0", features = ["serde"] }
 lightning-rapid-gossip-sync = { version = "0.0.121" }
 lightning-background-processor = { version = "0.0.121", features = ["futures"] }
 lightning-transaction-sync = { version = "0.0.121", default-features = false, features = ["esplora-async-https"] }
-lightning-liquidity = "0.1.0-alpha"
+lightning-liquidity = "0.1.0-alpha.2"
 chrono = "0.4.22"
 futures-util = { version = "0.3", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["multipart", "json"] }

--- a/mutiny-core/src/lsp/lsps.rs
+++ b/mutiny-core/src/lsp/lsps.rs
@@ -11,7 +11,7 @@ use lightning::util::logger::Logger;
 use lightning::{log_debug, log_error, log_info};
 use lightning_invoice::{Bolt11Invoice, InvoiceBuilder};
 use lightning_liquidity::events::Event;
-use lightning_liquidity::lsps0::msgs::RequestId;
+use lightning_liquidity::lsps0::ser::RequestId;
 use lightning_liquidity::lsps2::event::LSPS2ClientEvent;
 use lightning_liquidity::lsps2::msgs::OpeningFeeParams;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Upgrades lightning liquidity create to include some fixes:

- Fix serialization of numbers on the wire to be strings to match spec
- Fix infinite ping-pong'ing of error messages when there's a failure to parse a message
- Fix potential deadlock on deserialization failure

Without this change mutiny will be incompatible with other lsps LSP's who follow the spec.