### PR TITLE
Replace instant dependency with web-time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,7 +2525,6 @@ dependencies = [
  "getrandom",
  "gloo-net",
  "hex-conservative",
- "instant",
  "itertools 0.11.0",
  "js-sys",
  "jwt-compact",
@@ -2555,6 +2554,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+ "web-time",
 ]
 
 [[package]]
@@ -4592,6 +4592,16 @@ name = "web-sys"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -81,7 +81,7 @@ wasm-bindgen-futures = { version = "0.4.38" }
 web-sys = { version = "0.3.65", features = ["console"] }
 js-sys = "0.3.65"
 gloo-net = { version = "0.4.0" }
-instant = { version = "0.1", features = ["wasm-bindgen"] }
+web-time = "1.1"
 getrandom = { version = "0.2", features = ["js"] }
 # add nip07 feature for wasm32
 nostr = { version = "0.29.0", default-features = false, features = ["nip04", "nip05", "nip07", "nip47", "nip57"] }

--- a/mutiny-core/src/federation.rs
+++ b/mutiny-core/src/federation.rs
@@ -57,8 +57,6 @@ use fedimint_wallet_client::{WalletClientInit, WalletClientModule};
 use futures::future::{self};
 use futures_util::{pin_mut, StreamExt};
 use hex_conservative::{DisplayHex, FromHex};
-#[cfg(target_arch = "wasm32")]
-use instant::Instant;
 use lightning::{
     ln::PaymentHash, log_debug, log_error, log_info, log_trace, log_warn, util::logger::Logger,
 };
@@ -71,6 +69,8 @@ use std::{
     str::FromStr,
     sync::atomic::{AtomicU32, Ordering},
 };
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 // The amount of time in milliseconds to wait for
 // checking the status of a fedimint payment. This

--- a/mutiny-core/src/gossip.rs
+++ b/mutiny-core/src/gossip.rs
@@ -5,8 +5,6 @@ use crate::{
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::Network;
 use hex_conservative::DisplayHex;
-#[cfg(target_arch = "wasm32")]
-use instant::Instant;
 use lightning::ln::msgs::NodeAnnouncement;
 use lightning::routing::gossip::NodeId;
 use lightning::util::logger::Logger;
@@ -20,6 +18,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 use crate::logging::MutinyLogger;
 use crate::node::{NetworkGraph, RapidGossipSync};

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -96,8 +96,6 @@ use fedimint_core::{api::InviteCode, config::FederationId};
 use futures::{pin_mut, select, FutureExt};
 use futures_util::join;
 use hex_conservative::{DisplayHex, FromHex};
-#[cfg(target_arch = "wasm32")]
-use instant::Instant;
 use itertools::Itertools;
 use lightning::chain::BestBlock;
 use lightning::ln::PaymentHash;
@@ -120,6 +118,8 @@ use std::time::Instant;
 use std::{collections::HashMap, sync::atomic::AtomicBool};
 use std::{str::FromStr, sync::atomic::Ordering};
 use uuid::Uuid;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 use crate::labels::LabelItem;
 use crate::nostr::NostrKeySource;

--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -39,8 +39,6 @@ use core::time::Duration;
 use esplora_client::AsyncClient;
 use futures_util::lock::Mutex;
 use hex_conservative::DisplayHex;
-#[cfg(target_arch = "wasm32")]
-use instant::Instant;
 use lightning::events::bump_transaction::{BumpTransactionEventHandler, Wallet};
 use lightning::ln::channelmanager::ChannelDetails;
 use lightning::ln::PaymentSecret;
@@ -92,6 +90,8 @@ use std::{
         Arc, RwLock,
     },
 };
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 const INITIAL_RECONNECTION_DELAY: u64 = 10;
 const MAX_RECONNECTION_DELAY: u64 = 60;

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -41,8 +41,6 @@ use core::time::Duration;
 use esplora_client::{AsyncClient, Builder};
 use futures::{future::join_all, lock::Mutex};
 use hex_conservative::DisplayHex;
-#[cfg(target_arch = "wasm32")]
-use instant::Instant;
 use lightning::chain::Confirm;
 use lightning::events::ClosureReason;
 use lightning::ln::channelmanager::{ChannelDetails, PhantomRouteHints};
@@ -65,6 +63,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 use std::{collections::HashMap, ops::Deref, sync::Arc};
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 const BITCOIN_PRICE_CACHE_SEC: u64 = 300;
 pub const DEVICE_LOCK_INTERVAL_SECS: u64 = 30;

--- a/mutiny-core/src/utils.rs
+++ b/mutiny-core/src/utils.rs
@@ -49,8 +49,8 @@ pub async fn sleep(millis: i32) {
 }
 pub fn now() -> Duration {
     #[cfg(target_arch = "wasm32")]
-    return instant::SystemTime::now()
-        .duration_since(instant::SystemTime::UNIX_EPOCH)
+    return web_time::SystemTime::now()
+        .duration_since(web_time::SystemTime::UNIX_EPOCH)
         .unwrap();
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
web-time offers a number of advantages over the instant crate

- Actively maintained
- Stable 1.x API
- Exact std::time  replacement
- Compatible with rustls pki-types web feature
- Re-exports std::time when not targeting wasm32-unknown-unknown without pulling in any dependencies