### PR TITLE
add NWC commands

### DIFF
--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1408,10 +1408,11 @@ impl<S: MutinyStorage> NodeManager<S> {
         amt_sats: u64,
         message: Option<String>,
         labels: Vec<String>,
+        preimage: Option<[u8; 32]>,
     ) -> Result<MutinyInvoice, MutinyError> {
         let node = self.get_node_by_key_or_first(self_node_pubkey).await?;
         log_debug!(self.logger, "Keysending to {to_node}");
-        node.keysend_with_timeout(to_node, amt_sats, message, labels, None)
+        node.keysend_with_timeout(to_node, amt_sats, message, labels, None, preimage)
             .await
     }
 

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -3,7 +3,6 @@ use crate::labels::LabelStorage;
 use crate::ldkstorage::CHANNEL_CLOSURE_PREFIX;
 use crate::logging::LOGGING_KEY;
 use crate::utils::{sleep, spawn};
-use crate::MutinyInvoice;
 use crate::MutinyWalletConfig;
 use crate::{
     chain::MutinyChain,
@@ -23,6 +22,7 @@ use crate::{
     node::NodeBuilder,
     storage::{MutinyStorage, DEVICE_ID_KEY, KEYCHAIN_STORE_KEY, NEED_FULL_SYNC_KEY},
 };
+use crate::{CustomTLV, MutinyInvoice};
 use anyhow::anyhow;
 use async_lock::RwLock;
 use bdk::chain::{BlockId, ConfirmationTime};
@@ -1406,13 +1406,13 @@ impl<S: MutinyStorage> NodeManager<S> {
         self_node_pubkey: Option<&PublicKey>,
         to_node: PublicKey,
         amt_sats: u64,
-        message: Option<String>,
+        custom_tlvs: Vec<CustomTLV>,
         labels: Vec<String>,
         preimage: Option<[u8; 32]>,
     ) -> Result<MutinyInvoice, MutinyError> {
         let node = self.get_node_by_key_or_first(self_node_pubkey).await?;
         log_debug!(self.logger, "Keysending to {to_node}");
-        node.keysend_with_timeout(to_node, amt_sats, message, labels, None, preimage)
+        node.keysend_with_timeout(to_node, amt_sats, custom_tlvs, labels, None, preimage)
             .await
     }
 

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -1541,7 +1541,6 @@ impl<S: MutinyStorage, P: PrimalApi, C: NostrClient> NostrManager<S, P, C> {
 
         self.storage.set_nwc_sync_time(event.created_at.as_u64())?;
 
-        // TODO: handle nwc response here
         if let Some(mut nwc) = nwc {
             nwc.handle_nwc_request(event, invoice_handler, self).await?;
         }

--- a/mutiny-core/src/nostr/mod.rs
+++ b/mutiny-core/src/nostr/mod.rs
@@ -1531,7 +1531,7 @@ impl<S: MutinyStorage, P: PrimalApi, C: NostrClient> NostrManager<S, P, C> {
         &self,
         event: Event,
         invoice_handler: &impl InvoiceHandler,
-    ) -> anyhow::Result<Option<Event>> {
+    ) -> anyhow::Result<()> {
         let nwc = {
             let vec = self.nwc.read().unwrap();
             vec.iter()
@@ -1541,12 +1541,11 @@ impl<S: MutinyStorage, P: PrimalApi, C: NostrClient> NostrManager<S, P, C> {
 
         self.storage.set_nwc_sync_time(event.created_at.as_u64())?;
 
+        // TODO: handle nwc response here
         if let Some(mut nwc) = nwc {
-            let event = nwc.handle_nwc_request(event, invoice_handler, self).await?;
-            Ok(event)
-        } else {
-            Ok(None)
+            nwc.handle_nwc_request(event, invoice_handler, self).await?;
         }
+        Ok(())
     }
 
     pub(crate) fn save_nwc_profile(&self, nwc: NostrWalletConnect) -> Result<(), MutinyError> {

--- a/mutiny-core/src/test_utils.rs
+++ b/mutiny-core/src/test_utils.rs
@@ -50,6 +50,49 @@ pub fn create_nwc_request(nwc: &NostrWalletConnectURI, invoice: String) -> Event
     sign_nwc_request(nwc, req)
 }
 
+pub fn create_multi_invoice_nwc_request(
+    nwc: &NostrWalletConnectURI,
+    invoices: Vec<String>,
+) -> Event {
+    let mut invoices_param = Vec::with_capacity(invoices.len());
+    for invoice in invoices {
+        let invoice_param = PayInvoiceRequestParams {
+            id: Some(invoice.clone()),
+            invoice,
+            amount: None,
+        };
+        invoices_param.push(invoice_param);
+    }
+
+    let req = Request {
+        method: Method::MultiPayInvoice,
+        params: RequestParams::MultiPayInvoice(MultiPayInvoiceRequestParams {
+            invoices: invoices_param,
+        }),
+    };
+
+    sign_nwc_request(nwc, req)
+}
+
+pub fn create_pay_keysend_nwc_request(
+    nwc: &NostrWalletConnectURI,
+    amount_msat: u64,
+    pubkey: String,
+) -> Event {
+    let req = Request {
+        method: Method::PayKeysend,
+        params: RequestParams::PayKeysend(PayKeysendRequestParams {
+            id: None,
+            amount: amount_msat,
+            pubkey,
+            preimage: None,
+            tlv_records: vec![],
+        }),
+    };
+
+    sign_nwc_request(nwc, req)
+}
+
 pub fn sign_nwc_request(nwc: &NostrWalletConnectURI, req: Request) -> Event {
     let encrypted = encrypt(&nwc.secret, &nwc.public_key, req.as_json()).unwrap();
     let p_tag = Tag::PublicKey {

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -857,7 +857,7 @@ impl MutinyWallet {
         Ok(self
             .inner
             .node_manager
-            .keysend(None, to_node, amt_sats, message, labels)
+            .keysend(None, to_node, amt_sats, message, labels, None)
             .await?
             .into())
     }
@@ -1556,10 +1556,14 @@ impl MutinyWallet {
         let commands = match commands {
             None => vec![
                 Method::PayInvoice,
+                Method::MultiPayInvoice,
                 Method::GetInfo,
                 Method::GetBalance,
                 Method::LookupInvoice,
                 Method::MakeInvoice,
+                Method::ListTransactions,
+                Method::PayKeysend,
+                Method::MultiPayKeysend,
             ],
             Some(strs) => strs
                 .into_iter()
@@ -1593,10 +1597,14 @@ impl MutinyWallet {
         let commands = match commands {
             None => vec![
                 Method::PayInvoice,
+                Method::MultiPayInvoice,
                 Method::GetInfo,
                 Method::GetBalance,
                 Method::LookupInvoice,
                 Method::MakeInvoice,
+                Method::ListTransactions,
+                Method::PayKeysend,
+                Method::MultiPayKeysend,
             ],
             Some(strs) => strs
                 .into_iter()

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -850,14 +850,22 @@ impl MutinyWallet {
         &self,
         to_node: String,
         amt_sats: u64,
-        message: Option<String>,
+        custom_tlvs: Vec<CustomTLV>,
         labels: Vec<String>,
     ) -> Result<MutinyInvoice, MutinyJsError> {
         let to_node = PublicKey::from_str(&to_node)?;
+        let custom_tlvs = custom_tlvs
+            .into_iter()
+            .map(|tlv| mutiny_core::CustomTLV {
+                tlv_type: tlv.tlv_type,
+                value: tlv.value,
+            })
+            .collect();
+
         Ok(self
             .inner
             .node_manager
-            .keysend(None, to_node, amt_sats, message, labels, None)
+            .keysend(None, to_node, amt_sats, custom_tlvs, labels, None)
             .await?
             .into())
     }

--- a/mutiny-wasm/src/models.rs
+++ b/mutiny-wasm/src/models.rs
@@ -1197,3 +1197,10 @@ impl From<mutiny_core::DirectMessage> for DirectMessage {
         }
     }
 }
+
+#[wasm_bindgen]
+pub struct CustomTLV {
+    pub tlv_type: u64,
+    #[wasm_bindgen(skip)]
+    pub value: String,
+}


### PR DESCRIPTION
for https://github.com/MutinyWallet/mutiny-node/issues/1120 added `multi_pay_invoice`, `pay_keysend`, `multi_pay_keysend` and `list_transactions` NWC commands. I added those requests to the mutinynet faucet to help me test these from the UI. 

Reasoning for certain changes I did:
- I changed the return type and place where we were broadcasting the response events from the NWC requests. Discussed with @benthecarman and did this because some of the new commands (`multi_pay_invoice` and `multi_pay_keysend`) can return multiple events. So instead of waiting to return them until `start_nostr` method, now broadcasting in the respective handle methods where the response events are generated. 
- changed the type for `add_payment` and `remove_payment` because they were previously taking a Bolt11Invoice so I changed it to `TrackedPayment` to now be able to accommodate adding keysend payments as well instead of only invoices.
- added an optional preimage param to the keysend payment method. This is to generate the preimage deterministically from the request event for the nwc keysend payment to avoid paying the same keysend twice if we try to process the same event.
- added some methods to the `InvoiceHandler` trait that I needed for the new commands.