### PR TITLE
fix keysend payments

### DIFF
--- a/mutiny-core/src/node.rs
+++ b/mutiny-core/src/node.rs
@@ -1671,7 +1671,7 @@ impl<S: MutinyStorage> Node<S> {
                     MutinyError::InvoiceCreationFailed
                 })?
         } else {
-            RecipientOnionFields::secret_only(payment_secret)
+            RecipientOnionFields::spontaneous_empty()
         };
 
         let pay_result = self.channel_manager.send_spontaneous_payment_with_retry(


### PR DESCRIPTION
was testing keysend payments for adding the nwc commands that use it but payments were failing. With help from @benthecarman changing this line fixed it. 