### PR TITLE
Add function to return the current LSP

### DIFF
--- a/mutiny-core/src/lib.rs
+++ b/mutiny-core/src/lib.rs
@@ -26,7 +26,7 @@ pub mod labels;
 mod ldkstorage;
 pub mod lnurlauth;
 pub mod logging;
-mod lsp;
+pub mod lsp;
 mod messagehandler;
 mod networking;
 mod node;

--- a/mutiny-core/src/lsp/voltage.rs
+++ b/mutiny-core/src/lsp/voltage.rs
@@ -65,7 +65,7 @@ impl<'de> Deserialize<'de> for VoltageConfig {
 }
 
 #[derive(Clone)]
-pub(crate) struct LspClient {
+pub struct LspClient {
     pub pubkey: PublicKey,
     pub connection_string: String,
     pub url: String,

--- a/mutiny-core/src/nodemanager.rs
+++ b/mutiny-core/src/nodemanager.rs
@@ -1344,6 +1344,11 @@ impl<S: MutinyStorage> NodeManager<S> {
         Ok(peers)
     }
 
+    pub async fn get_configured_lsp(&self) -> Result<Option<LspConfig>, MutinyError> {
+        let node = self.get_node_by_key_or_first(None).await?;
+        Ok(node.node_index().await.lsp)
+    }
+
     /// Changes all the node's LSPs to the given config. If any of the nodes have an active channel with the
     /// current LSP, it will fail to change the LSP.
     ///

--- a/mutiny-core/src/scorer.rs
+++ b/mutiny-core/src/scorer.rs
@@ -277,9 +277,9 @@ fn build_preferred_hubs_set() -> HashSet<NodeId> {
         .collect()
 }
 
-pub(crate) type ProbScorer = ProbabilisticScorer<Arc<NetworkGraph>, Arc<MutinyLogger>>;
+pub type ProbScorer = ProbabilisticScorer<Arc<NetworkGraph>, Arc<MutinyLogger>>;
 
-pub(crate) struct HubPreferentialScorer {
+pub struct HubPreferentialScorer {
     inner: ProbScorer,
     preferred_hubs_set: HashSet<NodeId>,
 }

--- a/mutiny-wasm/src/lib.rs
+++ b/mutiny-wasm/src/lib.rs
@@ -47,7 +47,7 @@ use mutiny_core::{
     labels::LabelStorage,
     nodemanager::{create_lsp_config, NodeManager},
 };
-use mutiny_core::{logging::MutinyLogger, nostr::ProfileType};
+use mutiny_core::{logging::MutinyLogger, lsp::LspConfig, nostr::ProfileType};
 use nostr::prelude::Method;
 use nostr::{Keys, ToBech32};
 use std::collections::HashMap;
@@ -761,6 +761,15 @@ impl MutinyWallet {
 
         self.inner.node_manager.change_lsp(lsp_config).await?;
         Ok(())
+    }
+
+    /// Returns the current LSP config
+    pub async fn get_configured_lsp(&self) -> Result<JsValue, MutinyJsError> {
+        match self.inner.node_manager.get_configured_lsp().await? {
+            Some(LspConfig::VoltageFlow(config)) => Ok(JsValue::from_serde(&config)?),
+            Some(LspConfig::Lsps(config)) => Ok(JsValue::from_serde(&config)?),
+            None => Ok(JsValue::NULL),
+        }
     }
 
     /// Attempts to connect to a peer from the selected node.


### PR DESCRIPTION
This is to fix where old wallets will display on the server screen that its using the olympus LSP even though internally it is using the voltage LSP.

Needed to make the lsp module pub to be able to use it in mutiny-wasm.

needs https://github.com/MutinyWallet/mutiny-web/pull/1253 for testing