### PR TITLE
Hermes Tests

### DIFF
--- a/mutiny-core/src/federation.rs
+++ b/mutiny-core/src/federation.rs
@@ -171,6 +171,15 @@ pub struct FedimintBalance {
     pub amount: u64,
 }
 
+#[cfg_attr(test, mockall::automock)]
+pub trait FedimintClient {
+    async fn claim_external_receive(
+        &self,
+        secret_key: &SecretKey,
+        tweaks: Vec<u64>,
+    ) -> Result<(), MutinyError>;
+}
+
 pub(crate) struct FederationClient<S: MutinyStorage> {
     pub(crate) uuid: String,
     pub(crate) fedimint_client: ClientHandleArc,
@@ -738,6 +747,16 @@ fn maybe_update_after_checking_fedimint<S: MutinyStorage>(
     }
 
     Ok(())
+}
+
+impl<S: MutinyStorage> FedimintClient for FederationClient<S> {
+    async fn claim_external_receive(
+        &self,
+        secret_key: &SecretKey,
+        tweaks: Vec<u64>,
+    ) -> Result<(), MutinyError> {
+        self.claim_external_receive(secret_key, tweaks).await
+    }
 }
 
 fn sats_round_up(amount: &Amount) -> u64 {


### PR DESCRIPTION
Did a small refactor so testing the hermes claiming is simpler, just moving some code into its own function.

Otherwise adds a bunch of tests for handling zaps from hermes. Did find a niche bug with private zaps and using a NIP-07 extension, it would mark it as public when we couldn't decrypt instead of marking as Anon.

Wanted to add registration tests but might be easier to wait for when we support free addresses as the paid tests would make it 1000x more complex

Part of #1093