### PR TITLE
Use gloo-timers for windowless sleep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,6 +2583,7 @@ dependencies = [
  "futures-util",
  "getrandom",
  "gloo-net 0.4.0",
+ "gloo-timers 0.3.0",
  "hex-conservative",
  "itertools 0.11.0",
  "js-sys",

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -71,6 +71,8 @@ anyhow = "1.0"
 [dev-dependencies]
 wasm-bindgen-test = "0.3.33"
 mockall = "0.11.2"
+web-sys = { version = "0.3.65", features = ["console"] }
+js-sys = "0.3.65"
 
 [features]
 default = []
@@ -78,10 +80,9 @@ ignored_tests = []
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = { version = "0.4.38" }
-web-sys = { version = "0.3.65", features = ["console"] }
-js-sys = "0.3.65"
 gloo-net = { version = "0.4.0" }
 web-time = "1.1"
+gloo-timers = { version = "0.3.0", features = ["futures"] }
 getrandom = { version = "0.2", features = ["js"] }
 # add nip07 feature for wasm32
 nostr = { version = "0.29.0", default-features = false, features = ["nip04", "nip05", "nip07", "nip47", "nip57"] }

--- a/mutiny-core/src/utils.rs
+++ b/mutiny-core/src/utils.rs
@@ -32,20 +32,14 @@ pub(crate) fn min_lightning_amount(network: Network) -> u64 {
 }
 
 pub async fn sleep(millis: i32) {
+    let duration = Duration::from_millis(millis as u64);
     #[cfg(target_arch = "wasm32")]
     {
-        let mut cb = |resolve: js_sys::Function, _reject: js_sys::Function| {
-            web_sys::window()
-                .unwrap()
-                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, millis)
-                .unwrap();
-        };
-        let p = js_sys::Promise::new(&mut cb);
-        wasm_bindgen_futures::JsFuture::from(p).await.unwrap();
+        gloo_timers::future::sleep(duration).await
     }
     #[cfg(not(target_arch = "wasm32"))]
     {
-        tokio::time::sleep(Duration::from_millis(millis.try_into().unwrap())).await;
+        tokio::time::sleep(duration).await;
     }
 }
 pub fn now() -> Duration {


### PR DESCRIPTION
This should be safe, same sleep code that fedimint is using.

It uses `setTimeout` so I believe this can be used in a web worker :rocket: 

https://crates.io/crates/gloo-timers