### PR TITLE
Fixes for cashu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 [[package]]
 name = "bitcoin-waila"
 version = "0.4.1"
-source = "git+https://github.com/mutinywallet/bitcoin-waila?rev=1d6c416fc0abaa2efa78e3dcf28450975d8f7bfe#1d6c416fc0abaa2efa78e3dcf28450975d8f7bfe"
+source = "git+https://github.com/mutinywallet/bitcoin-waila?rev=a99b4c8d949661e775593354f8afbefa80aeb44a#a99b4c8d949661e775593354f8afbefa80aeb44a"
 dependencies = [
  "bip21",
  "bitcoin 0.30.2",
@@ -2521,8 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "moksha-core"
-version = "0.2.0-beta"
-source = "git+https://github.com/ngutech21/moksha?rev=18d99977965662d46ccec29fecdb0ce493745917#18d99977965662d46ccec29fecdb0ce493745917"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4923b0e31fd02fe8ebc2f58ed0909c8e1d90f0b5153948d3940e634421240c30"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,8 +443,9 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin-waila"
-version = "0.4.1"
-source = "git+https://github.com/mutinywallet/bitcoin-waila?rev=a99b4c8d949661e775593354f8afbefa80aeb44a#a99b4c8d949661e775593354f8afbefa80aeb44a"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0360146aaf278fbef5f34b7c83ff889cb5b43742af261bf0ee75b653ad1e495d"
 dependencies = [
  "bip21",
  "bitcoin 0.30.2",

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -48,7 +48,7 @@ payjoin = { version = "0.13.0", features = ["send", "base64"] }
 bincode = "1.3.3"
 hex-conservative = "0.1.1"
 async-lock = "3.2.0"
-bitcoin-waila = { git = "https://github.com/mutinywallet/bitcoin-waila", rev = "a99b4c8d949661e775593354f8afbefa80aeb44a" }
+bitcoin-waila = "0.5.0"
 
 fedimint-client = "0.3.0"
 fedimint-core = "0.3.0"

--- a/mutiny-core/Cargo.toml
+++ b/mutiny-core/Cargo.toml
@@ -48,7 +48,7 @@ payjoin = { version = "0.13.0", features = ["send", "base64"] }
 bincode = "1.3.3"
 hex-conservative = "0.1.1"
 async-lock = "3.2.0"
-bitcoin-waila = { git = "https://github.com/mutinywallet/bitcoin-waila", rev = "1d6c416fc0abaa2efa78e3dcf28450975d8f7bfe" }
+bitcoin-waila = { git = "https://github.com/mutinywallet/bitcoin-waila", rev = "a99b4c8d949661e775593354f8afbefa80aeb44a" }
 
 fedimint-client = "0.3.0"
 fedimint-core = "0.3.0"
@@ -58,7 +58,7 @@ fedimint-ln-client = "0.3.0"
 fedimint-bip39 = "0.3.0"
 fedimint-ln-common = "0.3.0"
 fedimint-tbs = "0.3.0"
-moksha-core = { git = "https://github.com/ngutech21/moksha", rev = "18d99977965662d46ccec29fecdb0ce493745917" }
+moksha-core = "0.2.1"
 
 base64 = "0.13.0"
 pbkdf2 = "0.11"

--- a/mutiny-core/src/cashu.rs
+++ b/mutiny-core/src/cashu.rs
@@ -26,11 +26,8 @@ impl CashuHttpClient {
         url: &Url,
         melt_quote_request: PostMeltQuoteBolt11Request,
     ) -> Result<PostMeltQuoteBolt11Response, MutinyError> {
-        self.mint_post(
-            &url.join("/v1/melt/quote/bolt11")?,
-            json!(melt_quote_request),
-        )
-        .await
+        let url = format!("{url}/v1/melt/quote/bolt11");
+        self.mint_post(url, json!(melt_quote_request)).await
     }
 
     pub async fn post_melt_bolt11(
@@ -38,18 +35,18 @@ impl CashuHttpClient {
         url: &Url,
         melt_request: PostMeltBolt11Request,
     ) -> Result<PostMeltBolt11Response, MutinyError> {
-        self.mint_post(&url.join("/v1/melt/bolt11")?, json!(melt_request))
-            .await
+        let url = format!("{url}/v1/melt/bolt11");
+        self.mint_post(url, json!(melt_request)).await
     }
 
     async fn mint_post<T: serde::de::DeserializeOwned>(
         &self,
-        url: &Url,
+        url: String,
         body: Value,
     ) -> Result<T, MutinyError> {
         let res = self
             .client
-            .post(url.clone())
+            .post(url)
             .header("Content-Type", "application/json")
             .body(body.to_string())
             .send()

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -47,7 +47,7 @@ payjoin = { version = "0.13.0", features = ["send", "base64"] }
 fedimint-core = "0.3.0"
 moksha-core = "0.2.1"
 
-bitcoin-waila = { git = "https://github.com/mutinywallet/bitcoin-waila", rev = "a99b4c8d949661e775593354f8afbefa80aeb44a" }
+bitcoin-waila = "0.5.0"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/mutiny-wasm/Cargo.toml
+++ b/mutiny-wasm/Cargo.toml
@@ -45,9 +45,9 @@ once_cell = "1.18.0"
 hex-conservative = "0.1.1"
 payjoin = { version = "0.13.0", features = ["send", "base64"] }
 fedimint-core = "0.3.0"
-moksha-core = { git = "https://github.com/ngutech21/moksha", rev = "18d99977965662d46ccec29fecdb0ce493745917" }
+moksha-core = "0.2.1"
 
-bitcoin-waila = { git = "https://github.com/mutinywallet/bitcoin-waila", rev = "1d6c416fc0abaa2efa78e3dcf28450975d8f7bfe" }
+bitcoin-waila = { git = "https://github.com/mutinywallet/bitcoin-waila", rev = "a99b4c8d949661e775593354f8afbefa80aeb44a" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires


### PR DESCRIPTION
This would break for mints that had a path in their mint url (ie `https://mint.minibits.cash/Bitcoin`). We would sometimes drop off the final path when calling `url.join` just creating the string ourself seems more fault tolerant.

Also updated to the latest release of moksha instead of using the pinned commit