### PR TITLE
Fixes for recommendation events

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -1244,7 +1244,12 @@ impl<S: MutinyStorage> MutinyWallet<S> {
                                                     Ok(false) => log_debug!(logger, "Got older contact list, ignoring..."),
                                                 }
                                             }
-                                            kind => log_warn!(logger, "Received unexpected note of kind {kind}")
+                                            kind => {
+                                                // ignore federation announcement events
+                                                if kind.as_u64() != 38000 && kind.as_u64() != 38173 {
+                                                    log_warn!(logger, "Received unexpected note of kind {kind}");
+                                                }
+                                            }
                                         }
                                     }
                                 },


### PR DESCRIPTION
`tag.kind() == TagKind::Custom("k".to_string())` was failing but `tag.kind() == TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::K))` would be true, even though they resolve to the same thing.

Added tests 