### PR TITLE
Better error when connecting to federation

### DIFF
--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -175,6 +175,9 @@ pub enum MutinyError {
     /// Federation required.
     #[error("A federation is required")]
     FederationRequired,
+    /// Failed to connect to a federation.
+    #[error("Failed to connect to a federation.")]
+    FederationConnectionFailed,
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -257,6 +260,8 @@ impl PartialEq for MutinyError {
             (Self::CashuMintError, Self::CashuMintError) => true,
             (Self::EmptyMintURLError, Self::EmptyMintURLError) => true,
             (Self::TokenAlreadySpent, Self::TokenAlreadySpent) => true,
+            (Self::FederationRequired, Self::FederationRequired) => true,
+            (Self::FederationConnectionFailed, Self::FederationConnectionFailed) => true,
             (Self::Other(e), Self::Other(e2)) => e.to_string() == e2.to_string(),
             _ => false,
         }

--- a/mutiny-core/src/federation.rs
+++ b/mutiny-core/src/federation.rs
@@ -228,7 +228,7 @@ impl<S: MutinyStorage> FederationClient<S> {
                 .await
                 .map_err(|e| {
                     log_error!(logger, "Could not open federation client: {e}");
-                    e
+                    MutinyError::FederationConnectionFailed
                 })?
         } else {
             let download = Instant::now();
@@ -249,7 +249,7 @@ impl<S: MutinyStorage> FederationClient<S> {
                 .await
                 .map_err(|e| {
                     log_error!(logger, "Could not join federation: {e}");
-                    e
+                    MutinyError::FederationConnectionFailed
                 })?
         };
         let fedimint_client = Arc::new(fedimint_client);

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -171,6 +171,9 @@ pub enum MutinyJsError {
     /// Federation required.
     #[error("A federation is required")]
     FederationRequired,
+    /// Failed to connect to a federation.
+    #[error("Failed to connect to a federation.")]
+    FederationConnectionFailed,
     /// Unknown error.
     #[error("Unknown Error")]
     UnknownError,
@@ -224,6 +227,7 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::EmptyMintURLError => MutinyJsError::EmptyMintURLError,
             MutinyError::TokenAlreadySpent => MutinyJsError::TokenAlreadySpent,
             MutinyError::FederationRequired => MutinyJsError::FederationRequired,
+            MutinyError::FederationConnectionFailed => MutinyJsError::FederationConnectionFailed,
             MutinyError::Other(e) => {
                 error!("Got unhandled error: {e}");
                 // FIXME: For some unknown reason, InsufficientBalance is being returned as `Other`


### PR DESCRIPTION
Fedimint would just return any anyhow error to us so this gets surfaced as `Unknown Error` to the front end. This will at least make it prettier 