### PR TITLE
Don't block on gateway fees

### DIFF
--- a/mutiny-core/src/federation.rs
+++ b/mutiny-core/src/federation.rs
@@ -160,7 +160,6 @@ pub struct FederationIdentity {
     pub federation_name: Option<String>,
     pub federation_expiry_timestamp: Option<String>,
     pub welcome_message: Option<String>,
-    pub gateway_fees: Option<GatewayFees>,
     // undocumented parameters that fedi uses: https://meta.dev.fedibtc.com/meta.json
     pub federation_icon_url: Option<String>,
     pub meta_external_url: Option<String>,
@@ -873,12 +872,10 @@ impl<S: MutinyStorage> FederationClient<S> {
     }
 
     pub async fn get_mutiny_federation_identity(&self) -> FederationIdentity {
-        let gateway_fees = self.gateway_fee().await.ok();
         get_federation_identity(
             self.uuid.clone(),
             self.fedimint_client.clone(),
             self.invite_code.clone(),
-            gateway_fees,
             self.logger.clone(),
         )
         .await
@@ -895,8 +892,6 @@ pub(crate) async fn get_federation_identity(
     uuid: String,
     fedimint_client: ClientHandleArc,
     invite_code: InviteCode,
-    gateway_fees: Option<GatewayFees>,
-
     logger: Arc<MutinyLogger>,
 ) -> FederationIdentity {
     let federation_id = fedimint_client.federation_id();
@@ -950,7 +945,6 @@ pub(crate) async fn get_federation_identity(
             fedimint_client.get_meta("welcome_message"),
             config.as_ref().and_then(|c| c.welcome_message.clone()),
         ),
-        gateway_fees, // Already merged using helper function...
         federation_icon_url: merge_values(
             fedimint_client.get_meta("federation_icon_url"),
             config.as_ref().and_then(|c| c.federation_icon_url.clone()),

--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -3804,13 +3804,11 @@ pub(crate) async fn create_new_federation<S: MutinyStorage>(
     storage.insert_federations(federation_mutex.clone()).await?;
 
     let federation_id = new_federation.fedimint_client.federation_id();
-    let gateway_fees = new_federation.gateway_fee().await.ok();
 
     let new_federation_identity = get_federation_identity(
         next_federation_uuid.clone(),
         new_federation.fedimint_client.clone(),
         federation_code.clone(),
-        gateway_fees,
         logger.clone(),
     )
     .await;


### PR DESCRIPTION
Closes #1225

Anytime we used the `FederationIdentity` struct we were blocking on getting the gateway fees, which was in `list_federations` that the frontend would call on startup. Looked throughout the codebase and we never used this `gateway_fees` value so easiest to just remove it