### PR TITLE
Add on chain for federations

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -2062,7 +2062,10 @@ impl<S: MutinyStorage> MutinyWallet<S> {
         }
     }
 
-    async fn create_address(&self, labels: Vec<String>) -> Result<bitcoin::Address, MutinyError> {
+    pub async fn create_address(
+        &self,
+        labels: Vec<String>,
+    ) -> Result<bitcoin::Address, MutinyError> {
         // Attempt to create federation invoice if available
         let federation_ids = self.list_federation_ids().await?;
         if !federation_ids.is_empty() {

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -150,6 +150,7 @@ const BITCOIN_PRICE_CACHE_SEC: u64 = 300;
 const DEFAULT_PAYMENT_TIMEOUT: u64 = 30;
 const SWAP_LABEL: &str = "SWAP";
 const MELT_CASHU_TOKEN: &str = "Cashu Token Melt";
+const DUST_LIMIT: u64 = 546;
 
 #[cfg_attr(test, automock)]
 pub trait InvoiceHandler {
@@ -1923,7 +1924,9 @@ impl<S: MutinyStorage> MutinyWallet<S> {
         amount: u64,
         fee_rate: Option<f32>,
     ) -> Result<u64, MutinyError> {
-        log_warn!(self.logger, "estimate_tx_fee");
+        if amount < DUST_LIMIT {
+            return Err(MutinyError::WalletOperationFailed);
+        }
 
         // Try each federation first
         let federation_ids = self.list_federation_ids().await?;

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -712,14 +712,12 @@ impl<S: MutinyStorage> NodeManager<S> {
     /// If a fee rate is not provided, one will be used from the fee estimator.
     pub async fn send_to_address(
         &self,
-        send_to: Address<NetworkUnchecked>,
+        send_to: Address,
         amount: u64,
         labels: Vec<String>,
         fee_rate: Option<f32>,
     ) -> Result<Txid, MutinyError> {
-        let address = send_to.require_network(self.network)?;
-
-        self.wallet.send(address, amount, labels, fee_rate).await
+        self.wallet.send(send_to, amount, labels, fee_rate).await
     }
 
     /// Sweeps all the funds from the wallet to the given address.
@@ -728,18 +726,16 @@ impl<S: MutinyStorage> NodeManager<S> {
     /// If a fee rate is not provided, one will be used from the fee estimator.
     pub async fn sweep_wallet(
         &self,
-        send_to: Address<NetworkUnchecked>,
+        send_to: Address,
         labels: Vec<String>,
         fee_rate: Option<f32>,
     ) -> Result<Txid, MutinyError> {
-        let address = send_to.require_network(self.network)?;
-
-        self.wallet.sweep(address, labels, fee_rate).await
+        self.wallet.sweep(send_to, labels, fee_rate).await
     }
 
     /// Estimates the onchain fee for a transaction sending to the given address.
     /// The amount is in satoshis and the fee rate is in sat/vbyte.
-    pub fn estimate_tx_fee(
+    pub(crate) fn estimate_tx_fee(
         &self,
         destination_address: Address,
         amount: u64,
@@ -753,7 +749,7 @@ impl<S: MutinyStorage> NodeManager<S> {
     /// to the given address.
     ///
     /// The fee rate is in sat/vbyte.
-    pub fn estimate_sweep_tx_fee(
+    pub(crate) fn estimate_sweep_tx_fee(
         &self,
         destination_address: Address,
         fee_rate: Option<f32>,

--- a/mutiny-core/src/onchain.rs
+++ b/mutiny-core/src/onchain.rs
@@ -25,12 +25,12 @@ use crate::error::MutinyError;
 use crate::fees::MutinyFeeEstimator;
 use crate::labels::*;
 use crate::logging::MutinyLogger;
-use crate::nodemanager::TransactionDetails;
 use crate::storage::{
     IndexItem, MutinyStorage, OnChainStorage, KEYCHAIN_STORE_KEY, NEED_FULL_SYNC_KEY,
     ONCHAIN_PREFIX,
 };
 use crate::utils::{now, sleep};
+use crate::TransactionDetails;
 
 pub(crate) const FULL_SYNC_STOP_GAP: usize = 150;
 pub(crate) const RESTORE_SYNC_STOP_GAP: usize = 20;
@@ -152,7 +152,7 @@ impl<S: MutinyStorage> OnChainWallet<S> {
                                 ConfirmationTime::Confirmed { time, .. } => Some(time),
                                 ConfirmationTime::Unconfirmed { .. } => None,
                             },
-                            key: format!("{ONCHAIN_PREFIX}{}", t.txid),
+                            key: format!("{ONCHAIN_PREFIX}{}", t.internal_id),
                         })
                         .collect::<Vec<_>>();
 
@@ -381,7 +381,8 @@ impl<S: MutinyStorage> OnChainWallet<S> {
 
                         Some(TransactionDetails {
                             transaction,
-                            txid: tx.tx_node.txid,
+                            txid: Some(tx.tx_node.txid),
+                            internal_id: tx.tx_node.txid,
                             received,
                             sent,
                             fee,
@@ -413,7 +414,8 @@ impl<S: MutinyStorage> OnChainWallet<S> {
                 let fee = wallet.calculate_fee(tx.tx_node.tx).ok();
                 let details = TransactionDetails {
                     transaction: Some(tx.tx_node.tx.to_owned()),
-                    txid,
+                    txid: Some(txid),
+                    internal_id: txid,
                     received,
                     sent,
                     fee,

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -926,6 +926,24 @@ pub(crate) fn persist_transaction_details<S: MutinyStorage>(
     Ok(())
 }
 
+pub(crate) fn delete_transaction_details<S: MutinyStorage>(
+    storage: &S,
+    transaction_details: &TransactionDetails,
+) -> Result<(), MutinyError> {
+    let key = transaction_details_key(transaction_details.internal_id);
+    storage.delete(&[key.clone()])?;
+
+    // delete from index
+    let index = storage.activity_index();
+    let mut index = index.try_write()?;
+    index.insert(IndexItem {
+        timestamp: None,
+        key,
+    });
+
+    Ok(())
+}
+
 pub(crate) fn get_transaction_details<S: MutinyStorage>(
     storage: &S,
     internal_id: Txid,

--- a/mutiny-core/src/storage.rs
+++ b/mutiny-core/src/storage.rs
@@ -926,19 +926,20 @@ pub(crate) fn persist_transaction_details<S: MutinyStorage>(
     Ok(())
 }
 
+// Deletes the transaction detail and removes the pending index if it exists
 pub(crate) fn delete_transaction_details<S: MutinyStorage>(
     storage: &S,
-    transaction_details: &TransactionDetails,
+    txid: Txid,
 ) -> Result<(), MutinyError> {
-    let key = transaction_details_key(transaction_details.internal_id);
+    let key = transaction_details_key(txid);
     storage.delete(&[key.clone()])?;
 
-    // delete from index
+    // delete the pending index item, if it exists
     let index = storage.activity_index();
     let mut index = index.try_write()?;
-    index.insert(IndexItem {
-        timestamp: None,
-        key,
+    index.remove(&IndexItem {
+        timestamp: None, // timestamp would be None for Unconfirmed
+        key: key.clone(),
     });
 
     Ok(())

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -700,9 +700,7 @@ impl MutinyWallet {
         txid: String,
     ) -> Result<JsValue /* Option<TransactionDetails> */, MutinyJsError> {
         let txid = Txid::from_str(&txid)?;
-        Ok(JsValue::from_serde(
-            &self.inner.node_manager.get_transaction(txid)?,
-        )?)
+        Ok(JsValue::from_serde(&self.inner.get_transaction(txid)?)?)
     }
 
     /// Gets the current balance of the wallet.

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -548,7 +548,6 @@ impl MutinyWallet {
         let send_to = Address::from_str(&destination_address)?;
         Ok(self
             .inner
-            .node_manager
             .send_to_address(send_to, amount, labels, fee_rate)
             .await?
             .to_string())

--- a/mutiny-wasm/src/models.rs
+++ b/mutiny-wasm/src/models.rs
@@ -75,7 +75,7 @@ impl From<mutiny_core::ActivityItem> for ActivityItem {
         };
 
         let id = match a {
-            mutiny_core::ActivityItem::OnChain(ref t) => t.txid.to_string(),
+            mutiny_core::ActivityItem::OnChain(ref t) => t.internal_id.to_string(),
             mutiny_core::ActivityItem::Lightning(ref ln) => {
                 ln.payment_hash.into_32().to_lower_hex_string()
             }


### PR DESCRIPTION
TODO:
- [x] Withdrawals
- [x] Frontend needs to allow withdrawals from fedimint balance
- [x] Change APIs to account for withdraw pending
- [x] Figure out max send situation
- [x] Monitor eventual TXID for confirmations (fedimint doesn't care about tracking it)
- [x] Lots of TODOs in the on chain cleanup in federation.rs
- [x] pull activity list for on chain addresses
- [x] Refreshing doesn't show on chain history
- [x] activity item for on chain deposit doesn't show additional info
- [x] tests for activity item & indexing
- [x] subscribe to pending on chain operations
- [x] show payment details on the onchain send screen when the link is clicked
- [x] handle tiny amounts properly if they are attempted to be paid