### PR TITLE
Skip hermes check if we don't have a ln address

### DIFF
--- a/mutiny-core/src/hermes.rs
+++ b/mutiny-core/src/hermes.rs
@@ -180,6 +180,11 @@ impl<S: MutinyStorage> HermesClient<S> {
                                 o.name
                             );
                             *c = (o.name.clone(), true);
+
+                            // if we don't have a lightning address, no need to continue
+                            if o.name.is_none() {
+                                break;
+                            }
                         }
 
                         // check that federation is still the same


### PR DESCRIPTION
Our sentry was getting filled up with logs of people who were getting a log because they don't have a lightning address.

![image](https://github.com/MutinyWallet/mutiny-node/assets/15256660/1deb63b8-9084-46de-b602-8f04f6be9e2e)
