### PR TITLE
Fix LSP connection failures during maintance

### DIFF
--- a/mutiny-core/src/lsp/mod.rs
+++ b/mutiny-core/src/lsp/mod.rs
@@ -124,9 +124,12 @@ pub enum AnyLsp<S: MutinyStorage> {
 }
 
 impl<S: MutinyStorage> AnyLsp<S> {
-    pub async fn new_voltage_flow(config: VoltageConfig) -> Result<Self, MutinyError> {
+    pub async fn new_voltage_flow(
+        config: VoltageConfig,
+        logger: Arc<MutinyLogger>,
+    ) -> Result<Self, MutinyError> {
         Ok(Self::VoltageFlow(Arc::new(RwLock::new(
-            LspClient::new(config).await?,
+            LspClient::new(config, logger).await?,
         ))))
     }
 

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -448,7 +448,7 @@ impl<S: MutinyStorage> NodeBuilder<S> {
 
         let (lsp_client, lsp_client_pubkey, liquidity) = match lsp_config {
             Some(LspConfig::VoltageFlow(config)) => {
-                let lsp = AnyLsp::new_voltage_flow(config).await?;
+                let lsp = AnyLsp::new_voltage_flow(config, logger.clone()).await?;
                 let pubkey = lsp.get_lsp_pubkey().await;
                 (Some(lsp), Some(pubkey), None)
             }

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -411,13 +411,16 @@ impl<S: MutinyStorage> NodeBuilder<S> {
                 log_info!(logger, "no lsp saved, using configured one if present");
                 self.lsp_config
             }
-            Some(ref lsp) => {
-                if self.lsp_config.as_ref().is_some_and(|l| l.matches(lsp)) {
+            Some(lsp) => {
+                if self.lsp_config.as_ref().is_some_and(|l| l.matches(&lsp)) {
                     log_info!(logger, "lsp config matches saved lsp config");
                     self.lsp_config
                 } else {
-                    log_info!(logger, "lsp config does not match saved lsp config");
-                    None
+                    log_warn!(
+                        logger,
+                        "lsp config does not match saved lsp config, using saved one"
+                    );
+                    Some(lsp)
                 }
             }
         };

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -414,7 +414,9 @@ impl<S: MutinyStorage> NodeBuilder<S> {
             Some(lsp) => {
                 if self.lsp_config.as_ref().is_some_and(|l| l.matches(&lsp)) {
                     log_info!(logger, "lsp config matches saved lsp config");
-                    self.lsp_config
+                    // prefer node index lsp config over configured one
+                    // as it may have extra info like the LSP connection info
+                    Some(lsp)
                 } else {
                     log_warn!(
                         logger,


### PR DESCRIPTION
Fixes #1065

First commit adds a bunch of logging for us

Second commit fixes an issue i discovered while debugging. If we changed the LSP env variable then it'd set the lsp in the user's config to `null`. This would cause problems if we ever changed the default LSP as then it would break people's old wallets.

Third commit fixes the root issue, was a bug from #1018 where all the optimizations I did weren't being fully utilized because we weren't using the saved LSP config but preferring the one from env variables which did not have the connection info so we'd have to refetch it.

For simulating the LSP being down I added another domain for the lsp `signet-lsp.mutinynet.com` and would change the proxy pass port when I wanted it to be down