### PR TITLE
Follow and Unfollow nostr contacts

### DIFF
--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -6,7 +6,7 @@ use crate::nostr::nwc::{
     SpendingConditions, PENDING_NWC_EVENTS_KEY,
 };
 use crate::nostr::primal::PrimalClient;
-use crate::storage::{MutinyStorage, NOSTR_CONTACT_LIST};
+use crate::storage::{update_nostr_contact_list, MutinyStorage, NOSTR_CONTACT_LIST};
 use crate::{error::MutinyError, utils::get_random_bip32_child_index};
 use crate::{labels::LabelStorage, InvoiceHandler};
 use crate::{utils, HTLCStatus};
@@ -94,6 +94,8 @@ pub struct NostrManager<S: MutinyStorage> {
     pub storage: S,
     /// Lock for pending nwc invoices
     pending_nwc_lock: Arc<Mutex<()>>,
+    /// Lock for following and unfollowing npubs
+    follow_lock: Arc<Mutex<()>>,
     /// Logger
     pub logger: Arc<MutinyLogger>,
     /// Atomic stop signal
@@ -265,6 +267,106 @@ impl<S: MutinyStorage> NostrManager<S> {
 
     pub fn get_profile(&self) -> Result<Metadata, MutinyError> {
         Ok(self.storage.get_nostr_profile()?.unwrap_or_default())
+    }
+
+    /// Follows the npub on nostr if we're not already following
+    ///
+    /// Returns true if we're now following, false if we were already following
+    pub async fn follow_npub(&self, npub: nostr::PublicKey) -> Result<(), MutinyError> {
+        let _lock = self.follow_lock.lock().await;
+        let event = self.storage.get_data::<Event>(NOSTR_CONTACT_LIST)?;
+
+        let builder = match event {
+            Some(event) => {
+                // check if we're already following
+                if event.iter_tags().any(|tag| {
+                    matches!(tag, Tag::PublicKey { public_key, uppercase: false, .. } if *public_key == npub)
+                }) {
+                    return Ok(());
+                }
+
+                let mut tags = event.tags.clone();
+                tags.push(Tag::public_key(npub));
+                EventBuilder::new(Kind::ContactList, &event.content, tags)
+            }
+            None => EventBuilder::new(Kind::ContactList, "", [Tag::public_key(npub)]),
+        };
+
+        let event = self.primary_key.sign_event_builder(builder).await?;
+        let event_id = self.client.send_event(event.clone()).await?;
+
+        update_nostr_contact_list(&self.storage, event)?;
+
+        log_info!(
+            self.logger,
+            "Followed npub: {npub}, new contact list event: {event_id}"
+        );
+
+        Ok(())
+    }
+
+    /// Unfollows the npub on nostr if we're following them
+    ///
+    /// Returns true if we were following them before
+    pub async fn unfollow_npub(&self, npub: nostr::PublicKey) -> Result<(), MutinyError> {
+        let _lock = self.follow_lock.lock().await;
+        let event = self.storage.get_data::<Event>(NOSTR_CONTACT_LIST)?;
+
+        match event {
+            None => Ok(()), // no follow list, nothing to unfollow
+            Some(event) => {
+                let mut tags = event.tags.clone();
+                tags.retain(|tag| {
+                    !matches!(tag, Tag::PublicKey { public_key, uppercase: false, .. } if *public_key == npub)
+                });
+
+                // check if we actually removed a tag,
+                // if not then we weren't following them
+                if tags.len() == event.tags.len() {
+                    return Ok(());
+                }
+
+                let builder = EventBuilder::new(Kind::ContactList, &event.content, tags);
+                let event = self.primary_key.sign_event_builder(builder).await?;
+                let event_id = self.client.send_event(event.clone()).await?;
+
+                update_nostr_contact_list(&self.storage, event)?;
+
+                log_info!(
+                    self.logger,
+                    "Unfollowed npub: {npub}, new contact list event: {event_id}"
+                );
+
+                Ok(())
+            }
+        }
+    }
+
+    /// Gets the list of npubs we're following
+    pub fn get_follow_list(&self) -> Result<HashSet<nostr::PublicKey>, MutinyError> {
+        let event = self.storage.get_data::<Event>(NOSTR_CONTACT_LIST)?;
+
+        match event {
+            None => Ok(HashSet::new()),
+            Some(event) => {
+                let npubs = event
+                    .into_iter_tags()
+                    .filter_map(|tag| {
+                        if let Tag::PublicKey {
+                            public_key,
+                            uppercase: false,
+                            ..
+                        } = tag
+                        {
+                            Some(public_key)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                Ok(npubs)
+            }
+        }
     }
 
     pub fn get_nwc_uri(&self, index: u32) -> Result<Option<NostrWalletConnectURI>, MutinyError> {
@@ -1335,6 +1437,7 @@ impl<S: MutinyStorage> NostrManager<S> {
             nwc: Arc::new(RwLock::new(nwc)),
             storage,
             pending_nwc_lock: Arc::new(Mutex::new(())),
+            follow_lock: Arc::new(Mutex::new(())),
             primal_client,
             logger,
             stop,

--- a/mutiny-wasm/src/models.rs
+++ b/mutiny-wasm/src/models.rs
@@ -710,6 +710,8 @@ pub struct TagItem {
     primal_image_url: Option<String>,
     /// Epoch time in seconds when this tag was last used
     pub last_used_time: u64,
+    /// If we follow this npub on nostr
+    pub is_followed: bool,
 }
 
 impl PartialOrd for TagItem {
@@ -773,8 +775,8 @@ impl TagItem {
     }
 }
 
-impl From<(String, MutinyContact)> for TagItem {
-    fn from((id, contact): (String, MutinyContact)) -> Self {
+impl TagItem {
+    pub fn from(id: String, contact: MutinyContact, is_followed: bool) -> Self {
         TagItem {
             id,
             kind: TagKind::Contact,
@@ -790,6 +792,7 @@ impl From<(String, MutinyContact)> for TagItem {
             }),
             image_url: contact.image_url,
             last_used_time: contact.last_used,
+            is_followed,
         }
     }
 }
@@ -807,8 +810,9 @@ impl From<labels::TagItem> for TagItem {
                 image_url: None,
                 primal_image_url: None,
                 last_used_time: item.last_used_time,
+                is_followed: false,
             },
-            labels::TagItem::Contact(contact) => contact.into(),
+            labels::TagItem::Contact((id, contact)) => TagItem::from(id, contact, false),
         }
     }
 }


### PR DESCRIPTION
Closes #1068

This has the base functionality needed for following and unfollowing. Tried to do my best to prevent us from deleting a follow list. ~One thing with this is there is potential race conditions if you call follow/unfollow in rapid succession. Could add a mutex around adding follows but that feels a little overkill, maybe will have to bite the bullet though~

@futurepaul I imagine you'll want some extra utility around this. I was thinking of adding `is_followed` to `TagItem`. Is there anything else I could add that you can think of?