### PR TITLE
Better handling for marking DM'd invoices as paid

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -1331,6 +1331,17 @@ impl<S: MutinyStorage> MutinyWallet<S> {
                         .await;
                     match payment_result {
                         Ok(r) => {
+                            // spawn a task to remove the pending invoice if it exists
+                            let nostr_clone = self.nostr.clone();
+                            let payment_hash = *inv.payment_hash();
+                            let logger = self.logger.clone();
+                            utils::spawn(async move {
+                                if let Err(e) =
+                                    nostr_clone.remove_pending_nwc_invoice(&payment_hash).await
+                                {
+                                    log_warn!(logger, "Failed to remove pending NWC invoice: {e}");
+                                }
+                            });
                             return Ok(r);
                         }
                         Err(e) => match e {
@@ -1368,9 +1379,22 @@ impl<S: MutinyStorage> MutinyWallet<S> {
             .sum::<u64>()
             > 0
         {
-            self.node_manager
+            let res = self
+                .node_manager
                 .pay_invoice(None, inv, amt_sats, labels)
-                .await
+                .await?;
+
+            // spawn a task to remove the pending invoice if it exists
+            let nostr_clone = self.nostr.clone();
+            let payment_hash = *inv.payment_hash();
+            let logger = self.logger.clone();
+            utils::spawn(async move {
+                if let Err(e) = nostr_clone.remove_pending_nwc_invoice(&payment_hash).await {
+                    log_warn!(logger, "Failed to remove pending NWC invoice: {e}");
+                }
+            });
+
+            Ok(res)
         } else {
             Err(last_federation_error.unwrap_or(MutinyError::InsufficientBalance))
         }

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -1156,8 +1156,8 @@ impl<S: MutinyStorage> MutinyWallet<S> {
                     log_warn!(logger, "Failed to clear in-active NWC profiles: {e}");
                 }
 
-                if let Err(e) = nostr.clear_expired_nwc_invoices().await {
-                    log_warn!(logger, "Failed to clear expired NWC invoices: {e}");
+                if let Err(e) = nostr.clear_invalid_nwc_invoices(&self_clone).await {
+                    log_warn!(logger, "Failed to clear invalid NWC invoices: {e}");
                 }
 
                 let client = Client::new(nostr.primary_key.clone());


### PR DESCRIPTION
Closes #1087

First commit is pretty straight forward, makes it so in our startup check instead of removing only expired invoices, we also check for paid ones

Second commit I don't love but not sure the best way to do this otherwise. This attempts to remove any payment we make from our pending nwc. I am not really sure a better way to handle this besides making the frontend instead call `approve_invoice` instead of `pay_invoice` for invoices in our dm's but that doesn't seem the best either.