### PR TITLE
Remove async wasm_bindgen constructor

### DIFF
--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -82,7 +82,7 @@ impl MutinyWallet {
     /// Creates a new [MutinyWallet] with the given parameters.
     /// The mnemonic seed is read from storage, unless one is provided.
     /// If no mnemonic is provided, a new one is generated and stored.
-    #[wasm_bindgen(constructor)]
+    #[wasm_bindgen]
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         password: Option<String>,


### PR DESCRIPTION
It seems async constructors aren't supported even by typescript, asked in their discord what is the expected behavior of this because it _seems_ to work, however, we really shouldn't be doing this since it is not supported