### PR TITLE
log when we prune a monitor

### DIFF
--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -176,6 +176,12 @@ impl<S: MutinyStorage> MutinyNodePersister<S> {
                             // if there are no claimable balances, we don't need to watch the channel
                             if !channel_monitor.get_claimable_balances().is_empty() {
                                 accum.push((blockhash, channel_monitor));
+                            } else {
+                                log_debug!(
+                                    self.logger,
+                                    "Channel monitor {} has no claimable balances, not watching",
+                                    channel_monitor.get_funding_txo().0
+                                );
                             }
                             Ok(accum)
                         }


### PR DESCRIPTION
May be the cause of https://github.com/MutinyWallet/mutiny-web/issues/1032, this would make it easier to debug