### PR TITLE
Fetch federation info from invite code if not on nostr

### DIFF
--- a/mutiny-core/src/federation.rs
+++ b/mutiny-core/src/federation.rs
@@ -170,7 +170,7 @@ pub struct FederationIdentity {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct FederationMetaConfig {
+pub(crate) struct FederationMetaConfig {
     #[serde(flatten)]
     pub federations: std::collections::HashMap<String, FederationMeta>,
 }


### PR DESCRIPTION
This now makes it so we try to fetch the metadata for the discovered federations from their invite code if its not available in the nostr event.

Now that we fetch this info, we can filter out expired federations or ones we can't connect to as well.

![image](https://github.com/MutinyWallet/mutiny-node/assets/15256660/35a16eff-4549-47e5-a4f8-09b1aa5aee6b)
