### PR TITLE
Fixes for blind tokens

### DIFF
--- a/mutiny-core/src/hermes.rs
+++ b/mutiny-core/src/hermes.rs
@@ -209,7 +209,14 @@ impl<S: MutinyStorage> HermesClient<S> {
         let available_paid_token =
             match find_hermes_token(&available_tokens, HERMES_SERVICE_ID, HERMES_PAID_PLAN_ID) {
                 Some(t) => t,
-                None => return Err(MutinyError::NotFound),
+                None => {
+                    log_error!(
+                        self.logger,
+                        "No available paid token for Hermes, current tokens: {}",
+                        available_tokens.len()
+                    );
+                    return Err(MutinyError::NotFound);
+                }
             };
 
         // check that we have a federation added and get it's id/invite code

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -10,7 +10,7 @@
 extern crate core;
 
 pub mod auth;
-mod blindauth;
+pub mod blindauth;
 mod cashu;
 mod chain;
 pub mod encrypt;


### PR DESCRIPTION
- We couldn't ever write the tokens to storage because it was trying to use `ServicePlanIndex` as a key for the json object. Json object's keys need to be strings so I manually implemented serde for it doing it just as `x-y`
- Added implementation for reading tokens from VSS