### PR TITLE
Show in-flight fedimint sends

### DIFF
--- a/mutiny-core/src/federation.rs
+++ b/mutiny-core/src/federation.rs
@@ -560,6 +560,7 @@ impl<S: MutinyStorage> FederationClient<S> {
         let mut stored_payment: MutinyInvoice = invoice.clone().into();
         stored_payment.inbound = inbound;
         stored_payment.labels = labels;
+        stored_payment.status = HTLCStatus::InFlight;
         let hash = stored_payment.payment_hash.into_32();
         let payment_info = PaymentInfo::from(stored_payment);
         persist_payment_info(&self.storage, &hash, &payment_info, inbound)?;


### PR DESCRIPTION
Fixes #1022

Right after the payment has initiated successfully, and before persisting the invoice, set its status to InFlight, so it doesn't get filtered out in the activity list.

![image](https://github.com/MutinyWallet/mutiny-node/assets/114611656/455d9160-f7e7-4e32-a7b2-cc502f4beb0e)
