### PR TITLE
Return channel open errors to user

### DIFF
--- a/mutiny-core/src/error.rs
+++ b/mutiny-core/src/error.rs
@@ -95,6 +95,9 @@ pub enum MutinyError {
     /// A channel could not be opened.
     #[error("Failed to create channel.")]
     ChannelCreationFailed,
+    /// A channel could not be opened.
+    #[error("Failed to create channel. {0}")]
+    ChannelCreationFailedWithReason(String),
     /// A channel could not be closed.
     #[error("Failed to close channel.")]
     ChannelClosingFailed,
@@ -237,6 +240,10 @@ impl PartialEq for MutinyError {
             (Self::RoutingFailed, Self::RoutingFailed) => true,
             (Self::PeerInfoParseFailed, Self::PeerInfoParseFailed) => true,
             (Self::ChannelCreationFailed, Self::ChannelCreationFailed) => true,
+            (
+                Self::ChannelCreationFailedWithReason(x),
+                Self::ChannelCreationFailedWithReason(y),
+            ) => x == y,
             (Self::ChannelClosingFailed, Self::ChannelClosingFailed) => true,
             (Self::PersistenceFailed { source }, Self::PersistenceFailed { source: source2 }) => {
                 source == source2

--- a/mutiny-core/src/event.rs
+++ b/mutiny-core/src/event.rs
@@ -523,7 +523,7 @@ impl<S: MutinyStorage> EventHandler<S> {
                 ..
             } => {
                 // if we still have channel open params, then it was just a failed channel open
-                // we should not persist this as a closed channel and just delete the channel open params
+                // we should not persist this as a closed channel and pass back the failure reason
                 if let Ok(Some(mut params)) =
                     self.persister.get_channel_open_params(user_channel_id)
                 {

--- a/mutiny-core/src/ldkstorage.rs
+++ b/mutiny-core/src/ldkstorage.rs
@@ -550,6 +550,8 @@ pub(crate) struct ChannelOpenParams {
     pub(crate) labels: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) opening_tx: Option<Transaction>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) failure_reason: Option<String>,
 }
 
 impl ChannelOpenParams {
@@ -560,6 +562,7 @@ impl ChannelOpenParams {
             utxos: None,
             labels: None,
             opening_tx: None,
+            failure_reason: None,
         }
     }
 
@@ -574,6 +577,7 @@ impl ChannelOpenParams {
             utxos: Some(utxos),
             labels: None,
             opening_tx: None,
+            failure_reason: None,
         }
     }
 }

--- a/mutiny-wasm/src/error.rs
+++ b/mutiny-wasm/src/error.rs
@@ -86,6 +86,9 @@ pub enum MutinyJsError {
     /// A channel could not be opened.
     #[error("Failed to create channel.")]
     ChannelCreationFailed,
+    /// A channel could not be opened.
+    #[error("Failed to create channel. {0}")]
+    ChannelCreationFailedWithReason(String),
     /// A channel could not be closed.
     #[error("Failed to close channel.")]
     ChannelClosingFailed,
@@ -203,6 +206,9 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::RoutingFailed => MutinyJsError::RoutingFailed,
             MutinyError::PeerInfoParseFailed => MutinyJsError::PeerInfoParseFailed,
             MutinyError::ChannelCreationFailed => MutinyJsError::ChannelCreationFailed,
+            MutinyError::ChannelCreationFailedWithReason(x) => {
+                MutinyJsError::ChannelCreationFailedWithReason(x)
+            }
             MutinyError::ChannelClosingFailed => MutinyJsError::ChannelClosingFailed,
             MutinyError::PersistenceFailed { source: _ } => MutinyJsError::PersistenceFailed,
             MutinyError::ReadError { source: _ } => MutinyJsError::ReadError,


### PR DESCRIPTION
Closes #1220

Now exposes the channel open error message to the user

![image](https://github.com/MutinyWallet/mutiny-node/assets/15256660/46e728b3-6a1d-4a2b-85d7-b8b79b02ffa9)
